### PR TITLE
patch oAuth sample custom challengehandler

### DIFF
--- a/src/main/java/com/esri/samples/map/create_and_save_map/OAuthChallengeHandler.java
+++ b/src/main/java/com/esri/samples/map/create_and_save_map/OAuthChallengeHandler.java
@@ -54,7 +54,7 @@ final class OAuthChallengeHandler implements AuthenticationChallengeHandler {
       // get the authorization code by sending user to the authorization screen
       String authorizationUrl = OAuthTokenCredentialRequest.getAuthorizationUrl(
           config.getPortalUrl(), config.getClientId(), config.getRedirectUri(), 0);
-      String authorizationCode = OAuthChallenge.getAuthorizationCode(authorizationUrl);
+      String authorizationCode = OAuthChallenge.getAuthorizationCode(authorizationUrl + "&display=classic");
 
       // use the authorization code to get a token
       OAuthTokenCredentialRequest request = new OAuthTokenCredentialRequest(

--- a/src/main/java/com/esri/samples/map/create_and_save_map/README.md
+++ b/src/main/java/com/esri/samples/map/create_and_save_map/README.md
@@ -40,3 +40,8 @@ chosen folder.</p>
   <li>PortalItem</li>
   <li>PortalUserContent</li>
 </ul>
+
+
+<h2>Additional information</h2>
+
+<p>The JavaFX <code>WebEngine</code> used in the `OAuthChallengeHandler` in this sample may not support rendering of some modern web elements returned by the <code>AuthorizationURL</code>. For this reason, we append <code>&display=classic</code> to the authorization URL, to ensure it renders properly.</p>

--- a/src/main/java/com/esri/samples/map/create_and_save_map/README.md
+++ b/src/main/java/com/esri/samples/map/create_and_save_map/README.md
@@ -44,4 +44,4 @@ chosen folder.</p>
 
 <h2>Additional information</h2>
 
-<p>The JavaFX <code>WebEngine</code> used in the `OAuthChallengeHandler` in this sample may not support rendering of some modern web elements returned by the <code>AuthorizationURL</code>. For this reason, we append <code>&display=classic</code> to the authorization URL, to ensure it renders properly.</p>
+<p>The JavaFX <code>WebEngine</code> used in the <code>OAuthChallengeHandler</code> in this sample may not support rendering of some modern web elements returned by the <code>AuthorizationURL</code>. For this reason, we append <code>&display=classic</code> to the authorization URL, to ensure it renders properly.</p>

--- a/src/main/java/com/esri/samples/portal/oauth/OAuthChallengeHandler.java
+++ b/src/main/java/com/esri/samples/portal/oauth/OAuthChallengeHandler.java
@@ -91,7 +91,7 @@ final class OAuthChallenge {
       dialog.setScene(new Scene(browser, 450, 450));
       dialog.show();
       WebEngine webEngine = browser.getEngine();
-      webEngine.load(authorizationUrl);
+      webEngine.load(authorizationUrl + "&display=classic");
 
       // read the HTTP response to user action
       webEngine.setOnStatusChanged(event -> {

--- a/src/main/java/com/esri/samples/portal/oauth/README.md
+++ b/src/main/java/com/esri/samples/portal/oauth/README.md
@@ -36,3 +36,7 @@ access token. This access token is used later to access user's profile.</p>
     <li>Portal</li>
     <li>PortalUser</li>
 </ul>
+
+<h2>Additional Information</h2>
+
+<p>The JavaFX <code>WebEngine</code> used in this sample may not support rendering of some modern web elements returned by the <code>AuthorizationURL</code>. For this reason, we append <code>&display=classic</code> to the authorization URL, to ensure it renders properly.</p>

--- a/src/main/java/com/esri/samples/portal/oauth/README.md
+++ b/src/main/java/com/esri/samples/portal/oauth/README.md
@@ -39,4 +39,4 @@ access token. This access token is used later to access user's profile.</p>
 
 <h2>Additional information</h2>
 
-<p>The JavaFX <code>WebEngine</code> used in the `OAuthChallengeHandler` in this sample may not support rendering of some modern web elements returned by the <code>AuthorizationURL</code>. For this reason, we append <code>&display=classic</code> to the authorization URL, to ensure it renders properly.</p>
+<p>The JavaFX <code>WebEngine</code> used in the <code>OAuthChallengeHandler</code> in this sample may not support rendering of some modern web elements returned by the <code>AuthorizationURL</code>. For this reason, we append <code>&display=classic</code> to the authorization URL, to ensure it renders properly.</p>

--- a/src/main/java/com/esri/samples/portal/oauth/README.md
+++ b/src/main/java/com/esri/samples/portal/oauth/README.md
@@ -37,6 +37,6 @@ access token. This access token is used later to access user's profile.</p>
     <li>PortalUser</li>
 </ul>
 
-<h2>Additional Information</h2>
+<h2>Additional information</h2>
 
 <p>The JavaFX <code>WebEngine</code> used in this sample may not support rendering of some modern web elements returned by the <code>AuthorizationURL</code>. For this reason, we append <code>&display=classic</code> to the authorization URL, to ensure it renders properly.</p>

--- a/src/main/java/com/esri/samples/portal/oauth/README.md
+++ b/src/main/java/com/esri/samples/portal/oauth/README.md
@@ -39,4 +39,4 @@ access token. This access token is used later to access user's profile.</p>
 
 <h2>Additional information</h2>
 
-<p>The JavaFX <code>WebEngine</code> used in this sample may not support rendering of some modern web elements returned by the <code>AuthorizationURL</code>. For this reason, we append <code>&display=classic</code> to the authorization URL, to ensure it renders properly.</p>
+<p>The JavaFX <code>WebEngine</code> used in the `OAuthChallengeHandler` in this sample may not support rendering of some modern web elements returned by the <code>AuthorizationURL</code>. For this reason, we append <code>&display=classic</code> to the authorization URL, to ensure it renders properly.</p>


### PR DESCRIPTION
Hi @Rachael-E & @tschie,
as discussed, there is a slight bug with some URLs and the custom challenge handler in the oAuth sample.
The fix involves adding `"&display=classic"` to the authorization URL. I've also added an `Additional information` section to the readme to explain why this is necessary.
Let me know what you think.
Thanks!