### PR TITLE
Orbit the camera around an object patch

### DIFF
--- a/src/main/java/com/esri/samples/scene/orbit_the_camera_around_an_object/OrbitTheCameraAroundAnObjectController.java
+++ b/src/main/java/com/esri/samples/scene/orbit_the_camera_around_an_object/OrbitTheCameraAroundAnObjectController.java
@@ -79,7 +79,6 @@ public class OrbitTheCameraAroundAnObjectController {
       SimpleRenderer renderer = new SimpleRenderer();
       renderer.getSceneProperties().setHeadingExpression("[HEADING]");
       renderer.getSceneProperties().setPitchExpression("[PITCH]");
-      renderer.getSceneProperties().setRollExpression("[ROLL]");
       sceneGraphicsOverlay.setRenderer(renderer);
 
       // create a graphic of a plane model


### PR DESCRIPTION
@tschie this is the patch for the "Orbit the camera around an object" sample, removing an unused setRollExpression on the renderer (for "ROLL"). Can you approve the change please, thanks. 