### PR TITLE
Patch/apply scheduled updates

### DIFF
--- a/map/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/samples/apply_scheduled_updates_to_preplanned_map_area/ApplyScheduledUpdatesToPreplannedMapAreaSample.java
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/samples/apply_scheduled_updates_to_preplanned_map_area/ApplyScheduledUpdatesToPreplannedMapAreaSample.java
@@ -35,6 +35,8 @@ import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.MobileMapPackage;
 import com.esri.arcgisruntime.mapping.view.MapView;
+import com.esri.arcgisruntime.security.AuthenticationManager;
+import com.esri.arcgisruntime.security.DefaultAuthenticationChallengeHandler;
 import com.esri.arcgisruntime.tasks.offlinemap.OfflineMapSyncJob;
 import com.esri.arcgisruntime.tasks.offlinemap.OfflineMapSyncParameters;
 import com.esri.arcgisruntime.tasks.offlinemap.OfflineMapSyncResult;
@@ -172,8 +174,9 @@ public class ApplyScheduledUpdatesToPreplannedMapAreaSample extends Application 
 
             // check if mobile map package reopen is required
             if (offlineMapSyncResult.isMobileMapPackageReopenRequired()) {
-              // remove the present mobile map package from the map view and close it
+              // release the mobile map package maps from the map view
               mapView.setMap(null);
+              // close the old mobile map package
               mobileMapPackage.close();
 
               // create a new instance of the now updated mobile map package

--- a/map/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/samples/apply_scheduled_updates_to_preplanned_map_area/ApplyScheduledUpdatesToPreplannedMapAreaSample.java
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/samples/apply_scheduled_updates_to_preplanned_map_area/ApplyScheduledUpdatesToPreplannedMapAreaSample.java
@@ -159,8 +159,6 @@ public class ApplyScheduledUpdatesToPreplannedMapAreaSample extends Application 
 
         // set the parameters to download all updates for the mobile map packages
         offlineMapSyncParameters.setPreplannedScheduledUpdatesOption(PreplannedScheduledUpdatesOption.DOWNLOAD_ALL_UPDATES);
-        // set the map package to rollback to the old state should the sync job fail
-        offlineMapSyncParameters.setRollbackOnFailure(true);
 
         // create a sync job using the parameters
         OfflineMapSyncJob offlineMapSyncJob = offlineMapSyncTask.syncOfflineMap(offlineMapSyncParameters);

--- a/map/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/samples/apply_scheduled_updates_to_preplanned_map_area/ApplyScheduledUpdatesToPreplannedMapAreaSample.java
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/samples/apply_scheduled_updates_to_preplanned_map_area/ApplyScheduledUpdatesToPreplannedMapAreaSample.java
@@ -27,6 +27,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
+
 import org.apache.commons.io.FileUtils;
 
 import com.esri.arcgisruntime.concurrent.Job;
@@ -35,8 +36,6 @@ import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.MobileMapPackage;
 import com.esri.arcgisruntime.mapping.view.MapView;
-import com.esri.arcgisruntime.security.AuthenticationManager;
-import com.esri.arcgisruntime.security.DefaultAuthenticationChallengeHandler;
 import com.esri.arcgisruntime.tasks.offlinemap.OfflineMapSyncJob;
 import com.esri.arcgisruntime.tasks.offlinemap.OfflineMapSyncParameters;
 import com.esri.arcgisruntime.tasks.offlinemap.OfflineMapSyncResult;


### PR DESCRIPTION
Hi both,
This PR is to make some minor changes to `Apply scheduled updates...`
The 'rollback on fail' flag isn't relevant in this API, so it needed removing.
Also, when checking for `isMobileMapPackageReopenRequired`, we cannot just do 
```
mmpk.close();
mmpk.loadAsync();
```
since this doesn't comply with the loadable pattern.
What is needed is to create a new instance of the now updated MMPK, and load that.