### PR TITLE
remove online elevation data source

### DIFF
--- a/src/main/java/com/esri/samples/scene/open_mobile_scene_package/OpenMobileScenePackageSample.java
+++ b/src/main/java/com/esri/samples/scene/open_mobile_scene_package/OpenMobileScenePackageSample.java
@@ -61,13 +61,6 @@ public class OpenMobileScenePackageSample extends Application {
     // create a new scene view
     sceneView = new SceneView();
 
-    // add base surface for elevation data
-    Surface surface = new Surface();
-    ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource("http://elevation3d.arcgis" +
-            ".com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer");
-    surface.getElevationSources().add(elevationSource);
-    scene.setBaseSurface(surface);
-
     // load a mobile scene package
     final String mspkPath = new File("./samples-data/mspk/philadelphia.mspk").getAbsolutePath();
 

--- a/src/main/java/com/esri/samples/scene/open_mobile_scene_package/OpenMobileScenePackageSample.java
+++ b/src/main/java/com/esri/samples/scene/open_mobile_scene_package/OpenMobileScenePackageSample.java
@@ -54,10 +54,6 @@ public class OpenMobileScenePackageSample extends Application {
     stage.setScene(fxScene);
     stage.show();
 
-    // create a new ArcGIS scene and set its basemap
-    ArcGISScene scene = new ArcGISScene();
-    scene.setBasemap(Basemap.createImagery());
-
     // create a new scene view
     sceneView = new SceneView();
 


### PR DESCRIPTION
Now that the scene package has valid elevation included, I've removed the online elevation source to better demonstrate the offline use case. @tschie can you approve when you have the time, many thanks.