### PR TITLE
remove reference to toggling coordinates

### DIFF
--- a/ogc/browse-wfs-layers/README.md
+++ b/ogc/browse-wfs-layers/README.md
@@ -12,8 +12,6 @@ Services often have multiple layers available for display. For example, a featur
 
 A list of layers in the WFS service will be shown. Select a layer to display it.
 
-Some WFS services return coordinates in X,Y order, while others return coordinates in lat/long (Y,X) order. If you don't see features rendered or you see features in the wrong location, use the checkbox to swap the coordinate order and reload. Note: the WFS service in this sample does not require coordinate swapping.
-
 ## How it works
 
 1. Create a `WfsService` object with a URL to a WFS feature service.


### PR DESCRIPTION
Hi both,

small change needed to this readme that @hardikc07 made me aware of.
The original design for this sample has a toggle box to swap the x-y-coordinates of the data. I vaguely remember the consensus being that this distracted from the purpose of the sample, and that functionality must have been removed (at least in the Java implementation). As a result, just need to remove the reference to this toggle box from the readme.

Let me know if you spot anything out of the order.

Thanks