### PR TITLE
Routing around barriers - add isStillSincePress to mouse events

### DIFF
--- a/network_analysis/routing-around-barriers/src/main/java/com/esri/samples/routing_around_barriers/RoutingAroundBarriersController.java
+++ b/network_analysis/routing-around-barriers/src/main/java/com/esri/samples/routing_around_barriers/RoutingAroundBarriersController.java
@@ -144,66 +144,68 @@ public class RoutingAroundBarriersController {
    */
   @FXML
   private void handleMapViewClicked(MouseEvent e) {
-    // convert clicked point to a map point
-    Point mapPoint = mapView.screenToLocation(new Point2D(e.getX(), e.getY()));
+    if (e.isStillSincePress()) {
+      // convert clicked point to a map point
+      Point mapPoint = mapView.screenToLocation(new Point2D(e.getX(), e.getY()));
 
-    // normalize geometry - important for geometries that will be sent to a server for processing
-    mapPoint = (Point) GeometryEngine.normalizeCentralMeridian(mapPoint);
+      // normalize geometry - important for geometries that will be sent to a server for processing
+      mapPoint = (Point) GeometryEngine.normalizeCentralMeridian(mapPoint);
 
-    // if the primary mouse button was clicked, add a stop or barrier to the clicked map point
-    if (e.getButton() == MouseButton.PRIMARY && e.isStillSincePress()) {
-      // clear the displayed route, if it exists, since it might not be up to date any more
-      routeGraphicsOverlay.getGraphics().clear();
-
-      if (btnAddStop.isSelected()) {
-        // use the clicked map point to construct a stop
-        Stop stopPoint = new Stop(new Point(mapPoint.getX(), mapPoint.getY(), mapPoint.getSpatialReference()));
-
-        // add the new stop to the list of stops
-        stopsList.add(stopPoint);
-
-        // create a marker symbol and graphics, and add the graphics to the graphics overlay
-        CompositeSymbol newStopSymbol = createCompositeStopSymbol(stopsList.size());
-        Graphic stopGraphic = new Graphic(mapPoint, newStopSymbol);
-        stopsGraphicsOverlay.getGraphics().add(stopGraphic);
-
-      } else if (btnAddBarrier.isSelected()) {
-        // create a buffered polygon around the clicked point
-        Polygon bufferedBarrierPolygon = GeometryEngine.buffer(mapPoint, 500);
-
-        // create a polygon barrier for the routing task, and add it to the list of barriers
-        PolygonBarrier barrier = new PolygonBarrier(bufferedBarrierPolygon);
-        barriersList.add(barrier);
-
-        // build graphics for the barrier and add it to the graphics overlay
-        Graphic barrierGraphic = new Graphic(bufferedBarrierPolygon, barrierSymbol);
-        barriersGraphicsOverlay.getGraphics().add(barrierGraphic);
-      }
-
-      // if the secondary mouse button was clicked, delete the last stop or barrier, respectively
-    } else if (e.getButton() == MouseButton.SECONDARY && e.isStillSincePress()) {
-
-      // check if we can remove stops
-      if (btnAddStop.isSelected() && !stopsList.isEmpty()) {
+      // if the primary mouse button was clicked, add a stop or barrier to the clicked map point
+      if (e.getButton() == MouseButton.PRIMARY) {
         // clear the displayed route, if it exists, since it might not be up to date any more
         routeGraphicsOverlay.getGraphics().clear();
 
-        // remove the last stop from the stop list and the graphics overlay
-        stopsList.removeLast();
-        stopsGraphicsOverlay.getGraphics().remove(stopsGraphicsOverlay.getGraphics().size() - 1);
+        if (btnAddStop.isSelected()) {
+          // use the clicked map point to construct a stop
+          Stop stopPoint = new Stop(new Point(mapPoint.getX(), mapPoint.getY(), mapPoint.getSpatialReference()));
 
-        // check if we can remove barriers
-      } else if (btnAddBarrier.isSelected() && !barriersList.isEmpty()) {
-        // clear the displayed route, if it exists, since it might not be up to date any more
-        routeGraphicsOverlay.getGraphics().clear();
+          // add the new stop to the list of stops
+          stopsList.add(stopPoint);
 
-        // remove the last barrier from the barrier list and the graphics overlay
-        barriersList.removeLast();
-        barriersGraphicsOverlay.getGraphics().remove(barriersGraphicsOverlay.getGraphics().size() - 1);
+          // create a marker symbol and graphics, and add the graphics to the graphics overlay
+          CompositeSymbol newStopSymbol = createCompositeStopSymbol(stopsList.size());
+          Graphic stopGraphic = new Graphic(mapPoint, newStopSymbol);
+          stopsGraphicsOverlay.getGraphics().add(stopGraphic);
+
+        } else if (btnAddBarrier.isSelected()) {
+          // create a buffered polygon around the clicked point
+          Polygon bufferedBarrierPolygon = GeometryEngine.buffer(mapPoint, 500);
+
+          // create a polygon barrier for the routing task, and add it to the list of barriers
+          PolygonBarrier barrier = new PolygonBarrier(bufferedBarrierPolygon);
+          barriersList.add(barrier);
+
+          // build graphics for the barrier and add it to the graphics overlay
+          Graphic barrierGraphic = new Graphic(bufferedBarrierPolygon, barrierSymbol);
+          barriersGraphicsOverlay.getGraphics().add(barrierGraphic);
+        }
+
+        // if the secondary mouse button was clicked, delete the last stop or barrier, respectively
+      } else if (e.getButton() == MouseButton.SECONDARY) {
+
+        // check if we can remove stops
+        if (btnAddStop.isSelected() && !stopsList.isEmpty()) {
+          // clear the displayed route, if it exists, since it might not be up to date any more
+          routeGraphicsOverlay.getGraphics().clear();
+
+          // remove the last stop from the stop list and the graphics overlay
+          stopsList.removeLast();
+          stopsGraphicsOverlay.getGraphics().remove(stopsGraphicsOverlay.getGraphics().size() - 1);
+
+          // check if we can remove barriers
+        } else if (btnAddBarrier.isSelected() && !barriersList.isEmpty()) {
+          // clear the displayed route, if it exists, since it might not be up to date any more
+          routeGraphicsOverlay.getGraphics().clear();
+
+          // remove the last barrier from the barrier list and the graphics overlay
+          barriersList.removeLast();
+          barriersGraphicsOverlay.getGraphics().remove(barriersGraphicsOverlay.getGraphics().size() - 1);
+        }
       }
+
+      createRouteAndDisplay();
     }
-
-    createRouteAndDisplay();
   }
 
   /**

--- a/network_analysis/routing-around-barriers/src/main/java/com/esri/samples/routing_around_barriers/RoutingAroundBarriersController.java
+++ b/network_analysis/routing-around-barriers/src/main/java/com/esri/samples/routing_around_barriers/RoutingAroundBarriersController.java
@@ -258,7 +258,7 @@ public class RoutingAroundBarriersController {
           }
 
         } catch (InterruptedException | ExecutionException e) {
-          new Alert(Alert.AlertType.ERROR, "Solve RouteTask failed " + e.getMessage() + e.getMessage()).show();
+          new Alert(Alert.AlertType.ERROR, "Solve RouteTask failed").show();
         }
 
         // enable the reset button


### PR DESCRIPTION
Hi @tschie & @Rachael-E, sorry to add something to this sample after it has just been merged, but I noticed the route is getting recalculated even when clicking and dragging on the map.
What I did was wrap the inside of the method `handleMapViewClicked(e)` in an `if (e.isStillSincePress())`, and took that condition away from ther internal logic (primary/secondary clicks to add/remove stops).
Curious to see if there's a better way to do it though, so please let me know.