### PR TITLE
remove use of arcgis gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@ If no `mainClass` property is supplied, the default sample (set in the build.gra
 
 There is no need to install Gradle to run the samples.
 
-## The ArcGIS Runtime Gradle Plugin
-The plugin provides the project with everything an ArcGIS runtime project needs to run. It adds the 
-arcgis api as a dependency and downloads the native libraries into `$USER_HOME/.arcgis`. This download occurs 
-automatically the first time you build the project and is only performed once.
-
 ## Java 11
 Java 11 users may find exceptions when running the project if their library path is still set for Oracle JDK 1.8 (see the [OpenJavaFX docs](https://openjfx.io/openjfx-docs/) for more information). A workaround for this is to add the following argument in the `run` task of the Gradle buildscript:
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ repositories {
     maven {
         url 'https://esri.bintray.com/arcgis'
     }
+    maven {
+        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+    }
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,13 @@
-buildscript {
-    repositories {
-        maven {
-            url 'https://esri.bintray.com/arcgis'
-        }
-    }
-    dependencies {
-        classpath 'com.esri.arcgisruntime:gradle-arcgis-java-plugin:1.0.0'
-    }
-}
-
 plugins {
     id 'application'
     id 'org.openjfx.javafxplugin' version '0.0.5'
 }
 
-apply plugin: 'com.esri.arcgisruntime.java'
-
 group = 'com.esri.samples'
 
-arcgis.version = '100.5.0'
+ext {
+    arcgisVersion = '100.5.0'
+}
 
 javafx {
     version = "11.0.1"
@@ -34,7 +23,14 @@ repositories {
     }
 }
 
+configurations {
+    natives
+}
+
 dependencies {
+    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
+    natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'
     compile 'commons-io:commons-io:2.4'
     compile 'org.jooq:joox:1.4.0'
@@ -82,8 +78,19 @@ task downloadData {
     downloadSampleData([new Download(id: '628e8e3521cf45e9a28a12fe10c02c4d', name: 'naperville_imagery', ext: 'tpk')], 'naperville')
 }
 
+task copyNatives(type: Copy) {
+    description = "Copies the arcgis native libraries into the project build directory for development."
+    group = "build"
+    configurations.natives.asFileTree.each {
+        from(zipTree(it))
+    }
+    into "build/natives"
+}
+
 run {
+    dependsOn copyNatives
     mainClassName = project.hasProperty("mainClass") ? mainClass : 'com.esri.samples.map.display_map.DisplayMapSample'
+    environment "ARCGISRUNTIMESDKJAVA_100_5_0", "build/natives"
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.5.0'
+    arcgisVersion = '100.6.0-2431'
 }
 
 javafx {
@@ -93,7 +93,7 @@ task copyNatives(type: Copy) {
 run {
     dependsOn copyNatives
     mainClassName = project.hasProperty("mainClass") ? mainClass : 'com.esri.samples.map.display_map.DisplayMapSample'
-    environment "ARCGISRUNTIMESDKJAVA_100_5_0", "build/natives"
+    environment "ARCGISRUNTIMESDKJAVA_100_6_0", "build/natives"
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
handle native dependencies without the ArcGIS Runtime Gradle plugin