### PR TITLE
Update slider to show values from 1-5 rather than 0-5

### DIFF
--- a/src/main/resources/fxml/terrain_exaggeration.fxml
+++ b/src/main/resources/fxml/terrain_exaggeration.fxml
@@ -47,7 +47,7 @@
             </Background>
         </background>
         <Label text="Exaggeration"/>
-        <Slider fx:id="exaggerationSlider" max="5" majorTickUnit="1" minorTickCount="0" showTickMarks="true" 
+        <Slider fx:id="exaggerationSlider" max="5" min="1" majorTickUnit="1" minorTickCount="0" showTickMarks="true"
           showTickLabels="true" snapToTicks="true"/>
     </VBox>
 </StackPane>


### PR DESCRIPTION
This is a patch to update the slider value for the terrain exaggeration sample. It will now show a slider from 1 - 5 for adjusting terrain exaggeration. @tschie could you have a look when you have a moment? Thanks! 