### PR TITLE
Patch/geometry engine simplify - add isSimple check

### DIFF
--- a/geometry/geometry-engine-simplify/README.md
+++ b/geometry/geometry-engine-simplify/README.md
@@ -1,29 +1,31 @@
-# Geometry Engine Simplify
+# Geometry engine simplify
 
-Simplify a polygon that has multiple parts.
+Simplify a polygon with a self-intersecting geometry.
 
-![](GeometryEngineSimplify.png)
+![Geometry Engine Simplify Sample](GeometryEngineSimplify.png)
+
+## Use case
+
+A user may draw a polygon which is self-intersecting or contains incorrect ring orientations. The geometry must be simplified before it can be saved to a geodatabase.
 
 ## How to use the sample
 
-Click on the simplify button to apply the simplify geometry operation between the intersecting polygons. Click reset to restart the sample.
+Click the 'Simplify' button to simplify the geometry. Click 'Reset' to reset to the original geometry.
 
 ## How it works
 
-To perform the simplify geometry operation on a `Polygon`:
-
-1. Create a `GraphicsOverlay` and add it to the `MapView`.
-2. Define the `PointCollection` of the `Geometry`.
-3. Add the polygons to the GraphicsOverlay.
-4. Determine the simplified geometry by using the `GeometryEngine.simplify(polygon.getGeometry())`.
+1. Check if the polygon geometry needs to be simplified using `GeometryEngine.isSimple(Geometry)`.
+2. Simplify the polygon's geometry using `GeometryEngine.simplify(Geometry)`.
 
 ## Relevant API
 
 * Geometry
-* Graphic
-* GraphicsOverlay
-* MapView
-* Point
-* PointCollection
-* SimpleLineSymbol
-* SimpleFillSymbol
+* GeometryEngine
+
+## Additional information
+
+The concept of topological simplicity is different than geometry generalization, where points are removed from polygons or lines to create a more generalized result while preserving overall shape. See the 'Densify and Generalize' sample for comparison.
+
+## Tags
+
+geometry, polygon, simplify, spatial operations, topology

--- a/geometry/geometry-engine-simplify/README.metadata.json
+++ b/geometry/geometry-engine-simplify/README.metadata.json
@@ -1,30 +1,21 @@
 {
     "category": "Geometry",
-    "description": "Simplify a polygon that has multiple parts.",
+    "description": "Simplify a polygon with a self-intersecting geometry.",
     "ignore": false,
     "images": [
         "GeometryEngineSimplify.png"
     ],
     "keywords": [
         "Geometry",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
-        "Point",
-        "PointCollection",
-        "SimpleLineSymbol",
-        "SimpleFillSymbol"
+        "Polygon",
+        "Simplify",
+        "Spatial operations",
+        "Topology"
     ],
     "redirect_from": "/java/latest/sample-code/geometry-engine-simplify.htm",
     "relevant_apis": [
         "Geometry",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
-        "Point",
-        "PointCollection",
-        "SimpleLineSymbol",
-        "SimpleFillSymbol"
+        "GeometryEngine"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/geometry_engine_simplify/GeometryEngineSimplifySample.java"

--- a/geometry/geometry-engine-simplify/src/main/java/com/esri/samples/geometry_engine_simplify/GeometryEngineSimplifySample.java
+++ b/geometry/geometry-engine-simplify/src/main/java/com/esri/samples/geometry_engine_simplify/GeometryEngineSimplifySample.java
@@ -90,16 +90,16 @@ public class GeometryEngineSimplifySample extends Application {
       resetButton.setMaxWidth(Double.MAX_VALUE);
       resetButton.setDisable(true);
 
-      // resolve a button press
+      // perform the simplify geometry operation
       simplifyButton.setOnAction(e -> {
 
         // check if the geometry needs to be simplified
         if (!GeometryEngine.isSimple(polygon.getGeometry())) {
 
-          // perform the simplify geometry operation
+          // simplify the geometry
           Geometry resultPolygon = GeometryEngine.simplify(polygon.getGeometry());
 
-          // update result as a red (0xFFE91F1F) geometry
+          // update result as a red graphic
           SimpleFillSymbol redSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, 0xFFE91F1F, line);
           resultGeomOverlay.getGraphics().add(new Graphic(resultPolygon, redSymbol));
 
@@ -112,6 +112,7 @@ public class GeometryEngineSimplifySample extends Application {
       resetButton.setOnAction(e -> {
         resultGeomOverlay.getGraphics().clear();
         simplifyButton.setDisable(false);
+        resetButton.setDisable(true);
       });
 
       // add buttons to the control panel

--- a/geometry/geometry-engine-simplify/src/main/java/com/esri/samples/geometry_engine_simplify/GeometryEngineSimplifySample.java
+++ b/geometry/geometry-engine-simplify/src/main/java/com/esri/samples/geometry_engine_simplify/GeometryEngineSimplifySample.java
@@ -90,16 +90,22 @@ public class GeometryEngineSimplifySample extends Application {
       resetButton.setMaxWidth(Double.MAX_VALUE);
       resetButton.setDisable(true);
 
-      // perform the simplify geometry operation
+      // resolve a button press
       simplifyButton.setOnAction(e -> {
-        Geometry resultPolygon = GeometryEngine.simplify(polygon.getGeometry());
 
-        // update result as a red (0xFFE91F1F) geometry
-        SimpleFillSymbol redSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, 0xFFE91F1F, line);
-        resultGeomOverlay.getGraphics().add(new Graphic(resultPolygon, redSymbol));
+        // check if the geometry needs to be simplified
+        if (!GeometryEngine.isSimple(polygon.getGeometry())) {
 
-        resetButton.setDisable(false);
-        simplifyButton.setDisable(true);
+          // perform the simplify geometry operation
+          Geometry resultPolygon = GeometryEngine.simplify(polygon.getGeometry());
+
+          // update result as a red (0xFFE91F1F) geometry
+          SimpleFillSymbol redSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, 0xFFE91F1F, line);
+          resultGeomOverlay.getGraphics().add(new Graphic(resultPolygon, redSymbol));
+
+          resetButton.setDisable(false);
+          simplifyButton.setDisable(true);
+        }
       });
 
       // clear result layer


### PR DESCRIPTION
Hi both,
As discussed when reviewing the readme, this is a quick change to the 'Geometry Engine Simplify' sample. I've added a `.isSimple(geometry)` check to happen before applying the 'simplify' operation.
@Rachael-E and I have discussed perhaps changing the Data to be slightly overlapping circles instead of the three boxes (we found them a little confusing). But I'm thinking to maybe log an issue for that and keep it for later.
Let me know what you think! Thanks