### PR TITLE
small readme updates

### DIFF
--- a/feature_layers/service-feature-table-manual-cache/README.md
+++ b/feature_layers/service-feature-table-manual-cache/README.md
@@ -26,6 +26,10 @@ Note: Maximum of Features returned is set to 1000.
 * ServiceFeatureTable.FeatureRequestMode
 * ServiceFeatureTable
 
+## About the data
+
+The samples uses an [incident feature layer](https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0) queried to show tree maintenance or damage. The sample opens with an initial visible extent centered over San Francisco.
+ 
 ## Additional information
 
 In **manual cache** mode, features are never automatically populated from the service. All features are loaded manually using calls to `PopulateFromServiceAsync`.

--- a/map/generate-offline-map/README.md
+++ b/map/generate-offline-map/README.md
@@ -10,7 +10,7 @@ Taking a web map offline allows users continued productivity when their network 
 
 ## How to use the sample
 
-When the app starts, you will be prompted to sign in using a free ArcGIS Online account. Once the map loads, zoom to the extent you want to take offline. The red border shows the extent that will be downloaded. Click the "Take Map Offline" button to start the offline map job. The progress bar will show the job's progress. When complete, the offline map will replace the online map in the map view.
+When the app starts, you will be prompted to sign in using an ArcGIS Online account. Once the map loads, zoom to the extent you want to take offline. The red border shows the extent that will be downloaded. Click the "Take Map Offline" button to start the offline map job. The progress bar will show the job's progress. When complete, the offline map will replace the online map in the map view.
 
 ## How it works
 


### PR DESCRIPTION
Added in the missing About the Data section to service feature manual cache (matching the data we use in the sample) and removing the reference to the "free" ArcGIS Online account which the team agreed caused confusion.