### PR TITLE
In Java Samples topic in CMS, I changed ordered sublists to bullet lists (feature_layer_rendering_mode_scene_java_readme.md)

### DIFF
--- a/src/main/java/com/esri/samples/mapview/scale_bar/README.md
+++ b/src/main/java/com/esri/samples/mapview/scale_bar/README.md
@@ -27,13 +27,13 @@
 <h2>Relevant API</h2>
 
 <ul>
-<li><code>ArcGISMap</code></li>
+<li>ArcGISMap</li>
 
-<li><code>MapView</code></li>
+<li>MapView</li>
 
-<li><code>Scalebar</code></li>
+<li>Scalebar</li>
 
-<li><code>UnitSystem</code></li>
+<li>UnitSystem</li>
 </ul>
 
 <h2>Tags</h2>

--- a/src/main/java/com/esri/samples/scene/feature_layer_rendering_mode_scene/README.md
+++ b/src/main/java/com/esri/samples/scene/feature_layer_rendering_mode_scene/README.md
@@ -11,18 +11,18 @@
 <ol>
     <li>Create a <code>ArcGISScene</code>.</li>
     <li>Set preferred rendering mode to scene, <code>sceneBottom.getLoadSettings().setPreferredPointFeatureRenderingMode(FeatureLayer.RenderingMode.DYNAMIC)</code>.
-      <ol>
+      <ul>
         <li>Can set preferred rendering mode for <code>Points</code>, <code>Polylines</code>, or <code>Polygons</code>.</li>
         <li><code>Multipoint</code> preferred rendering mode is the same as point.</li>
-      </ol>
+      </ul>
     </li>
     <li>Set scene to <code>SceneView</code>, <code>sceneViewBottom.setArcGISScene(sceneBottom)</code>.</li>
     <li>Create a <code>ServiceFeatureTable</code> from a point service, <code>new ServiceFeatureTable("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/0");</code>.</li>
     <li>Create <code>FeatureLayer</code> from table, <code>new FeatureLayer(poinServiceFeatureTable)</code>.</li>
     <li>Add layer to scene, <code>sceneBottom.getOperationalLayers().add(pointFeatureLayer.copy())</code>
-      <ol>
+      <ul>
         <li>Now the point layer will be rendered dynamically to scene view.</li>
-      </ol>
+      </ul>
     </li>
 </ol>
 


### PR DESCRIPTION
REMINDER: There's an apparent bug in the MD (markdown) parse when mixing MD with HTML accommodate:
- Nested lists must be \<ul\>, and not not \<ol\> (unordered lists, not ordered lists).
Bug arises in README file, when we use \<li\>elements within an \<ol\> element. The nested list gets corrupted along the way, and the result is not pretty:
![image](https://user-images.githubusercontent.com/4381859/51011597-00e14700-150e-11e9-854d-201bf8f6f773.png)

Note: The README looks fine in the Github repo, but it gets mangled in the HTML page output by the CMS.