### PR TITLE
Fixing nested lists -- which must be nested bullet points.

### DIFF
--- a/src/main/java/com/esri/samples/scene/feature_layer_rendering_mode_scene/README.md
+++ b/src/main/java/com/esri/samples/scene/feature_layer_rendering_mode_scene/README.md
@@ -11,18 +11,17 @@
 <ol>
     <li>Create a <code>ArcGISScene</code>.</li>
     <li>Set preferred rendering mode to scene, <code>sceneBottom.getLoadSettings().setPreferredPointFeatureRenderingMode(FeatureLayer.RenderingMode.DYNAMIC)</code>.
-      <ol>
+      <ul>
         <li>Can set preferred rendering mode for <code>Points</code>, <code>Polylines</code>, or <code>Polygons</code>.</li>
         <li><code>Multipoint</code> preferred rendering mode is the same as point.</li>
-      </ol>
-    </li>
+        </ul>
     <li>Set scene to <code>SceneView</code>, <code>sceneViewBottom.setArcGISScene(sceneBottom)</code>.</li>
     <li>Create a <code>ServiceFeatureTable</code> from a point service, <code>new ServiceFeatureTable("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/0");</code>.</li>
     <li>Create <code>FeatureLayer</code> from table, <code>new FeatureLayer(poinServiceFeatureTable)</code>.</li>
     <li>Add layer to scene, <code>sceneBottom.getOperationalLayers().add(pointFeatureLayer.copy())</code>
-      <ol>
+      <ul>
         <li>Now the point layer will be rendered dynamically to scene view.</li>
-      </ol>
+      </ul>
     </li>
 </ol>
 


### PR DESCRIPTION
REMINDER: There's a bug which we have to accommodate:
- Nested lists must be \<ul\>, and not not \<ol\> (unordered lists, not ordered lists).
Bug arises in README file, when we use \<li\>elements within an \<ol\> element. The nested list gets corrupted along the way, and the result is not pretty:
![image](https://user-images.githubusercontent.com/4381859/51011597-00e14700-150e-11e9-854d-201bf8f6f773.png)


