### PR TITLE
Jon/remove unpack workflow2

### DIFF
--- a/scene/open-mobile-scene-package/README.md
+++ b/scene/open-mobile-scene-package/README.md
@@ -8,22 +8,20 @@ Open and display a scene from an offline Mobile Scene Package (.mspk).
 
 A .mspk file is an archive containing the data (specifically, basemaps and features) used to display an offline 3. scene.
 
+## How to use the sample
+
+The sample loads a mobile scene package. Pan and zoom to explore the scene.
+
 ## How it works
 
-1. Use the static method `MobileScenePackage.isDirectReadSupportedAsync(mspkData)` to check whether the package can be read in the archived form (.mspk) or whether it needs to be unpacked.
-2. If direct read is supported, use `isDirectReadSupported.get()` and instantiate a `MobileScenePackage` with the path to the .mspk file.
-3. If the mobile scene package requires unpacking, use `MobileScenePackage.unpackAsync(mspkPath, pathToUnpackTo)` and instantiate a `MobileScenePackage` with the path to the unpacked .mspk file.
-4. Call `mobileScenePackage.loadAsync` to load the mobile scene package. When finished, get the `ArcGISScene` objects inside with `mobileScenePackage.getScenes()`.
-5. Set the first scene in the object collection on the scene view with `sceneView.setArcGISScene(scene)`.
+1. Create a `MobileScenePackage` with the path to a .mspk file.
+2. Call `mobileScenePackage.loadAsync` to load the mobile scene package. When finished, get the `ArcGISScene` objects inside with `mobileScenePackage.getScenes()`.
+3. Set the first scene to the scene view.
 
 ## Relevant API
 
 * MobileScenePackage
 
-## Additional information
-
-Before loading the `MobileScenePackage`, it is important to first check if direct read is supported. The mobile scene package could contain certain data types that would require the data to be unpacked. For example, scenes containing raster data will need to be unpacked.
-
 ## Tags
 
-Offline, Scene, MobileScenePackage
+offline, scene

--- a/scene/open-mobile-scene-package/src/main/java/com/esri/samples/open_mobile_scene_package/OpenMobileScenePackageSample.java
+++ b/scene/open-mobile-scene-package/src/main/java/com/esri/samples/open_mobile_scene_package/OpenMobileScenePackageSample.java
@@ -50,7 +50,7 @@ public class OpenMobileScenePackageSample extends Application {
     sceneView = new SceneView();
 
     // create a mobile scene package from a file
-    final String mspkPath = new File("./samples-data/mspk/philadelphia.mspk").getAbsolutePath();
+    final String mspkPath = new File(System.getProperty("data.dir"),"./samples-data/mspk/philadelphia.mspk").getAbsolutePath();
     MobileScenePackage mobileScenePackage = new MobileScenePackage(mspkPath);
 
     // load the mobile scene package

--- a/scene/open-mobile-scene-package/src/main/java/com/esri/samples/open_mobile_scene_package/OpenMobileScenePackageSample.java
+++ b/scene/open-mobile-scene-package/src/main/java/com/esri/samples/open_mobile_scene_package/OpenMobileScenePackageSample.java
@@ -16,28 +16,24 @@
 
 package com.esri.samples.open_mobile_scene_package;
 
-import com.esri.arcgisruntime.concurrent.ListenableFuture;
-import com.esri.arcgisruntime.loadable.LoadStatus;
-import com.esri.arcgisruntime.mapping.MobileScenePackage;
-import com.esri.arcgisruntime.mapping.view.SceneView;
+import java.io.File;
+
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.concurrent.ExecutionException;
+import com.esri.arcgisruntime.loadable.LoadStatus;
+import com.esri.arcgisruntime.mapping.MobileScenePackage;
+import com.esri.arcgisruntime.mapping.view.SceneView;
 
 public class OpenMobileScenePackageSample extends Application {
 
   private SceneView sceneView;
 
   @Override
-  public void start(Stage stage) throws Exception {
+  public void start(Stage stage) {
 
     // create stack pane and application scene
     StackPane stackPane = new StackPane();
@@ -53,56 +49,15 @@ public class OpenMobileScenePackageSample extends Application {
     // create a new scene view
     sceneView = new SceneView();
 
-    // load a mobile scene package
-    final String mspkPath = new File(System.getProperty("data.dir"), "./samples-data/mspk/philadelphia.mspk").getAbsolutePath();
+    // create a mobile scene package from a file
+    final String mspkPath = new File("./samples-data/mspk/philadelphia.mspk").getAbsolutePath();
+    MobileScenePackage mobileScenePackage = new MobileScenePackage(mspkPath);
 
-    // check if the mobile scene package can be read directly using a static method
-    ListenableFuture<Boolean> isDirectReadSupported = MobileScenePackage.isDirectReadSupportedAsync(mspkPath);
-    isDirectReadSupported.addDoneListener(() -> {
-
-      try {
-        // if the mobile scene package can be read directly, then load the mspk from the direct read path directory
-        if (isDirectReadSupported.get()) {
-          //instantiate mobile scene package for direct read file
-          MobileScenePackage directReadMSPK = new MobileScenePackage(mspkPath);
-          loadMobileScenePackage(directReadMSPK);
-
-        } else {
-          // create a temporary directory to store unpacked file if appropriate
-          Path tempDirectory = Files.createTempDirectory("offline_map");
-          final String tempUnpackedPath = tempDirectory.toString();
-
-          // if the mobile scene package has to be unpacked, then unpack the mobile scene package and store it in a local path
-          MobileScenePackage.unpackAsync(mspkPath, tempUnpackedPath).addDoneListener(() -> {
-            //instantiate mobile scene package for unpacked file
-            MobileScenePackage unpackedMSPK = new MobileScenePackage(tempUnpackedPath);
-            // load the mobile scene package from the unpacked path
-            loadMobileScenePackage(unpackedMSPK);
-          });
-        }
-
-      } catch (InterruptedException | ExecutionException e) {
-        Alert alert = new Alert(Alert.AlertType.ERROR, "Mobile Scene Package direct read could not be determined");
-        alert.show();
-
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
-
-    });
-
-    // add the sceneview to the stackpane
-    stackPane.getChildren().add(sceneView);
-  }
-
-  /**
-   * Loads the mobile scene package asynchronously, and once it has loaded, sets the first scene within the package to the scene view.
-   */
-  private void loadMobileScenePackage(MobileScenePackage mobileScenePackage) {
-
+    // load the mobile scene package
     mobileScenePackage.loadAsync();
-    mobileScenePackage.addDoneLoadingListener(() -> {
 
+    // wait for the mobile scene package to load
+    mobileScenePackage.addDoneLoadingListener(() -> {
       if (mobileScenePackage.getLoadStatus() == LoadStatus.LOADED && mobileScenePackage.getScenes().size() > 0) {
         // set the first scene from the package to the scene view
         sceneView.setArcGISScene(mobileScenePackage.getScenes().get(0));
@@ -111,6 +66,9 @@ public class OpenMobileScenePackageSample extends Application {
         alert.show();
       }
     });
+
+    // add the sceneview to the stackpane
+    stackPane.getChildren().add(sceneView);
   }
 
   /**
@@ -134,5 +92,3 @@ public class OpenMobileScenePackageSample extends Application {
     Application.launch(args);
   }
 }
-
-


### PR DESCRIPTION
Hi both, 
following the rebase-mess I've created with the previous PR: 
https://github.com/Esri/arcgis-runtime-samples-java/pull/417#issuecomment-553911024

New PR, same content (+ `System.getProperty("data.dir")` when loading the scene layer).
Looking to merge this change into `dev` (instead of `master`) so that we can verify using the Sample Viewer.

Apologies for the hassle!