### PR TITLE
Service Feature Table no longer needs to load fields

### DIFF
--- a/src/main/java/com/esri/samples/featurelayers/feature_layer_extrusion/FeatureLayerExtrusionSample.java
+++ b/src/main/java/com/esri/samples/featurelayers/feature_layer_extrusion/FeatureLayerExtrusionSample.java
@@ -16,8 +16,6 @@
 
 package com.esri.samples.featurelayers.feature_layer_extrusion;
 
-import java.util.Collections;
-
 import javafx.application.Application;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -27,7 +25,6 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
-import com.esri.arcgisruntime.data.QueryParameters;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
@@ -69,12 +66,6 @@ public class FeatureLayerExtrusionSample extends Application {
 
     // get us census data as a service feature table
     ServiceFeatureTable statesServiceFeatureTable = new ServiceFeatureTable("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3");
-    statesServiceFeatureTable.setFeatureRequestMode(ServiceFeatureTable.FeatureRequestMode.MANUAL_CACHE);
-
-    // load all features, with all fields (attributes), from service feature table
-    QueryParameters queryParams = new QueryParameters();
-    queryParams.setWhereClause("1=1");
-    statesServiceFeatureTable.populateFromServiceAsync(queryParams, true, Collections.singletonList("*"));
 
     // creates feature layer from table and add to scene
     final FeatureLayer statesFeatureLayer = new FeatureLayer(statesServiceFeatureTable);

--- a/src/main/java/com/esri/samples/featurelayers/feature_layer_extrusion/README.md
+++ b/src/main/java/com/esri/samples/featurelayers/feature_layer_extrusion/README.md
@@ -10,8 +10,6 @@
 
 <ol>
   <li>Create a <code>ServiceFeatureTable</code> from an URL.</li>
-  <li>Set request mode of table, <code>statesServiceFeatureTable.setFeatureRequestMode(FeatureRequestMode.MANUAL_CACHE)</code>.</li>
-  <li>Create an <code>QueryParameters</code> to select all features and load all fields (attributes).</li>
   <li>Create a feature layer from service feature table.
   <ol>Make sure to set rendering mode to dynamic, <code>statesFeatureLayer.setRenderingMode(RenderingMode.DYNAMIC)</code>.</ol></li>
   <li>Apply a <code>SimpleRenderer</code> to the feature layer.</li>


### PR DESCRIPTION
@tschie Can you look this over?

It use to be that in order to use different fields from a Service Feature Table you would have to load those fields first. This no longer has to be done and the server will now get that fields information when needed.