### PR TITLE
correct category case for subtype sample

### DIFF
--- a/feature_layers/display-subtype-feature-layer/README.metadata.json
+++ b/feature_layers/display-subtype-feature-layer/README.metadata.json
@@ -1,5 +1,5 @@
 {
-  "category": "Feature Layers",
+  "category": "Feature layers",
   "description": "Display a composite layer of all the subtype values in a feature class.",
   "ignore": false,
   "images": [


### PR DESCRIPTION
The dev website currently shows two Feature Layer tabs as a result of this oversight, each with different cases: the correct one is "Feature layers".  This PR corrects the title case for the category entry in the metadata. 