### PR TITLE
Data parent directory

### DIFF
--- a/analysis/line-of-sight-geoelement/src/main/java/com/esri/samples/line_of_sight_geoelement/LineOfSightGeoElementSample.java
+++ b/analysis/line-of-sight-geoelement/src/main/java/com/esri/samples/line_of_sight_geoelement/LineOfSightGeoElementSample.java
@@ -162,7 +162,7 @@ public class LineOfSightGeoElementSample extends Application {
       );
 
       // create a graphic of a taxi to be the target
-      String modelURI = new File("./samples-data/dolmus_3ds/dolmus.3ds").getAbsolutePath();
+      String modelURI = new File(System.getProperty("data.dir"), "./samples-data/dolmus_3ds/dolmus.3ds").getAbsolutePath();
       ModelSceneSymbol taxiSymbol = new ModelSceneSymbol(modelURI, 1.0);
       taxiSymbol.setAnchorPosition(SceneSymbol.AnchorPosition.BOTTOM);
       taxiSymbol.loadAsync();

--- a/analysis/viewshed-geoelement/src/main/java/com/esri/samples/viewshed_geoelement/ViewshedGeoElementSample.java
+++ b/analysis/viewshed-geoelement/src/main/java/com/esri/samples/viewshed_geoelement/ViewshedGeoElementSample.java
@@ -113,8 +113,10 @@ public class ViewshedGeoElementSample extends Application {
       graphicsOverlay.setRenderer(renderer3D);
 
       // create a graphic of a tank
-      String modelURI = new File("./samples-data/bradley_low_3ds/bradle.3ds").getAbsolutePath();
-      ModelSceneSymbol tankSymbol = new ModelSceneSymbol(modelURI, 10.0);
+      String modelURI =
+              new File(System.getProperty("data.dir"), "./samples-data/bradley_low_3ds/bradle.3ds").getAbsolutePath();
+      System.out.println(modelURI);
+      ModelSceneSymbol tankSymbol = new ModelSceneSymbol(modelURI.replace("\\", "/"), 10.0);
       tankSymbol.setHeading(90);
       tankSymbol.setAnchorPosition(SceneSymbol.AnchorPosition.BOTTOM);
       tankSymbol.loadAsync();

--- a/analysis/viewshed-geoelement/src/main/java/com/esri/samples/viewshed_geoelement/ViewshedGeoElementSample.java
+++ b/analysis/viewshed-geoelement/src/main/java/com/esri/samples/viewshed_geoelement/ViewshedGeoElementSample.java
@@ -113,9 +113,7 @@ public class ViewshedGeoElementSample extends Application {
       graphicsOverlay.setRenderer(renderer3D);
 
       // create a graphic of a tank
-      String modelURI =
-              new File(System.getProperty("data.dir"), "./samples-data/bradley_low_3ds/bradle.3ds").getAbsolutePath();
-      System.out.println(modelURI);
+      String modelURI = new File(System.getProperty("data.dir"), "./samples-data/bradley_low_3ds/bradle.3ds").getAbsolutePath();
       ModelSceneSymbol tankSymbol = new ModelSceneSymbol(modelURI.replace("\\", "/"), 10.0);
       tankSymbol.setHeading(90);
       tankSymbol.setAnchorPosition(SceneSymbol.AnchorPosition.BOTTOM);

--- a/display_information/dictionary-renderer-graphics-overlay/src/main/java/com/esri/samples/dictionary_renderer_graphics_overlay/DictionaryRendererGraphicsOverlaySample.java
+++ b/display_information/dictionary-renderer-graphics-overlay/src/main/java/com/esri/samples/dictionary_renderer_graphics_overlay/DictionaryRendererGraphicsOverlaySample.java
@@ -75,8 +75,9 @@ public class DictionaryRendererGraphicsOverlaySample extends Application {
     graphicsOverlay.setMinScale(1000000);
     mapView.getGraphicsOverlays().add(graphicsOverlay);
 
-    // create symbol dictionary from style file
-    DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle.createFromFile("./samples-data/stylx/mil2525d.stylx");
+    // create symbol dictionary from style file\
+    File stylxFile = new File(System.getProperty("data.dir"), "./samples-data/stylx/mil2525d.stylx");
+    DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle.createFromFile(stylxFile.getAbsolutePath());
 
     // tells graphics overlay how to render graphics with symbol dictionary attributes set
     DictionaryRenderer renderer = new DictionaryRenderer(symbolDictionary);

--- a/display_information/dictionary-renderer-graphics-overlay/src/main/java/com/esri/samples/dictionary_renderer_graphics_overlay/DictionaryRendererGraphicsOverlaySample.java
+++ b/display_information/dictionary-renderer-graphics-overlay/src/main/java/com/esri/samples/dictionary_renderer_graphics_overlay/DictionaryRendererGraphicsOverlaySample.java
@@ -102,7 +102,7 @@ public class DictionaryRendererGraphicsOverlaySample extends Application {
    */
   private List<Map<String, Object>> parseMessages() throws Exception {
 
-    File mil2525dFile = new File("./samples-data/xml/Mil2525DMessages.xml");
+    File mil2525dFile = new File(System.getProperty("data.dir"), "./samples-data/xml/Mil2525DMessages.xml");
     DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
     DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
     Document document = documentBuilder.parse(mil2525dFile);

--- a/display_information/dictionary-renderer-graphics-overlay/src/main/java/com/esri/samples/dictionary_renderer_graphics_overlay/DictionaryRendererGraphicsOverlaySample.java
+++ b/display_information/dictionary-renderer-graphics-overlay/src/main/java/com/esri/samples/dictionary_renderer_graphics_overlay/DictionaryRendererGraphicsOverlaySample.java
@@ -76,7 +76,8 @@ public class DictionaryRendererGraphicsOverlaySample extends Application {
     mapView.getGraphicsOverlays().add(graphicsOverlay);
 
     // create symbol dictionary from style file
-    DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle.createFromFile("./samples-data/stylx/mil2525d.stylx");
+    File stylxFile = new File(System.getProperty("data.dir"), "./samples-data/stylx/mil2525d.stylx");
+    DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle.createFromFile(stylxFile.getAbsolutePath());
 
     // tells graphics overlay how to render graphics with symbol dictionary attributes set
     DictionaryRenderer renderer = new DictionaryRenderer(symbolDictionary);

--- a/display_information/dictionary-renderer-graphics-overlay/src/main/java/com/esri/samples/dictionary_renderer_graphics_overlay/DictionaryRendererGraphicsOverlaySample.java
+++ b/display_information/dictionary-renderer-graphics-overlay/src/main/java/com/esri/samples/dictionary_renderer_graphics_overlay/DictionaryRendererGraphicsOverlaySample.java
@@ -75,9 +75,8 @@ public class DictionaryRendererGraphicsOverlaySample extends Application {
     graphicsOverlay.setMinScale(1000000);
     mapView.getGraphicsOverlays().add(graphicsOverlay);
 
-    // create symbol dictionary from style file\
-    File stylxFile = new File(System.getProperty("data.dir"), "./samples-data/stylx/mil2525d.stylx");
-    DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle.createFromFile(stylxFile.getAbsolutePath());
+    // create symbol dictionary from style file
+    DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle.createFromFile("./samples-data/stylx/mil2525d.stylx");
 
     // tells graphics overlay how to render graphics with symbol dictionary attributes set
     DictionaryRenderer renderer = new DictionaryRenderer(symbolDictionary);

--- a/editing/edit-and-sync-features/src/main/java/com/esri/samples/edit_and_sync_features/EditAndSyncFeaturesController.java
+++ b/editing/edit-and-sync-features/src/main/java/com/esri/samples/edit_and_sync_features/EditAndSyncFeaturesController.java
@@ -84,7 +84,7 @@ public class EditAndSyncFeaturesController {
     try {
       // create a basemap from a local tile cache
       File tpkFile = new File(System.getProperty("data.dir"), "./samples-data/sanfrancisco/SanFrancisco.tpk");
-      TileCache sanFranciscoTileCache = new TileCache(tpkFile.getCanonicalPath());
+      TileCache sanFranciscoTileCache = new TileCache(tpkFile.getAbsolutePath());
       ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(sanFranciscoTileCache);
       Basemap basemap = new Basemap(tiledLayer);
 

--- a/editing/edit-and-sync-features/src/main/java/com/esri/samples/edit_and_sync_features/EditAndSyncFeaturesController.java
+++ b/editing/edit-and-sync-features/src/main/java/com/esri/samples/edit_and_sync_features/EditAndSyncFeaturesController.java
@@ -83,7 +83,8 @@ public class EditAndSyncFeaturesController {
 
     try {
       // create a basemap from a local tile cache
-      TileCache sanFranciscoTileCache = new TileCache("samples-data/sanfrancisco/SanFrancisco.tpk");
+      File tpkFile = new File(System.getProperty("data.dir"), "./samples-data/sanfrancisco/SanFrancisco.tpk");
+      TileCache sanFranciscoTileCache = new TileCache(tpkFile.getCanonicalPath());
       ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(sanFranciscoTileCache);
       Basemap basemap = new Basemap(tiledLayer);
 

--- a/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
+++ b/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
@@ -31,6 +31,8 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.DictionaryRenderer;
 import com.esri.arcgisruntime.symbology.DictionarySymbolStyle;
 
+import java.io.File;
+
 public class FeatureLayerDictionaryRendererSample extends Application {
 
   private MapView mapView;
@@ -57,7 +59,8 @@ public class FeatureLayerDictionaryRendererSample extends Application {
     geodatabase.loadAsync();
 
     // render tells layer what symbols to apply to what features
-    DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle.createFromFile("./samples-data/stylx/mil2525d.stylx");
+    File stylxFile = new File(System.getProperty("data.dir"), "./samples-data/stylx/mil2525d.stylx");
+    DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle.createFromFile(stylxFile.getAbsolutePath());
     symbolDictionary.loadAsync();
 
     geodatabase.addDoneLoadingListener(() -> {

--- a/feature_layers/feature-layer-geodatabase/src/main/java/com/esri/samples/feature_layer_geodatabase/FeatureLayerGeodatabaseSample.java
+++ b/feature_layers/feature-layer-geodatabase/src/main/java/com/esri/samples/feature_layer_geodatabase/FeatureLayerGeodatabaseSample.java
@@ -58,8 +58,9 @@ public class FeatureLayerGeodatabaseSample extends Application {
       mapView.setMap(map);
 
       // create geodatabase from local resource
-      String geodatabaseUrl = new File("samples-data/los_angeles/LA_Trails.geodatabase").getAbsolutePath();
-      Geodatabase geodatabase = new Geodatabase(geodatabaseUrl);
+      File geodatabaseFile = new File(System.getProperty("data.dir"), "./samples-data/los_angeles/LA_Trails" +
+              ".geodatabase");
+      Geodatabase geodatabase = new Geodatabase(geodatabaseFile.getCanonicalPath());
       geodatabase.addDoneLoadingListener(() -> {
         if (geodatabase.getLoadStatus() == LoadStatus.LOADED) {
           // access the geodatabase's feature table Trailheads

--- a/feature_layers/feature-layer-geodatabase/src/main/java/com/esri/samples/feature_layer_geodatabase/FeatureLayerGeodatabaseSample.java
+++ b/feature_layers/feature-layer-geodatabase/src/main/java/com/esri/samples/feature_layer_geodatabase/FeatureLayerGeodatabaseSample.java
@@ -60,7 +60,7 @@ public class FeatureLayerGeodatabaseSample extends Application {
       // create geodatabase from local resource
       File geodatabaseFile = new File(System.getProperty("data.dir"), "./samples-data/los_angeles/LA_Trails" +
               ".geodatabase");
-      Geodatabase geodatabase = new Geodatabase(geodatabaseFile.getCanonicalPath());
+      Geodatabase geodatabase = new Geodatabase(geodatabaseFile.getAbsolutePath());
       geodatabase.addDoneLoadingListener(() -> {
         if (geodatabase.getLoadStatus() == LoadStatus.LOADED) {
           // access the geodatabase's feature table Trailheads

--- a/feature_layers/feature-layer-geopackage/src/main/java/com/esri/samples/feature_layer_geopackage/FeatureLayerGeoPackageSample.java
+++ b/feature_layers/feature-layer-geopackage/src/main/java/com/esri/samples/feature_layer_geopackage/FeatureLayerGeoPackageSample.java
@@ -57,7 +57,7 @@ public class FeatureLayerGeoPackageSample extends Application {
       ArcGISMap map = new ArcGISMap(Basemap.createStreetsVector());
 
       // create a GeoPackage from a local gpkg file
-      File geoPackageFile = new File("./samples-data/auroraCO/AuroraCO.gpkg");
+      File geoPackageFile = new File(System.getProperty("data.dir"), "./samples-data/auroraCO/AuroraCO.gpkg");
       GeoPackage geoPackage = new GeoPackage(geoPackageFile.getAbsolutePath());
       geoPackage.loadAsync();
 

--- a/feature_layers/feature-layer-shapefile/src/main/java/com/esri/samples/feature_layer_shapefile/FeatureLayerShapefileSample.java
+++ b/feature_layers/feature-layer-shapefile/src/main/java/com/esri/samples/feature_layer_shapefile/FeatureLayerShapefileSample.java
@@ -58,7 +58,7 @@ public class FeatureLayerShapefileSample extends Application {
       mapView.setMap(map);
 
       // create a shapefile feature table from the local file
-      File shapefile = new File("./samples-data/auroraCO/Public_Art.shp");
+      File shapefile = new File(System.getProperty("data.dir"), "./samples-data/auroraCO/Public_Art.shp");
       ShapefileFeatureTable shapefileFeatureTable = new ShapefileFeatureTable(shapefile.getAbsolutePath());
 
       // use the shapefile feature table to create a feature layer

--- a/feature_layers/generate-geodatabase/src/main/java/com/esri/samples/generate_geodatabase/GenerateGeodatabaseSample.java
+++ b/feature_layers/generate-geodatabase/src/main/java/com/esri/samples/generate_geodatabase/GenerateGeodatabaseSample.java
@@ -71,7 +71,8 @@ public class GenerateGeodatabaseSample extends Application {
       stage.show();
 
       // use a local tile package for the basemap
-      TileCache tileCache = new TileCache("samples-data/sanfrancisco/SanFrancisco.tpk");
+      File tpkFile = new File(System.getProperty("data.dir"), "./samples-data/sanfrancisco/SanFrancisco.tpk");
+      TileCache tileCache = new TileCache(tpkFile.getCanonicalPath());
       ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(tileCache);
 
       // create a map view and add a map

--- a/feature_layers/generate-geodatabase/src/main/java/com/esri/samples/generate_geodatabase/GenerateGeodatabaseSample.java
+++ b/feature_layers/generate-geodatabase/src/main/java/com/esri/samples/generate_geodatabase/GenerateGeodatabaseSample.java
@@ -72,7 +72,7 @@ public class GenerateGeodatabaseSample extends Application {
 
       // use a local tile package for the basemap
       File tpkFile = new File(System.getProperty("data.dir"), "./samples-data/sanfrancisco/SanFrancisco.tpk");
-      TileCache tileCache = new TileCache(tpkFile.getCanonicalPath());
+      TileCache tileCache = new TileCache(tpkFile.getAbsolutePath());
       ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(tileCache);
 
       // create a map view and add a map

--- a/hydrography/add-enc-exchange-set/src/main/java/com/esri/samples/add_enc_exchange_set/AddEncExchangeSetSample.java
+++ b/hydrography/add-enc-exchange-set/src/main/java/com/esri/samples/add_enc_exchange_set/AddEncExchangeSetSample.java
@@ -85,7 +85,7 @@ public class AddEncExchangeSetSample extends Application {
       mapView.setMap(map);
 
       // load the ENC exchange set from local data
-      File encPath = new File("./samples-data/enc/ExchangeSetwithoutUpdates/ENC_ROOT/CATALOG.031");
+      File encPath = new File(System.getProperty("data.dir"), "./samples-data/enc/ExchangeSetwithoutUpdates/ENC_ROOT/CATALOG.031");
       EncExchangeSet encExchangeSet = new EncExchangeSet(Collections.singletonList(encPath.getAbsolutePath()));
       encExchangeSet.loadAsync();
       encExchangeSet.addDoneLoadingListener(() -> {

--- a/kml/display-kml/src/main/java/com/esri/samples/display_kml/DisplayKMLSample.java
+++ b/kml/display-kml/src/main/java/com/esri/samples/display_kml/DisplayKMLSample.java
@@ -88,7 +88,7 @@ public class DisplayKMLSample extends Application {
               kmlLayer = new KmlLayer(portalItem);
               break;
             case LOCAL_FILE:
-              File kmlFile = new File("./samples-data/kml/US_State_Capitals.kml");
+              File kmlFile = new File(System.getProperty("data.dir"), "./samples-data/kml/US_State_Capitals.kml");
               KmlDataset fileKmlDataset = new KmlDataset(kmlFile.getAbsolutePath());
               kmlLayer = new KmlLayer(fileKmlDataset);
               break;

--- a/kml/list-kml-contents/src/main/java/com/esri/samples/list_kml_contents/ListKMLContentsSample.java
+++ b/kml/list-kml-contents/src/main/java/com/esri/samples/list_kml_contents/ListKMLContentsSample.java
@@ -72,7 +72,7 @@ public class ListKMLContentsSample extends Application {
       sceneView.setArcGISScene(scene);
 
       // load a KML dataset from a local KMZ file and show it as an operational layer
-      File kmzFile = new File("./samples-data/kml/esri_test_data.kmz");
+      File kmzFile = new File(System.getProperty("data.dir"), "./samples-data/kml/esri_test_data.kmz");
       KmlDataset kmlDataset = new KmlDataset(kmzFile.getAbsolutePath());
       KmlLayer kmlLayer = new KmlLayer(kmlDataset);
       scene.getOperationalLayers().add(kmlLayer);

--- a/kml/play-a-kml-tour/src/main/java/com/esri/samples/play_a_kml_tour/PlayAKMLTourSample.java
+++ b/kml/play-a-kml-tour/src/main/java/com/esri/samples/play_a_kml_tour/PlayAKMLTourSample.java
@@ -112,7 +112,7 @@ public class PlayAKMLTourSample extends Application {
       controlsVBox.getChildren().addAll(playPauseButton, replayButton);
 
       // add a KML layer from a KML dataset with a KML tour
-      KmlDataset kmlDataset = new KmlDataset(new File("./samples-data/kml/Esri_tour.kmz").getAbsolutePath());
+      KmlDataset kmlDataset = new KmlDataset(new File(System.getProperty("data.dir"), "./samples-data/kml/Esri_tour.kmz").getAbsolutePath());
       KmlLayer kmlLayer = new KmlLayer(kmlDataset);
       scene.getOperationalLayers().add(kmlLayer);
 

--- a/local_server/local-server-dynamic-workspace-raster/src/main/java/com/esri/samples/local_server_dynamic_workspace_raster/LocalServerDynamicWorkspaceRasterSample.java
+++ b/local_server/local-server-dynamic-workspace-raster/src/main/java/com/esri/samples/local_server_dynamic_workspace_raster/LocalServerDynamicWorkspaceRasterSample.java
@@ -99,7 +99,7 @@ public class LocalServerDynamicWorkspaceRasterSample extends Application {
         FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle("Open Resource File");
         fileChooser.getExtensionFilters().addAll(new ExtensionFilter("Image Files", "*.tif"));
-        fileChooser.setInitialDirectory(new File("./samples-data/raster/"));
+        fileChooser.setInitialDirectory(new File(System.getProperty("data.dir"), "./samples-data/raster/"));
         File selectedFile = fileChooser.showOpenDialog(stage);
 
         if (selectedFile != null) {

--- a/local_server/local-server-dynamic-workspace-shapefile/src/main/java/com/esri/samples/local_server_dynamic_workspace_shapefile/LocalServerDynamicWorkspaceShapefileSample.java
+++ b/local_server/local-server-dynamic-workspace-shapefile/src/main/java/com/esri/samples/local_server_dynamic_workspace_shapefile/LocalServerDynamicWorkspaceShapefileSample.java
@@ -99,7 +99,7 @@ public class LocalServerDynamicWorkspaceShapefileSample extends Application {
       FileChooser fileChooser = new FileChooser();
       fileChooser.setTitle("Open Resource File");
       fileChooser.getExtensionFilters().addAll(new ExtensionFilter("Shapefiles", "*.shp"));
-      fileChooser.setInitialDirectory(new File("./samples-data/shapefiles/"));
+      fileChooser.setInitialDirectory(new File(System.getProperty("data.dir"), "./samples-data/shapefiles/"));
       // choose the file, then start the local map service
       addButton.setOnAction(e -> {
         // browse to the shapefile file

--- a/local_server/local-server-feature-layer/src/main/java/com/esri/samples/local_server_feature_layer/LocalServerFeatureLayerSample.java
+++ b/local_server/local-server-feature-layer/src/main/java/com/esri/samples/local_server_feature_layer/LocalServerFeatureLayerSample.java
@@ -80,8 +80,8 @@ public class LocalServerFeatureLayerSample extends Application {
         server.addStatusChangedListener(status -> {
           if (server.getStatus() == LocalServerStatus.STARTED) {
             // start feature service
-            String featureServiceURL = new File("samples-data/local_server/PointsofInterest.mpk").getAbsolutePath();
-            featureService = new LocalFeatureService(featureServiceURL);
+            File mpkFile = new File(System.getProperty("data.dir"), "./samples-data/local_server/PointsofInterest.mpk");
+            featureService = new LocalFeatureService(mpkFile.getAbsolutePath());
             featureService.addStatusChangedListener(this::addLocalFeatureLayer);
             featureService.startAsync();
           }

--- a/local_server/local-server-geoprocessing/src/main/java/com/esri/samples/local_server_geoprocessing/LocalServerGeoprocessingController.java
+++ b/local_server/local-server-geoprocessing/src/main/java/com/esri/samples/local_server_geoprocessing/LocalServerGeoprocessingController.java
@@ -69,7 +69,7 @@ public class LocalServerGeoprocessingController {
       mapView.setMap(map);
 
       //load tiled layer and zoom to location
-      String rasterURL = new File("./samples-data/local_server/RasterHillshade.tpk").getAbsolutePath();
+      String rasterURL = new File(System.getProperty("data.dir"), "./samples-data/local_server/RasterHillshade.tpk").getAbsolutePath();
       TileCache tileCache = new TileCache(rasterURL);
       ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(tileCache);
       tiledLayer.loadAsync();
@@ -91,7 +91,7 @@ public class LocalServerGeoprocessingController {
         server.addStatusChangedListener(status -> {
           if (server.getStatus() == LocalServerStatus.STARTED) {
             try {
-              String gpServiceURL = new File("./samples-data/local_server/Contour.gpk").getAbsolutePath();
+              String gpServiceURL = new File(System.getProperty("data.dir"), "./samples-data/local_server/Contour.gpk").getAbsolutePath();
               // need map server result to add contour lines to map
               localGPService =
                   new LocalGeoprocessingService(gpServiceURL, ServiceType.ASYNCHRONOUS_SUBMIT_WITH_MAP_SERVER_RESULT);

--- a/local_server/local-server-map-image-layer/src/main/java/com/esri/samples/local_server_map_image_layer/LocalServerMapImageLayerSample.java
+++ b/local_server/local-server-map-image-layer/src/main/java/com/esri/samples/local_server_map_image_layer/LocalServerMapImageLayerSample.java
@@ -79,7 +79,7 @@ public class LocalServerMapImageLayerSample extends Application {
         server.addStatusChangedListener(status -> {
           if (status.getNewStatus() == LocalServerStatus.STARTED) {
             // start map image service
-            String mapServiceURL = new File("./samples-data/local_server/RelationshipID.mpk").getAbsolutePath();
+            String mapServiceURL = new File(System.getProperty("data.dir"), "./samples-data/local_server/RelationshipID.mpk").getAbsolutePath();
             mapImageService = new LocalMapService(mapServiceURL);
             mapImageService.addStatusChangedListener(this::addLocalMapImageLayer);
             mapImageService.startAsync();

--- a/local_server/local-server-services/src/main/java/com/esri/samples/local_server_services/LocalServerServicesController.java
+++ b/local_server/local-server-services/src/main/java/com/esri/samples/local_server_services/LocalServerServicesController.java
@@ -92,7 +92,7 @@ public class LocalServerServicesController {
     // create a file chooser to select package files
     packageChooser = new FileChooser();
     packagePath.textProperty().bind(packageChooser.initialFileNameProperty());
-    packageChooser.setInitialDirectory(new File("./samples-data/local_server"));
+    packageChooser.setInitialDirectory(new File(System.getProperty("data.dir"), "./samples-data/local_server"));
     packageChooser.setInitialFileName(packageChooser.getInitialDirectory().getAbsolutePath() + "/PointsOfInterest.mpk");
 
     // create filters to choose files for specific services

--- a/map/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/samples/apply_scheduled_updates_to_preplanned_map_area/ApplyScheduledUpdatesToPreplannedMapAreaSample.java
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/samples/apply_scheduled_updates_to_preplanned_map_area/ApplyScheduledUpdatesToPreplannedMapAreaSample.java
@@ -73,7 +73,7 @@ public class ApplyScheduledUpdatesToPreplannedMapAreaSample extends Application 
       // create a temporary copy of the local offline map files, so that updating does not overwrite them permanently
       tempMobileMapPackageDirectory = Files.createTempDirectory("canyonlands_offline_map").toFile();
       tempMobileMapPackageDirectory.deleteOnExit();
-      File sourceDirectory = new File("./samples-data/canyonlands/");
+      File sourceDirectory = new File(System.getProperty("data.dir"), "./samples-data/canyonlands/");
       FileUtils.copyDirectory(sourceDirectory, tempMobileMapPackageDirectory);
 
       // load the offline map as a mobile map package

--- a/map/generate-offline-map-with-local-basemap/src/main/java/com/esri/samples/generate_offline_map_with_local_basemap/GenerateOfflineMapWithLocalBasemapSample.java
+++ b/map/generate-offline-map-with-local-basemap/src/main/java/com/esri/samples/generate_offline_map_with_local_basemap/GenerateOfflineMapWithLocalBasemapSample.java
@@ -137,7 +137,7 @@ public class GenerateOfflineMapWithLocalBasemapSample extends Application {
                 // open a directory chooser to select the directory containing the referenced basemap
                 DirectoryChooser directoryChooser = new DirectoryChooser();
                 // for this sample, the directory chosen should be "naperville"
-                directoryChooser.setInitialDirectory(new File("./samples-data"));
+                directoryChooser.setInitialDirectory(new File(System.getProperty("data.dir"), "./samples-data"));
                 directoryChooser.setTitle("Choose directory containing local basemap");
                 File localBasemapDirectory = directoryChooser.showDialog(stage.getOwner());
 

--- a/map/mobile-map-search-and-route/src/main/java/com/esri/samples/mobile_map_search_and_route/MobileMapSearchAndRouteSample.java
+++ b/map/mobile-map-search-and-route/src/main/java/com/esri/samples/mobile_map_search_and_route/MobileMapSearchAndRouteSample.java
@@ -93,7 +93,7 @@ public class MobileMapSearchAndRouteSample extends Application {
       FileChooser fileChooser = new FileChooser();
       FileChooser.ExtensionFilter mpkFilter = new FileChooser.ExtensionFilter("Map Packages (*.mmpk)", "*.mmpk");
       fileChooser.getExtensionFilters().add(mpkFilter);
-      fileChooser.setInitialDirectory(new File("./samples-data/mmpk"));
+      fileChooser.setInitialDirectory(new File(System.getProperty("data.dir"), "./samples-data/mmpk"));
 
       // click a button to open the file chooser
       Button findMmpkButton = new Button("Open mobile map package");

--- a/map/open-mobile-map-package/src/main/java/com/esri/samples/open_mobile_map_package/OpenMobileMapPackageSample.java
+++ b/map/open-mobile-map-package/src/main/java/com/esri/samples/open_mobile_map_package/OpenMobileMapPackageSample.java
@@ -52,7 +52,7 @@ public class OpenMobileMapPackageSample extends Application {
       mapView = new MapView();
 
       //load a mobile map package
-      final String mmpkPath = new File("./samples-data/mmpk/Yellowstone.mmpk").getAbsolutePath();
+      final String mmpkPath = new File(System.getProperty("data.dir"), "./samples-data/mmpk/Yellowstone.mmpk").getAbsolutePath();
       mobileMapPackage = new MobileMapPackage(mmpkPath);
 
       mobileMapPackage.loadAsync();

--- a/map/read-geopackage/src/main/java/com/esri/samples/read_geopackage/ReadGeoPackageSample.java
+++ b/map/read-geopackage/src/main/java/com/esri/samples/read_geopackage/ReadGeoPackageSample.java
@@ -57,7 +57,7 @@ public class ReadGeoPackageSample extends Application {
       mapView.setMap(map);
 
       // load the local GeoPackage
-      File geoPackageFile = new File("./samples-data/auroraCO/AuroraCO.gpkg");
+      File geoPackageFile = new File(System.getProperty("data.dir"), "./samples-data/auroraCO/AuroraCO.gpkg");
       GeoPackage geoPackage = new GeoPackage(geoPackageFile.getAbsolutePath());
       geoPackage.loadAsync();
       geoPackage.addDoneLoadingListener(() -> {

--- a/raster/blend-renderer/src/main/java/com/esri/samples/blend_renderer/BlendRendererController.java
+++ b/raster/blend-renderer/src/main/java/com/esri/samples/blend_renderer/BlendRendererController.java
@@ -46,8 +46,8 @@ public class BlendRendererController {
   public void initialize() {
 
     // create rasters
-    imageryRasterPath = new File("./samples-data/raster/Shasta.tif").getAbsolutePath();
-    elevationRasterPath = new File("./samples-data/raster/Shasta_Elevation.tif").getAbsolutePath();
+    imageryRasterPath = new File(System.getProperty("data.dir"), "./samples-data/raster/Shasta.tif").getAbsolutePath();
+    elevationRasterPath = new File(System.getProperty("data.dir"), "./samples-data/raster/Shasta_Elevation.tif").getAbsolutePath();
 
     // create a raster layer
     RasterLayer rasterLayer = new RasterLayer(new Raster(imageryRasterPath));

--- a/raster/colormap-renderer/src/main/java/com/esri/samples/colormap_renderer/ColormapRendererSample.java
+++ b/raster/colormap-renderer/src/main/java/com/esri/samples/colormap_renderer/ColormapRendererSample.java
@@ -55,7 +55,7 @@ public class ColormapRendererSample extends Application {
       stage.show();
 
       // create a raster from a local raster file
-      Raster raster = new Raster(new File("./samples-data/raster/ShastaBW.tif").getAbsolutePath());
+      Raster raster = new Raster(new File(System.getProperty("data.dir"), "./samples-data/raster/ShastaBW.tif").getAbsolutePath());
 
       // create a raster layer
       RasterLayer rasterLayer = new RasterLayer(raster);

--- a/raster/hillshade-renderer/src/main/java/com/esri/samples/hillshade_renderer/HillshadeRendererController.java
+++ b/raster/hillshade-renderer/src/main/java/com/esri/samples/hillshade_renderer/HillshadeRendererController.java
@@ -42,7 +42,7 @@ public class HillshadeRendererController {
   public void initialize() {
 
     // create raster
-    Raster raster = new Raster(new File("./samples-data/raster/srtm.tiff").getAbsolutePath());
+    Raster raster = new Raster(new File(System.getProperty("data.dir"), "./samples-data/raster/srtm.tiff").getAbsolutePath());
 
     // create a raster layer
     rasterLayer = new RasterLayer(raster);

--- a/raster/raster-function/src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java
+++ b/raster/raster-function/src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java
@@ -70,7 +70,7 @@ public class RasterFunctionSample extends Application {
 
           if (imageServiceRaster.getLoadStatus() == LoadStatus.LOADED) {
             // create raster function from local json file
-            File jsonFile = new File("./samples-data/raster/hillshade_simplified.json");
+            File jsonFile = new File(System.getProperty("data.dir"), "./samples-data/raster/hillshade_simplified.json");
             try (Scanner scanner = new Scanner(jsonFile)) {
               // read in the complete file as a string
               String json = scanner.useDelimiter("\\A").next();

--- a/raster/raster-layer-file/src/main/java/com/esri/samples/raster_layer_file/RasterLayerFileSample.java
+++ b/raster/raster-layer-file/src/main/java/com/esri/samples/raster_layer_file/RasterLayerFileSample.java
@@ -51,7 +51,7 @@ public class RasterLayerFileSample extends Application {
       stage.show();
 
       // create a raster from a local raster file
-      Raster raster = new Raster(new File("./samples-data/raster/Shasta.tif").getAbsolutePath());
+      Raster raster = new Raster(new File(System.getProperty("data.dir"), "./samples-data/raster/Shasta.tif").getAbsolutePath());
 
       // create a raster layer
       RasterLayer rasterLayer = new RasterLayer(raster);

--- a/raster/raster-layer-geopackage/src/main/java/com/esri/samples/raster_layer_geopackage/RasterLayerGeopackageSample.java
+++ b/raster/raster-layer-geopackage/src/main/java/com/esri/samples/raster_layer_geopackage/RasterLayerGeopackageSample.java
@@ -57,7 +57,7 @@ public class RasterLayerGeopackageSample extends Application {
       mapView.setMap(map);
 
       // create a geopackage from a local gpkg file
-      GeoPackage geoPackage = new GeoPackage(new File("./samples-data/auroraCO/AuroraCO.gpkg").getAbsolutePath());
+      GeoPackage geoPackage = new GeoPackage(new File(System.getProperty("data.dir"), "./samples-data/auroraCO/AuroraCO.gpkg").getAbsolutePath());
 
       // load the geopackage
       geoPackage.loadAsync();

--- a/raster/rgb-renderer/src/main/java/com/esri/samples/rgb_renderer/RgbRendererController.java
+++ b/raster/rgb-renderer/src/main/java/com/esri/samples/rgb_renderer/RgbRendererController.java
@@ -60,7 +60,7 @@ public class RgbRendererController {
   public void initialize() {
 
     // create raster
-    Raster raster = new Raster(new File("./samples-data/raster/Shasta.tif").getAbsolutePath());
+    Raster raster = new Raster(new File(System.getProperty("data.dir"), "./samples-data/raster/Shasta.tif").getAbsolutePath());
 
     // create a raster layer
     rasterLayer = new RasterLayer(raster);

--- a/raster/stretch-renderer/src/main/java/com/esri/samples/stretch_renderer/StretchRendererController.java
+++ b/raster/stretch-renderer/src/main/java/com/esri/samples/stretch_renderer/StretchRendererController.java
@@ -55,7 +55,7 @@ public class StretchRendererController {
   public void initialize() {
 
     // create raster
-    Raster raster = new Raster(new File("./samples-data/raster/ShastaBW.tif").getAbsolutePath());
+    Raster raster = new Raster(new File(System.getProperty("data.dir"), "./samples-data/raster/ShastaBW.tif").getAbsolutePath());
 
     // create a raster layer
     rasterLayer = new RasterLayer(raster);

--- a/scene/animate-3d-graphic/src/main/java/com/esri/samples/animate_3d_graphic/Animate3dGraphicController.java
+++ b/scene/animate-3d-graphic/src/main/java/com/esri/samples/animate_3d_graphic/Animate3dGraphicController.java
@@ -141,7 +141,7 @@ public class Animate3dGraphicController {
       mapOverlay.getGraphics().add(plane2D);
 
       // create a graphic with a ModelSceneSymbol of a plane to add to the scene
-      String modelURI = new File("./samples-data/bristol/Collada/Bristol.dae").getAbsolutePath();
+      String modelURI = new File(System.getProperty("data.dir"), "./samples-data/bristol/Collada/Bristol.dae").getAbsolutePath();
       ModelSceneSymbol plane3DSymbol = new ModelSceneSymbol(modelURI, 1.0);
       plane3DSymbol.loadAsync();
       plane3D = new Graphic(new Point(0, 0, 0, WGS84), plane3DSymbol);

--- a/scene/choose-camera-controller/src/main/java/com/esri/samples/choose_camera_controller/ChooseCameraControllerSample.java
+++ b/scene/choose-camera-controller/src/main/java/com/esri/samples/choose_camera_controller/ChooseCameraControllerSample.java
@@ -88,7 +88,7 @@ public class ChooseCameraControllerSample extends Application {
       sceneView.getGraphicsOverlays().add(sceneGraphicsOverlay);
 
       // create a graphic with a ModelSceneSymbol of a plane to add to the scene
-      String modelURI = new File("./samples-data/bristol/Collada/Bristol.dae").getAbsolutePath();
+      String modelURI = new File(System.getProperty("data.dir"), "./samples-data/bristol/Collada/Bristol.dae").getAbsolutePath();
       ModelSceneSymbol plane3DSymbol = new ModelSceneSymbol(modelURI, 1.0);
       plane3DSymbol.loadAsync();
       plane3DSymbol.setHeading(45);

--- a/scene/create-terrain-surface-from-local-raster/src/main/java/com/esri/samples/create_terrain_surface_from_local_raster/CreateTerrainSurfaceFromLocalRasterSample.java
+++ b/scene/create-terrain-surface-from-local-raster/src/main/java/com/esri/samples/create_terrain_surface_from_local_raster/CreateTerrainSurfaceFromLocalRasterSample.java
@@ -63,7 +63,7 @@ public class CreateTerrainSurfaceFromLocalRasterSample extends Application {
 
       // list paths to local raster(s)
       List<String> localDataFilePaths = Collections.singletonList(
-          new File("./samples-data/monterey_elevation/MontereyElevation.dt2").getAbsolutePath()
+          new File(System.getProperty("data.dir"), "./samples-data/monterey_elevation/MontereyElevation.dt2").getAbsolutePath()
       );
 
       // create an elevation source from the raster collection

--- a/scene/create-terrain-surface-from-local-tile-package/src/main/java/com/esri/samples/create_terrain_surface_from_local_tile_package/CreateTerrainSurfaceFromLocalTilePackageSample.java
+++ b/scene/create-terrain-surface-from-local-tile-package/src/main/java/com/esri/samples/create_terrain_surface_from_local_tile_package/CreateTerrainSurfaceFromLocalTilePackageSample.java
@@ -60,7 +60,7 @@ public class CreateTerrainSurfaceFromLocalTilePackageSample extends Application 
 
       // create an elevation source from the local LERC encoded tile package
       ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource(
-          new File("./samples-data/monterey_elevation/MontereyElevation.tpk"
+          new File(System.getProperty("data.dir"), "./samples-data/monterey_elevation/MontereyElevation.tpk"
       ).getAbsolutePath());
 
       // create a surface, adding the elevation source

--- a/scene/distance-composite-symbol/src/main/java/com/esri/samples/distance_composite_symbol/DistanceCompositeSymbolSample.java
+++ b/scene/distance-composite-symbol/src/main/java/com/esri/samples/distance_composite_symbol/DistanceCompositeSymbolSample.java
@@ -88,7 +88,7 @@ public class DistanceCompositeSymbolSample extends Application {
       SimpleMarkerSceneSymbol coneSymbol = SimpleMarkerSceneSymbol.createCone(red, 3, 10);
       coneSymbol.setPitch(-90);
       coneSymbol.setAnchorPosition(AnchorPosition.CENTER);
-      String modelURI = new File("./samples-data/bristol/Collada/Bristol.dae").getAbsolutePath();
+      String modelURI = new File(System.getProperty("data.dir"), "./samples-data/bristol/Collada/Bristol.dae").getAbsolutePath();
       ModelSceneSymbol modelSymbol = new ModelSceneSymbol(modelURI, 1.0);
       modelSymbol.loadAsync();
 

--- a/scene/open-mobile-scene-package/src/main/java/com/esri/samples/open_mobile_scene_package/OpenMobileScenePackageSample.java
+++ b/scene/open-mobile-scene-package/src/main/java/com/esri/samples/open_mobile_scene_package/OpenMobileScenePackageSample.java
@@ -54,7 +54,7 @@ public class OpenMobileScenePackageSample extends Application {
     sceneView = new SceneView();
 
     // load a mobile scene package
-    final String mspkPath = new File("./samples-data/mspk/philadelphia.mspk").getAbsolutePath();
+    final String mspkPath = new File(System.getProperty("data.dir"), "./samples-data/mspk/philadelphia.mspk").getAbsolutePath();
 
     // check if the mobile scene package can be read directly using a static method
     ListenableFuture<Boolean> isDirectReadSupported = MobileScenePackage.isDirectReadSupportedAsync(mspkPath);

--- a/scene/orbit-the-camera-around-an-object/src/main/java/com/esri/samples/orbit_the_camera_around_an_object/OrbitTheCameraAroundAnObjectController.java
+++ b/scene/orbit-the-camera-around-an-object/src/main/java/com/esri/samples/orbit_the_camera_around_an_object/OrbitTheCameraAroundAnObjectController.java
@@ -81,7 +81,7 @@ public class OrbitTheCameraAroundAnObjectController {
       sceneGraphicsOverlay.setRenderer(renderer);
 
       // create a graphic of a plane model
-      String modelURI = new File("./samples-data/bristol/Collada/Bristol.dae").getAbsolutePath();
+      String modelURI = new File(System.getProperty("data.dir"), "./samples-data/bristol/Collada/Bristol.dae").getAbsolutePath();
       ModelSceneSymbol plane3DSymbol = new ModelSceneSymbol(modelURI, 1.0);
       plane3DSymbol.loadAsync();
       // position the plane over a runway

--- a/scene/view-point-cloud-data-offline/src/main/java/com/esri/samples/view_point_cloud_data_offline/ViewPointCloudDataOfflineSample.java
+++ b/scene/view-point-cloud-data-offline/src/main/java/com/esri/samples/view_point_cloud_data_offline/ViewPointCloudDataOfflineSample.java
@@ -68,7 +68,7 @@ public class ViewPointCloudDataOfflineSample extends Application {
       scene.setBaseSurface(surface);
 
       // add a point cloud layer from a scene layer package of Balboa Park in San Diego
-      File pointCloudSLPK = new File("./samples-data/slpks/sandiego-north-balboa-pointcloud.slpk");
+      File pointCloudSLPK = new File(System.getProperty("data.dir"), "./samples-data/slpks/sandiego-north-balboa-pointcloud.slpk");
       PointCloudLayer pointCloudLayer = new PointCloudLayer(pointCloudSLPK.getAbsolutePath());
       scene.getOperationalLayers().add(pointCloudLayer);
 

--- a/search/offline-geocode/src/main/java/com/esri/samples/offline_geocode/OfflineGeocodeSample.java
+++ b/search/offline-geocode/src/main/java/com/esri/samples/offline_geocode/OfflineGeocodeSample.java
@@ -125,7 +125,7 @@ public class OfflineGeocodeSample extends Application {
 
       // create a basemap from a local tile package
       File tpkFile = new File(System.getProperty("data.dir"), "./samples-data/sanfrancisco/SanFrancisco.tpk");
-      TileCache tileCache = new TileCache(tpkFile.getCanonicalPath());
+      TileCache tileCache = new TileCache(tpkFile.getAbsolutePath());
       tiledLayer = new ArcGISTiledLayer(tileCache);
       Basemap basemap = new Basemap(tiledLayer);
 

--- a/search/offline-geocode/src/main/java/com/esri/samples/offline_geocode/OfflineGeocodeSample.java
+++ b/search/offline-geocode/src/main/java/com/esri/samples/offline_geocode/OfflineGeocodeSample.java
@@ -124,8 +124,8 @@ public class OfflineGeocodeSample extends Application {
       });
 
       // create a basemap from a local tile package
-      final String tileCachePath = new File("samples-data/sanfrancisco/SanFrancisco.tpk").getAbsolutePath();
-      TileCache tileCache = new TileCache(tileCachePath);
+      File tpkFile = new File(System.getProperty("data.dir"), "./samples-data/sanfrancisco/SanFrancisco.tpk");
+      TileCache tileCache = new TileCache(tpkFile.getCanonicalPath());
       tiledLayer = new ArcGISTiledLayer(tileCache);
       Basemap basemap = new Basemap(tiledLayer);
 
@@ -162,7 +162,8 @@ public class OfflineGeocodeSample extends Application {
       callout.setLeaderPosition(LeaderPosition.BOTTOM);
 
       // create a locator task
-      final String locatorPath = new File("samples-data/sanfrancisco/SanFranciscoLocator.loc").getAbsolutePath();
+      final String locatorPath =
+              new File(System.getProperty("data.dir"), "./samples-data/sanfrancisco/SanFranciscoLocator.loc").getAbsolutePath();
       locatorTask = new LocatorTask(locatorPath);
 
       // set geocode task parameters

--- a/symbology/graphics-overlay-dictionary-renderer-3D/src/main/java/com/esri/samples/graphics_overlay_dictionary_renderer_3D/GraphicsOverlayDictionaryRenderer3DSample.java
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/src/main/java/com/esri/samples/graphics_overlay_dictionary_renderer_3D/GraphicsOverlayDictionaryRenderer3DSample.java
@@ -112,7 +112,7 @@ public class GraphicsOverlayDictionaryRenderer3DSample extends Application {
    */
   private List<Map<String, Object>> parseMessages() throws Exception {
 
-    File mil2525dFile = new File("./samples-data/xml/Mil2525DMessages.xml");
+    File mil2525dFile = new File(System.getProperty("data.dir"), "./samples-data/xml/Mil2525DMessages.xml");
     DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
     DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
     Document document = documentBuilder.parse(mil2525dFile);

--- a/symbology/symbolize-shapefile/src/main/java/com/esri/samples/symbolize_shapefile/SymbolizeShapefileSample.java
+++ b/symbology/symbolize-shapefile/src/main/java/com/esri/samples/symbolize_shapefile/SymbolizeShapefileSample.java
@@ -64,7 +64,7 @@ public class SymbolizeShapefileSample extends Application {
       mapView.setMap(map);
 
       // create a shapefile feature table from the local data
-      File shapefile = new File("./samples-data/auroraCO/Subdivisions.shp");
+      File shapefile = new File(System.getProperty("data.dir"), "./samples-data/auroraCO/Subdivisions.shp");
       ShapefileFeatureTable shapefileFeatureTable = new ShapefileFeatureTable(shapefile.getAbsolutePath());
 
       // use the shapefile feature table to create a feature layer

--- a/tiled_layers/tile-cache/src/main/java/com/esri/samples/tile_cache/TileCacheSample.java
+++ b/tiled_layers/tile-cache/src/main/java/com/esri/samples/tile_cache/TileCacheSample.java
@@ -27,6 +27,8 @@ import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.Basemap;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
+import java.io.File;
+
 public class TileCacheSample extends Application {
 
   private MapView mapView;
@@ -47,7 +49,8 @@ public class TileCacheSample extends Application {
       stage.show();
 
       // create a tile cache from a local tile package
-      TileCache tileCache = new TileCache("samples-data/sanfrancisco/SanFrancisco.tpk");
+      File tpkFile = new File(System.getProperty("data.dir"), "./samples-data/sanfrancisco/SanFrancisco.tpk");
+      TileCache tileCache = new TileCache(tpkFile.getCanonicalPath());
 
       // create a tiled layer from the tile cache
       ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(tileCache);

--- a/tiled_layers/tile-cache/src/main/java/com/esri/samples/tile_cache/TileCacheSample.java
+++ b/tiled_layers/tile-cache/src/main/java/com/esri/samples/tile_cache/TileCacheSample.java
@@ -50,7 +50,7 @@ public class TileCacheSample extends Application {
 
       // create a tile cache from a local tile package
       File tpkFile = new File(System.getProperty("data.dir"), "./samples-data/sanfrancisco/SanFrancisco.tpk");
-      TileCache tileCache = new TileCache(tpkFile.getCanonicalPath());
+      TileCache tileCache = new TileCache(tpkFile.getAbsolutePath());
 
       // create a tiled layer from the tile cache
       ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(tileCache);


### PR DESCRIPTION
This PR adds the parent directory argument to every File constructor. This allows one to use the `data.dir` system property to specify the location of the samples-data folder. This is useful for when you want to run a jar version of the sample from a directory which does not contain the samples-data folder.