### PR TITLE
Revert "remove alt text from screenshot (#469)"

### DIFF
--- a/analysis/analyze-hotspots/README.md
+++ b/analysis/analyze-hotspots/README.md
@@ -2,7 +2,7 @@
 
 Use a geoprocessing service and a set of features to identify statistically significant hot spots and cold spots.
 
-![](AnalyzeHotspots.png)
+![Image of analyze hotspots](AnalyzeHotspots.png)
 
 ## Use case
 

--- a/analysis/distance-measurement-analysis/README.md
+++ b/analysis/distance-measurement-analysis/README.md
@@ -2,7 +2,7 @@
 
 Measure distances between two points in 3D.
 
-![](DistanceMeasurementAnalysis.png)
+![Image of distance measurement analysis](DistanceMeasurementAnalysis.png)
 
 ## Use case
 

--- a/analysis/line-of-sight-geoelement/README.md
+++ b/analysis/line-of-sight-geoelement/README.md
@@ -2,7 +2,7 @@
 
 Show a line of sight between two moving objects.
 
-![](LineOfSightGeoElement.gif)
+![Image of line of sight geoelement](LineOfSightGeoElement.gif)
 
 ## Use case
 

--- a/analysis/line-of-sight-location/README.md
+++ b/analysis/line-of-sight-location/README.md
@@ -2,7 +2,7 @@
 
 Perform a line of sight analysis between two points in real time.
 
-![](LineOfSightLocation.gif)
+![Image of line of sight location](LineOfSightLocation.gif)
 
 ## Use case
 

--- a/analysis/viewshed-camera/README.md
+++ b/analysis/viewshed-camera/README.md
@@ -2,7 +2,7 @@
 
 Analyze the viewshed for a camera. A viewshed shows the visible and obstructed areas from an observer's vantage point. 
 
-![](ViewshedCamera.png)
+![Image of viewshed for camera](ViewshedCamera.png)
 
 ## Use case
 

--- a/analysis/viewshed-geoelement/README.md
+++ b/analysis/viewshed-geoelement/README.md
@@ -2,7 +2,7 @@
 
 Analyze the viewshed for an object (GeoElement) in a scene.
 
-![](ViewshedGeoElement.png)
+![Image of viewshed for geoelement](ViewshedGeoElement.png)
 
 ## Use case
 

--- a/analysis/viewshed-geoprocessing/README.md
+++ b/analysis/viewshed-geoprocessing/README.md
@@ -2,7 +2,7 @@
 
 Calculate a viewshed using a geoprocessing service, in this case showing what parts of a landscape are visible from points on mountainous terrain.
 
-![](ViewshedGeoprocessing.png)
+![Image of viewshed geoprocessing](ViewshedGeoprocessing.png)
 
 ## Use case
 

--- a/analysis/viewshed-location/README.md
+++ b/analysis/viewshed-location/README.md
@@ -2,7 +2,7 @@
 
 Perform a viewshed analysis from a defined vantage point. 
 
-![](ViewshedLocation.png)
+![Image of viewshed location](ViewshedLocation.png)
 
 ## Use case
 

--- a/display_information/add-graphics-with-renderer/README.md
+++ b/display_information/add-graphics-with-renderer/README.md
@@ -2,7 +2,7 @@
 
 A renderer allows you to change the style of all graphics in a graphics overlay by referencing a single symbol style. A renderer will only effect graphics that do not specify their own symbol style.
 
-![](AddGraphicsWithRenderer.png)
+![Image of adding graphics with renderer](AddGraphicsWithRenderer.png)
 
 ## Use case
 

--- a/display_information/add-graphics-with-symbols/README.md
+++ b/display_information/add-graphics-with-symbols/README.md
@@ -2,7 +2,7 @@
 
 Use a symbol style to display a graphic on a graphics overlay.
 
-![](AddGraphicsWithSymbols.png)
+![Image of adding graphics with symbols](AddGraphicsWithSymbols.png)
 
 ## Use case
 

--- a/display_information/control-annotation-sublayer-visibility/README.md
+++ b/display_information/control-annotation-sublayer-visibility/README.md
@@ -2,7 +2,7 @@
 
 Use annotation sublayers to gain finer control of annotation layer subtypes.
 
-![](ControlAnnotationSublayerVisibility.png)
+![Image of control annotation sublayer visibility](ControlAnnotationSublayerVisibility.png)
 
 ## Use case
 

--- a/display_information/dictionary-renderer-graphics-overlay/README.md
+++ b/display_information/dictionary-renderer-graphics-overlay/README.md
@@ -2,7 +2,7 @@
 
 Create graphics using a local mil2525d style file and an XML file with key/value pairs for each graphic.
 
-![](DictionaryRendererGraphicsOverlay.png)
+![Image of dictionary renderer graphics overlay](DictionaryRendererGraphicsOverlay.png)
 
 ## Use case
 

--- a/display_information/display-annotation/README.md
+++ b/display_information/display-annotation/README.md
@@ -2,7 +2,7 @@
 
 Display annotation from a feature service URL.
 
-![](DisplayAnnotation.png)
+![Image showing the Display Annotation sample](DisplayAnnotation.png)
 
 ## Use case
 

--- a/display_information/display-grid/README.md
+++ b/display_information/display-grid/README.md
@@ -2,7 +2,7 @@
 
 Display coordinate system grids including Latitude/Longitude, MGRS, UTM and USNG on a map view. Also, toggle label visibility and change the color of grid lines and grid labels.
 
-![](DisplayGrid.png)
+![Image of display grid](DisplayGrid.png)
 
 ## Use case
 

--- a/display_information/format-coordinates/README.md
+++ b/display_information/format-coordinates/README.md
@@ -2,7 +2,7 @@
 
 Format coordinates in a variety of common notations.
 
-![](FormatCoordinates.png)
+![Image of format coordinates](FormatCoordinates.png)
 
 ## Use case
 

--- a/display_information/identify-graphics/README.md
+++ b/display_information/identify-graphics/README.md
@@ -2,7 +2,7 @@
 
 Identify a graphic to get further information about the object.
 
-![](IdentifyGraphics.png)
+![Image of identify graphics](IdentifyGraphics.png)
 
 ## Use case
 

--- a/display_information/show-callout/README.md
+++ b/display_information/show-callout/README.md
@@ -2,7 +2,7 @@
 
 Show a callout with the latitude and longitude of user-clicked points.
 
-![](ShowCallout.png)
+![Image of show callout](ShowCallout.png)
 
 ## Use case
 

--- a/display_information/show-labels-on-layer/README.md
+++ b/display_information/show-labels-on-layer/README.md
@@ -2,7 +2,7 @@
 
 Display custom labels on a feature layer.
 
-![](ShowLabelsOnLayer.png)
+![Image of show labels on layers](ShowLabelsOnLayer.png)
 
 ## Use case
 

--- a/display_information/sketch-on-map/README.md
+++ b/display_information/sketch-on-map/README.md
@@ -2,7 +2,7 @@
 
 Use the Sketch Editor to edit or sketch a new point, line, or polygon geometry on to a map.
 
-![](SketchOnMap.png)
+![Image of sketch on map](SketchOnMap.png)
 
 ## Use case
 

--- a/display_information/update-graphics/README.md
+++ b/display_information/update-graphics/README.md
@@ -2,7 +2,7 @@
 
 Change a graphic's symbol, attributes, and geometry.
 
-![](UpdateGraphics.gif)
+![Image of Update Graphics](UpdateGraphics.gif)
 
 ## Use case
 

--- a/editing/add-features/README.md
+++ b/editing/add-features/README.md
@@ -2,7 +2,7 @@
 
 Add features to a feature layer.
 
-![](AddFeatures.gif)
+![Image of adding features](AddFeatures.gif)
 
 ## Use case
 

--- a/editing/delete-features/README.md
+++ b/editing/delete-features/README.md
@@ -2,7 +2,7 @@
 
 Delete features from an online feature service.
 
-![](DeleteFeatures.gif)
+![Image of delete features feature service](DeleteFeatures.gif)
 
 ## Use case
 

--- a/editing/edit-and-sync-features/README.md
+++ b/editing/edit-and-sync-features/README.md
@@ -2,7 +2,7 @@
 
 Synchronize offline edits with a feature service.
 
-![](EditAndSyncFeatures.png)
+![Image of edit and sync features](EditAndSyncFeatures.png)
 
 ## Use case
 

--- a/editing/edit-feature-attachments/README.md
+++ b/editing/edit-feature-attachments/README.md
@@ -2,7 +2,7 @@
 
 Add, delete, and download attachments for features from a service.
 
-![](EditFeatureAttachments.gif)
+![Image of edit feature attachments](EditFeatureAttachments.gif)
 
 ## Use case
 

--- a/editing/update-attributes/README.md
+++ b/editing/update-attributes/README.md
@@ -2,7 +2,7 @@
 
 Update feature attributes in an online feature service.
 
-![](UpdateAttributes.gif)
+![Image of update attributes feature service](UpdateAttributes.gif)
 
 ## Use case
 

--- a/editing/update-geometries/README.md
+++ b/editing/update-geometries/README.md
@@ -2,7 +2,7 @@
 
 Update a feature's location in an online feature service.
 
-![](UpdateGeometries.gif)
+![Image of update geometries feature service](UpdateGeometries.gif)
 
 ## Use case
 

--- a/feature_layers/feature-layer-dictionary-renderer/README.md
+++ b/feature_layers/feature-layer-dictionary-renderer/README.md
@@ -2,7 +2,7 @@
 
 Convert features into graphics to show them with mil2525d symbols.
 
-![](FeatureLayerDictionaryRenderer.png)
+![Image of dictionary renderer with feature layer](FeatureLayerDictionaryRenderer.png)
 
 ## Use case
 

--- a/feature_layers/feature-layer-extrusion/README.md
+++ b/feature_layers/feature-layer-extrusion/README.md
@@ -2,7 +2,7 @@
 
 Extrude features based on their attributes.
 
-![](FeatureLayerExtrusion.gif)
+![Image of feature layer extrusion](FeatureLayerExtrusion.gif)
 
 ## Use case
 

--- a/feature_layers/feature-layer-feature-service/README.md
+++ b/feature_layers/feature-layer-feature-service/README.md
@@ -2,7 +2,7 @@
 
 Show features from an online feature service.
 
-![](screenshot.png)
+![Image of feature layer feature service](screenshot.png)
 
 ## Use case
 

--- a/feature_layers/feature-layer-geodatabase/README.md
+++ b/feature_layers/feature-layer-geodatabase/README.md
@@ -2,7 +2,7 @@
 
 Display features from a local geodatabase.
 
-![](FeatureLayerGeodatabase.png)
+![Image of feature layer geodatabase](FeatureLayerGeodatabase.png)
 
 ## Use case
 

--- a/feature_layers/feature-layer-geopackage/README.md
+++ b/feature_layers/feature-layer-geopackage/README.md
@@ -2,7 +2,7 @@
 
 Display features from a local GeoPackage.
 
-![](FeatureLayerGeoPackage.png)
+![Image of feature layer geopackage](FeatureLayerGeoPackage.png)
 
 ## Use case
 

--- a/geometry/buffer-list/README.md
+++ b/geometry/buffer-list/README.md
@@ -2,7 +2,7 @@
 
 Generate multiple individual buffers or a single unioned buffer around multiple points.
 
-![](BufferList.png)
+![Image of Buffer list](BufferList.png)
 
 ## Use case
 

--- a/geometry/buffer/README.md
+++ b/geometry/buffer/README.md
@@ -2,7 +2,7 @@
 
 Create a buffer around a map point and display the results as a `Graphic`
 
-![](Buffer.png)
+![Image of Buffer](Buffer.png)
 
 ## Use case
 

--- a/geometry/clip-geometry/README.md
+++ b/geometry/clip-geometry/README.md
@@ -2,7 +2,7 @@
 
 Clip a geometry with another geometry.
 
-![](ClipGeometry.png)
+![Image of clip geometry](ClipGeometry.png)
 
 ## Use case
 

--- a/geometry/convex-hull-list/README.md
+++ b/geometry/convex-hull-list/README.md
@@ -2,7 +2,7 @@
 
 Generate convex hull polygon(s) from multiple input geometries.
 
-![](ConvexHullList.png)
+![Image of convex hull list](ConvexHullList.png)
 
 ## Use case
 

--- a/geometry/convex-hull/README.md
+++ b/geometry/convex-hull/README.md
@@ -2,7 +2,7 @@
 
 Create a convex hull for a given set of points. The convex hull is a polygon with shortest perimeter that encloses a set of points. As a visual analogy, consider a set of points as nails in a board. The convex hull of the points would be like a rubber band stretched around the outermost nails.
 
-![](ConvexHull.png)
+![Image of convex hull](ConvexHull.png)
 
 ## Use case
 

--- a/geometry/create-geometries/README.md
+++ b/geometry/create-geometries/README.md
@@ -2,7 +2,7 @@
 
 Create simple geometry types.
 
-![](CreateGeometries.png)
+![Image of create geometries](CreateGeometries.png)
 
 ## Use case
 

--- a/geometry/cut-geometry/README.md
+++ b/geometry/cut-geometry/README.md
@@ -2,7 +2,7 @@
 
 Cut a geometry along a polyline.
 
-![](CutGeometry.png)
+![Image of cut geometry](CutGeometry.png)
 
 ## Use case
 

--- a/geometry/densify-and-generalize/README.md
+++ b/geometry/densify-and-generalize/README.md
@@ -2,7 +2,7 @@
 
 A multipart geometry can be densified by adding interpolated points at regular intervals. Generalizing multipart geometry simplifies it while preserving its general shape. Densifying a multipart geometry adds more vertices at regular intervals.
 
-![](DensifyAndGeneralize.gif)
+![Image of densify and generalize](DensifyAndGeneralize.gif)
 
 ## Use case
 

--- a/geometry/geodesic-operations/README.md
+++ b/geometry/geodesic-operations/README.md
@@ -2,7 +2,7 @@
 
 Calculate a geodesic path between two points and measure its distance.
 
-![](GeodesicOperations.png)
+![Image of geodesic operations](GeodesicOperations.png)
 
 ## Use case
 

--- a/geometry/geodesic-sector-and-ellipse/README.md
+++ b/geometry/geodesic-sector-and-ellipse/README.md
@@ -2,7 +2,7 @@
 
 Create and display geodesic sectors and ellipses.
 
-![](GeodesicSectorAndEllipse.png)
+![Image of geodesic sector and ellipse](GeodesicSectorAndEllipse.png)
 
 ## Use case
 

--- a/geometry/geometry-engine-simplify/README.md
+++ b/geometry/geometry-engine-simplify/README.md
@@ -2,7 +2,7 @@
 
 Simplify a polygon with a self-intersecting geometry.
 
-![](GeometryEngineSimplify.png)
+![Image of geometry engine simplify](GeometryEngineSimplify.png)
 
 ## Use case
 

--- a/geometry/list-transformations-by-suitability/README.md
+++ b/geometry/list-transformations-by-suitability/README.md
@@ -2,7 +2,7 @@
 
 Get a list of suitable transformations for projecting a geometry between two spatial references with different horizontal datums.
 
-![](ListTransformationsBySuitability.png)
+![Image of list transformations by suitability](ListTransformationsBySuitability.png)
 
 ## Use case
 

--- a/geometry/nearest-vertex/README.md
+++ b/geometry/nearest-vertex/README.md
@@ -2,7 +2,7 @@
 
 Find the closest vertex and coordinate of a geometry to a point.
 
-![](NearestVertex.png)
+![Image of nearest vertex](NearestVertex.png)
 
 ## Use case
 

--- a/geometry/project/README.md
+++ b/geometry/project/README.md
@@ -2,7 +2,7 @@
 
 Project a point from one spatial reference to another.
 
-![](Project.png)
+![Image of project](Project.png)
 
 ## Use case
 

--- a/geometry/spatial-operations/README.md
+++ b/geometry/spatial-operations/README.md
@@ -2,7 +2,7 @@
 
 Find the union, difference, or intersection of two geometries.
 
-![](SpatialOperations.png)
+![Image of spatial operations](SpatialOperations.png)
 
 ## Use case
 

--- a/geometry/spatial-relationships/README.md
+++ b/geometry/spatial-relationships/README.md
@@ -2,7 +2,7 @@
 
 Determine spatial relationships between two geometries.
 
-![](SpatialRelationships.png)
+![Image of spatial relationships](SpatialRelationships.png)
 
 ## Use case
 

--- a/group_layers/group-layers/README.md
+++ b/group_layers/group-layers/README.md
@@ -2,7 +2,7 @@
 
 Group a collection of layers together and toggle their visibility as a group.
 
-![](GroupLayers.png)
+![Image of group layers](GroupLayers.png)
 
 ## Use case
 

--- a/hydrography/add-enc-exchange-set/README.md
+++ b/hydrography/add-enc-exchange-set/README.md
@@ -2,7 +2,7 @@
 
 Display nautical charts per the ENC specification.
 
-![](AddEncExchangeSet.png)
+![Image showing the add ENC exchange set app](AddEncExchangeSet.png)
 
 ## Use case
 

--- a/image_layers/change-sublayer-renderer/README.md
+++ b/image_layers/change-sublayer-renderer/README.md
@@ -2,7 +2,7 @@
 
 Apply a renderer to a sublayer.
 
-![](ChangeSublayerRenderer.png)
+![Image of change sublayer renderer](ChangeSublayerRenderer.png)
 
 ## Use case
 

--- a/image_layers/map-image-layer-sublayer-visibility/README.md
+++ b/image_layers/map-image-layer-sublayer-visibility/README.md
@@ -2,7 +2,7 @@
 
 Change the visibility of sublayers.
 
-![](MapImageLayerSublayerVisibility.png)
+![Image of map image layer sublayer visibility](MapImageLayerSublayerVisibility.png)
 
 ## Use case
 

--- a/image_layers/map-image-layer-tables/README.md
+++ b/image_layers/map-image-layer-tables/README.md
@@ -2,7 +2,7 @@
 
 Find features in a spatial table related to features in a non-spatial table.
 
-![](MapImageLayerTables.png)
+![Image of map image layer tables](MapImageLayerTables.png)
 
 ## Use case
 

--- a/image_layers/map-image-layer/README.md
+++ b/image_layers/map-image-layer/README.md
@@ -2,7 +2,7 @@
 
 Display a layer from an ArcGIS map image layer service.
 
-![](MapImageLayer.png)
+![Image of map image layer](MapImageLayer.png)
 
 ## Use case
 

--- a/image_layers/query-map-image-sublayer/README.md
+++ b/image_layers/query-map-image-sublayer/README.md
@@ -2,7 +2,7 @@
 
 Find features in a sublayer based on attributes and location.
 
-![](QueryMapImageSublayer.png)
+![Image of query map image sublayer](QueryMapImageSublayer.png)
 
 ## Use case
 

--- a/kml/create-and-save-kml-file/README.md
+++ b/kml/create-and-save-kml-file/README.md
@@ -2,7 +2,7 @@
 
 Construct a KML document and save it as a KMZ file.
 
-![](CreateAndSaveKmlFile.png)
+![Image of create and save KML file](CreateAndSaveKmlFile.png)
 
 ## Use case
 

--- a/kml/display-kml-network-links/README.md
+++ b/kml/display-kml-network-links/README.md
@@ -2,7 +2,7 @@
 
 Display a file with a KML network link, including displaying any network link control messages at launch.
 
-![](DisplayKmlNetworkLinks.png)
+![Image of display KML network links](DisplayKmlNetworkLinks.png)
 
 ## Use case
 

--- a/kml/display-kml/README.md
+++ b/kml/display-kml/README.md
@@ -2,7 +2,7 @@
 
 Display KML from a URL, portal item, or local KML file.
 
-![](DisplayKml.png)
+![Image of display KML](DisplayKml.png)
 
 ## Use case
 

--- a/kml/edit-kml-ground-overlay/README.md
+++ b/kml/edit-kml-ground-overlay/README.md
@@ -2,7 +2,7 @@
 
 Edit the values of a KML ground overlay.
 
-![](EditKmlGroundOverlay.png)
+![Image of edit KML ground overlay](EditKmlGroundOverlay.png)
 
 ## Use case
 

--- a/kml/identify-kml-features/README.md
+++ b/kml/identify-kml-features/README.md
@@ -2,7 +2,7 @@
 
 Show a callout with formatted content for a KML feature.
 
-![](IdentifyKMLFeatures.png)
+![Image of identify KML features](IdentifyKMLFeatures.png)
 
 ## Use case
 

--- a/kml/list-kml-contents/README.md
+++ b/kml/list-kml-contents/README.md
@@ -2,7 +2,7 @@
 
 List the contents of a KML file.
 
-![](ListKMLContents.png)
+![Image of list KML contents](ListKMLContents.png)
 
 ## Use case
 

--- a/kml/play-a-kml-tour/README.md
+++ b/kml/play-a-kml-tour/README.md
@@ -2,7 +2,7 @@
 
 Play tours in KML files.
 
-![](PlayAKMLTour.png)
+![Image of play KML tour](PlayAKMLTour.png)
 
 ## Use case
 

--- a/local_server/local-server-feature-layer/README.md
+++ b/local_server/local-server-feature-layer/README.md
@@ -2,7 +2,7 @@
 
 Start a local feature service and display its features in a map.
 
-![](LocalServerFeatureLayer.png)
+![Image of local server feature layer](LocalServerFeatureLayer.png)
 
 ## Use case
 

--- a/local_server/local-server-geoprocessing/README.md
+++ b/local_server/local-server-geoprocessing/README.md
@@ -2,7 +2,7 @@
 
 Create contour lines from local raster data using a local geoprocessing package `.gpk` and the contour geoprocessing tool.
 
-![](LocalServerGeoprocessing.png)
+![Image of local server geoprocessing](LocalServerGeoprocessing.png)
 
 ## Use case
 

--- a/local_server/local-server-map-image-layer/README.md
+++ b/local_server/local-server-map-image-layer/README.md
@@ -2,7 +2,7 @@
 
 Start the Local Server and Local Map Service, create an ArcGIS Map Image Layer from the Local Map Service, and add it to a map.
 
-![](screenshot.png)
+![Image of local server map image layer](screenshot.png)
 
 ## Use case
 

--- a/local_server/local-server-services/README.md
+++ b/local_server/local-server-services/README.md
@@ -2,7 +2,7 @@
 
 Demonstrates how to start and stop the Local Server and start and stop a local map, feature, and geoprocessing service running on the Local Server.
 
-![](LocalServerServices.png)
+![Image of local server services](LocalServerServices.png)
 
 ## Use case
 

--- a/map/access-load-status/README.md
+++ b/map/access-load-status/README.md
@@ -2,7 +2,7 @@
 
 Determine the map's load status which can be: `NOT_LOADED`, `FAILED_TO_LOAD`, `LOADING`, `LOADED`.
 
-![](AccessLoadStatus.png)
+![Image of access load status](AccessLoadStatus.png)
 
 ## Use case
 

--- a/map/apply-scheduled-updates-to-preplanned-map-area/README.md
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/README.md
@@ -2,7 +2,7 @@
 
 Apply scheduled updates to a downloaded preplanned map area.
 
-![](ApplyScheduledUpdatesToPreplannedMapArea.png)
+![Image of apply scheduled updates to preplanned map area](ApplyScheduledUpdatesToPreplannedMapArea.png)
 
 ## Use case
 

--- a/map/change-basemap/README.md
+++ b/map/change-basemap/README.md
@@ -2,7 +2,7 @@
 
 Change a map's basemap. A basemap is beneath all layers on an `ArcGISMap` and is used to provide visual reference for the operational layers.
 
-![](ChangeBasemap.png)
+![Image of change basemap](ChangeBasemap.png)
 
 ## Use case
 

--- a/map/create-and-save-map/README.md
+++ b/map/create-and-save-map/README.md
@@ -2,7 +2,7 @@
 
 Create and save a map as an ArcGIS `PortalItem` (i.e. web map). 
 
-![](CreateAndSaveMap.png)
+![Image of create and save map](CreateAndSaveMap.png)
 
 ## Use case
 

--- a/map/display-map/README.md
+++ b/map/display-map/README.md
@@ -2,7 +2,7 @@
 
 Display a map with an imagery basemap.
 
-![](DisplayMap.png)
+![Image of display map](DisplayMap.png)
 
 ## Use case
 

--- a/map/download-preplanned-map/README.md
+++ b/map/download-preplanned-map/README.md
@@ -2,7 +2,7 @@
 
 Take a map offline using a preplanned map area.
 
-![Download Preplanned Map Sample](DownloadPreplannedMap.png)
+![Image of Download Preplanned Map](DownloadPreplannedMap.png)
 
 ## Use case
 

--- a/map/download-preplanned-map/README.md
+++ b/map/download-preplanned-map/README.md
@@ -2,7 +2,7 @@
 
 Take a map offline using a preplanned map area.
 
-![](DownloadPreplannedMap.png)
+![Download Preplanned Map Sample](DownloadPreplannedMap.png)
 
 ## Use case
 

--- a/map/honor-mobile-map-package-expiration-date/README.md
+++ b/map/honor-mobile-map-package-expiration-date/README.md
@@ -2,7 +2,7 @@
 
 Determine a mobile map package's expiration date.
 
-![](HonorMobileMapPackageExpirationDate.png)
+![Honor mobile map package expiration date sample](HonorMobileMapPackageExpirationDate.png)
 
 ## Use case
 

--- a/map/honor-mobile-map-package-expiration-date/README.md
+++ b/map/honor-mobile-map-package-expiration-date/README.md
@@ -2,7 +2,7 @@
 
 Determine a mobile map package's expiration date.
 
-![Honor mobile map package expiration date sample](HonorMobileMapPackageExpirationDate.png)
+![Image of honor mobile map package expiration date](HonorMobileMapPackageExpirationDate.png)
 
 ## Use case
 

--- a/symbology/custom-dictionary-style/README.md
+++ b/symbology/custom-dictionary-style/README.md
@@ -2,7 +2,7 @@
 
 Use a custom dictionary style (.stylx) to symbolize features using a variety of attribute values.
 
-![Custom dictionary style](CustomDictionaryStyle.png)
+![Image of custom dictionary style](CustomDictionaryStyle.png)
 
 ## Use case
 

--- a/symbology/custom-dictionary-style/README.md
+++ b/symbology/custom-dictionary-style/README.md
@@ -2,7 +2,7 @@
 
 Use a custom dictionary style (.stylx) to symbolize features using a variety of attribute values.
 
-![](CustomDictionaryStyle.png)
+![Custom dictionary style](CustomDictionaryStyle.png)
 
 ## Use case
 


### PR DESCRIPTION
This reverts commit ec7ec7b52d4d3671e1d2129481c5b3250cb7f84b.

Restoring the alt text for screenshots in some of the readmes that previously removed as it was causing issues with the sample viewer.