### PR TITLE
Update service URLs to use HTTPS

### DIFF
--- a/analysis/analyze-hotspots/src/main/java/com/esri/samples/analyze_hotspots/AnalyzeHotspotsSample.java
+++ b/analysis/analyze-hotspots/src/main/java/com/esri/samples/analyze_hotspots/AnalyzeHotspotsSample.java
@@ -110,7 +110,7 @@ public class AnalyzeHotspotsSample extends Application {
       StackPane.setMargin(controlsVBox, new Insets(10, 0, 0, 10));
 
       // create the geoprocessing task with the service URL and load it
-      GeoprocessingTask geoprocessingTask = new GeoprocessingTask("http://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot");
+      GeoprocessingTask geoprocessingTask = new GeoprocessingTask("https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot");
       geoprocessingTask.loadAsync();
 
       geoprocessingTask.addDoneLoadingListener(() -> {

--- a/analysis/line-of-sight-geoelement/src/main/java/com/esri/samples/line_of_sight_geoelement/LineOfSightGeoElementSample.java
+++ b/analysis/line-of-sight-geoelement/src/main/java/com/esri/samples/line_of_sight_geoelement/LineOfSightGeoElementSample.java
@@ -105,8 +105,7 @@ public class LineOfSightGeoElementSample extends Application {
 
       // add base surface for elevation data
       Surface surface = new Surface();
-      surface.getElevationSources().add(new ArcGISTiledElevationSource("http://elevation3d.arcgis" +
-          ".com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
+      surface.getElevationSources().add(new ArcGISTiledElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
       scene.setBaseSurface(surface);
 
       // add buildings from New York City

--- a/analysis/line-of-sight-location/src/main/java/com/esri/samples/line_of_sight_location/LineOfSightLocationSample.java
+++ b/analysis/line-of-sight-location/src/main/java/com/esri/samples/line_of_sight_location/LineOfSightLocationSample.java
@@ -70,7 +70,7 @@ public class LineOfSightLocationSample extends Application {
 
       // add base surface for elevation data
       Surface surface = new Surface();
-      surface.getElevationSources().add(new ArcGISTiledElevationSource("http://elevation3d.arcgis" +
+      surface.getElevationSources().add(new ArcGISTiledElevationSource("https://elevation3d.arcgis" +
           ".com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
       scene.setBaseSurface(surface);
 

--- a/analysis/viewshed-camera/src/main/java/com/esri/samples/viewshed_camera/ViewshedCameraSample.java
+++ b/analysis/viewshed-camera/src/main/java/com/esri/samples/viewshed_camera/ViewshedCameraSample.java
@@ -68,13 +68,12 @@ public class ViewshedCameraSample extends Application {
 
       // add base surface for elevation data
       Surface surface = new Surface();
-      final String localElevationImageService = "http://scene.arcgis" +
-          ".com/arcgis/rest/services/BREST_DTM_1M/ImageServer";
+      final String localElevationImageService = "https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer";
       surface.getElevationSources().add(new ArcGISTiledElevationSource(localElevationImageService));
       scene.setBaseSurface(surface);
 
       // add a scene layer
-      final String buildings = "http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0";
+      final String buildings = "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0";
       ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(buildings);
       scene.getOperationalLayers().add(sceneLayer);
 

--- a/analysis/viewshed-geoelement/src/main/java/com/esri/samples/viewshed_geoelement/ViewshedGeoElementSample.java
+++ b/analysis/viewshed-geoelement/src/main/java/com/esri/samples/viewshed_geoelement/ViewshedGeoElementSample.java
@@ -91,13 +91,12 @@ public class ViewshedGeoElementSample extends Application {
 
       // add base surface for elevation data
       Surface surface = new Surface();
-      final String localElevationImageService = "http://scene.arcgis" +
-          ".com/arcgis/rest/services/BREST_DTM_1M/ImageServer";
+      final String localElevationImageService = "https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer";
       surface.getElevationSources().add(new ArcGISTiledElevationSource(localElevationImageService));
       scene.setBaseSurface(surface);
 
       // add a scene layer
-      final String buildings = "http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0";
+      final String buildings = "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0";
       ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(buildings);
       scene.getOperationalLayers().add(sceneLayer);
 

--- a/editing/add-features/src/main/java/com/esri/samples/add_features/AddFeaturesSample.java
+++ b/editing/add-features/src/main/java/com/esri/samples/add_features/AddFeaturesSample.java
@@ -49,7 +49,7 @@ public class AddFeaturesSample extends Application {
   private ServiceFeatureTable featureTable;
 
   private static final String SERVICE_LAYER_URL =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
 
   @Override
   public void start(Stage stage) {

--- a/editing/delete-features/src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java
+++ b/editing/delete-features/src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java
@@ -53,7 +53,7 @@ public class DeleteFeaturesSample extends Application {
   private ListenableFuture<FeatureQueryResult> selectionResult;
 
   private static final String FEATURE_LAYER_URL =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
 
   @Override
   public void start(Stage stage) {

--- a/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
+++ b/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
@@ -68,7 +68,7 @@ public class EditFeatureAttachmentsSample extends Application {
   private List<Attachment> attachments;
 
   private static final String SERVICE_FEATURE_URL =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
 
   @Override
   public void start(Stage stage) {

--- a/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
+++ b/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
@@ -61,7 +61,7 @@ public class UpdateAttributesSample extends Application {
   private ComboBox<String> comboBox;
 
   private static final String FEATURE_LAYER_URL =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
 
   @Override
   public void start(Stage stage) {

--- a/editing/update-geometries/src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java
+++ b/editing/update-geometries/src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java
@@ -51,7 +51,7 @@ public class UpdateGeometriesSample extends Application {
   private FeatureLayer featureLayer;
 
   private static final String FEATURE_LAYER_URL =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
 
   @Override
   public void start(Stage stage) {

--- a/feature_layers/feature-layer-definition-expression/src/main/java/com/esri/samples/feature_layer_definition_expression/FeatureLayerDefinitionExpressionSample.java
+++ b/feature_layers/feature-layer-definition-expression/src/main/java/com/esri/samples/feature_layer_definition_expression/FeatureLayerDefinitionExpressionSample.java
@@ -38,7 +38,7 @@ public class FeatureLayerDefinitionExpressionSample extends Application {
   private FeatureLayer featureLayer;
 
   private final static String FEATURE_SERVICE_URL =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0";
 
   @Override
   public void start(Stage stage) {

--- a/feature_layers/feature-layer-extrusion/src/main/java/com/esri/samples/feature_layer_extrusion/FeatureLayerExtrusionSample.java
+++ b/feature_layers/feature-layer-extrusion/src/main/java/com/esri/samples/feature_layer_extrusion/FeatureLayerExtrusionSample.java
@@ -66,7 +66,7 @@ public class FeatureLayerExtrusionSample extends Application {
     stackPane.getChildren().add(sceneView);
 
     // get us census data as a service feature table
-    ServiceFeatureTable statesServiceFeatureTable = new ServiceFeatureTable("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3");
+    ServiceFeatureTable statesServiceFeatureTable = new ServiceFeatureTable("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3");
 
     // creates feature layer from table and add to scene
     final FeatureLayer statesFeatureLayer = new FeatureLayer(statesServiceFeatureTable);

--- a/feature_layers/feature-layer-feature-service/src/main/java/com/esri/samples/feature_layer_feature_service/FeatureLayerFeatureServiceSample.java
+++ b/feature_layers/feature-layer-feature-service/src/main/java/com/esri/samples/feature_layer_feature_service/FeatureLayerFeatureServiceSample.java
@@ -35,7 +35,7 @@ public class FeatureLayerFeatureServiceSample extends Application {
   private MapView mapView;
 
   private static final String GEOLOGY_FEATURE_SERVICE =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9";
 
   @Override
   public void start(Stage stage) {

--- a/feature_layers/feature-layer-geodatabase/README.md
+++ b/feature_layers/feature-layer-geodatabase/README.md
@@ -34,7 +34,7 @@ The sample shows trailheads in the greater Los Angeles area displayed on top of 
 
 One of the ArcGIS Runtime data set types that can be accessed via the local storage of the device (i.e. hard drive, flash drive, micro SD card, USB stick, etc.) is a mobile geodatabase. A mobile geodatabase can be provisioned for use in an ArcGIS Runtime application by ArcMap. The following provide some helpful tips on how to create a mobile geodatabase file:
 
-In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
+In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: https://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
 
 Note: You could also use the 'Services Pattern' and access the Geodatabase class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the Geodatabase class to access the .geodatabase file on disk, you would use GeodatabaseSyncTask point to a Uri instead. For more information review the document: https://developers.arcgis.com/java/latest/guide/work-with-offline-layers.htm.
 

--- a/feature_layers/feature-layer-rendering-mode-map/src/main/java/com/esri/samples/feature_layer_rendering_mode_map/FeatureLayerRenderingModeMapSample.java
+++ b/feature_layers/feature-layer-rendering-mode-map/src/main/java/com/esri/samples/feature_layer_rendering_mode_map/FeatureLayerRenderingModeMapSample.java
@@ -81,9 +81,9 @@ public class FeatureLayerRenderingModeMapSample extends Application {
       splitPane.getItems().add(mapViewBottom);
 
       // create service feature table using a point, polyline, and polygon service
-      ServiceFeatureTable pointServiceFeatureTable = new ServiceFeatureTable("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/0");
-      ServiceFeatureTable polylineServiceFeatureTable = new ServiceFeatureTable("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/8");
-      ServiceFeatureTable polygonServiceFeatureTable = new ServiceFeatureTable("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9");
+      ServiceFeatureTable pointServiceFeatureTable = new ServiceFeatureTable("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/0");
+      ServiceFeatureTable polylineServiceFeatureTable = new ServiceFeatureTable("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/8");
+      ServiceFeatureTable polygonServiceFeatureTable = new ServiceFeatureTable("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9");
 
       // create feature layer from service feature tables
       FeatureLayer pointFeatureLayer = new FeatureLayer(pointServiceFeatureTable);

--- a/feature_layers/service-feature-table-manual-cache/src/main/java/com/esri/samples/service_feature_table_manual_cache/ServiceFeatureTableManualCacheSample.java
+++ b/feature_layers/service-feature-table-manual-cache/src/main/java/com/esri/samples/service_feature_table_manual_cache/ServiceFeatureTableManualCacheSample.java
@@ -57,7 +57,7 @@ public class ServiceFeatureTableManualCacheSample extends Application {
   private ListenableFuture<FeatureQueryResult> tableResult;
 
   private static final String SERVICE_FEATURE_URL =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0";
 
   @Override
   public void start(Stage stage) {

--- a/group_layers/group-layers/src/main/java/com/esri/samples/group_layers/GroupLayersSample.java
+++ b/group_layers/group-layers/src/main/java/com/esri/samples/group_layers/GroupLayersSample.java
@@ -72,7 +72,7 @@ public class GroupLayersSample extends Application {
 
       // set the base surface with world elevation
       Surface surface = new Surface();
-      surface.getElevationSources().add(new ArcGISTiledElevationSource("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
+      surface.getElevationSources().add(new ArcGISTiledElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
       scene.setBaseSurface(surface);
 
       // create different types of layers

--- a/image_layers/change-sublayer-renderer/src/main/java/com/esri/samples/change_sublayer_renderer/ChangeSublayerRendererSample.java
+++ b/image_layers/change-sublayer-renderer/src/main/java/com/esri/samples/change_sublayer_renderer/ChangeSublayerRendererSample.java
@@ -73,7 +73,7 @@ public class ChangeSublayerRendererSample extends Application {
       rendererButton.setDisable(true);
 
       // create a map image layer from a service URL
-      ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer");
+      ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer");
 
       // load the layer and find one of its sublayers
       imageLayer.addDoneLoadingListener(() -> {

--- a/image_layers/map-image-layer-sublayer-visibility/src/main/java/com/esri/samples/map_image_layer_sublayer_visibility/MapImageLayerSublayerVisibilitySample.java
+++ b/image_layers/map-image-layer-sublayer-visibility/src/main/java/com/esri/samples/map_image_layer_sublayer_visibility/MapImageLayerSublayerVisibilitySample.java
@@ -41,7 +41,7 @@ public class MapImageLayerSublayerVisibilitySample extends Application {
 
   // World Topo Map Service URL
   private static final String WORLD_CITIES_SERVICE =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer";
 
   @Override
   public void start(Stage stage) {

--- a/image_layers/map-image-layer/src/main/java/com/esri/samples/map_image_layer/MapImageLayerSample.java
+++ b/image_layers/map-image-layer/src/main/java/com/esri/samples/map_image_layer/MapImageLayerSample.java
@@ -45,7 +45,7 @@ public class MapImageLayerSample extends Application {
       stage.show();
 
       // create new ArcGISMap image Layer from service url
-      String serviceFeatureUrl = "http://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer";
+      String serviceFeatureUrl = "https://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer";
       final ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer(serviceFeatureUrl);
 
       final ArcGISMap map = new ArcGISMap();

--- a/kml/create-and-save-kml-file/src/main/java/com/esri/samples/create_and_save_kml_file/CreateAndSaveKMLFileController.java
+++ b/kml/create-and-save-kml-file/src/main/java/com/esri/samples/create_and_save_kml_file/CreateAndSaveKMLFileController.java
@@ -80,12 +80,12 @@ public class CreateAndSaveKMLFileController {
     // set the images for the icon selection combo box
     List<String> iconLinks = Arrays.asList(
             null, // for the default symbol
-            "http://static.arcgis.com/images/Symbols/Shapes/BlueCircleLargeB.png",
-            "http://static.arcgis.com/images/Symbols/Shapes/BlueDiamondLargeB.png",
-            "http://static.arcgis.com/images/Symbols/Shapes/BluePin1LargeB.png",
-            "http://static.arcgis.com/images/Symbols/Shapes/BluePin2LargeB.png",
-            "http://static.arcgis.com/images/Symbols/Shapes/BlueSquareLargeB.png",
-            "http://static.arcgis.com/images/Symbols/Shapes/BlueStarLargeB.png");
+            "https://static.arcgis.com/images/Symbols/Shapes/BlueCircleLargeB.png",
+            "https://static.arcgis.com/images/Symbols/Shapes/BlueDiamondLargeB.png",
+            "https://static.arcgis.com/images/Symbols/Shapes/BluePin1LargeB.png",
+            "https://static.arcgis.com/images/Symbols/Shapes/BluePin2LargeB.png",
+            "https://static.arcgis.com/images/Symbols/Shapes/BlueSquareLargeB.png",
+            "https://static.arcgis.com/images/Symbols/Shapes/BlueStarLargeB.png");
     pointSymbolComboBox.getItems().addAll(iconLinks);
     pointSymbolComboBox.setCellFactory(comboBox -> new ImageURLListCell());
     pointSymbolComboBox.setButtonCell(new ImageURLListCell());

--- a/kml/play-a-kml-tour/src/main/java/com/esri/samples/play_a_kml_tour/PlayAKMLTourSample.java
+++ b/kml/play-a-kml-tour/src/main/java/com/esri/samples/play_a_kml_tour/PlayAKMLTourSample.java
@@ -72,7 +72,7 @@ public class PlayAKMLTourSample extends Application {
 
       // add elevation data
       Surface surface = new Surface();
-      surface.getElevationSources().add(new ArcGISTiledElevationSource("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
+      surface.getElevationSources().add(new ArcGISTiledElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
       scene.setBaseSurface(surface);
 
       // create play/pause button

--- a/map/apply-scheduled-updates-to-preplanned-map-area/gradlew
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/map/apply-scheduled-updates-to-preplanned-map-area/gradlew.bat
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem      http://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/map/apply-scheduled-updates-to-preplanned-map-area/gradlew.bat
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/map/create-and-save-map/src/main/java/com/esri/samples/create_and_save_map/CreateAndSaveMapController.java
+++ b/map/create-and-save-map/src/main/java/com/esri/samples/create_and_save_map/CreateAndSaveMapController.java
@@ -91,11 +91,11 @@ public class CreateAndSaveMapController {
 
     // set operational layer options
     String worldElevationService =
-            "http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer";
+            "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer";
     ArcGISMapImageLayer worldElevation = new ArcGISMapImageLayer(worldElevationService);
     worldElevation.loadAsync();
 
-    String worldCensusService = "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer";
+    String worldCensusService = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer";
     ArcGISMapImageLayer worldCensus = new ArcGISMapImageLayer(worldCensusService);
     worldCensus.loadAsync();
 
@@ -143,7 +143,7 @@ public class CreateAndSaveMapController {
         // add the OAuth configuration
         AuthenticationManager.addOAuthConfiguration(configuration);
 
-        portal = new Portal("http://" + configuration.getPortalUrl(), true);
+        portal = new Portal("https://" + configuration.getPortalUrl(), true);
         portal.addDoneLoadingListener(() -> {
           if (portal.getLoadStatus() == LoadStatus.LOADED) {
             try {

--- a/map/manage-operational-layers/src/main/java/com/esri/samples/manage_operational_layers/ManageOperationalLayersSample.java
+++ b/map/manage-operational-layers/src/main/java/com/esri/samples/manage_operational_layers/ManageOperationalLayersSample.java
@@ -46,11 +46,11 @@ public class ManageOperationalLayersSample extends Application {
   private LayerList mapAddedLayers;
 
   private static final String ELEVATION_LAYER =
-      "http://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer";
+      "https://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer";
   private static final String CENSUS_LAYER =
-      "http://sampleserver5.arcgisonline.com/arcgis/rest/services/Census/MapServer";
+      "https://sampleserver5.arcgisonline.com/arcgis/rest/services/Census/MapServer";
   private static final String DAMAGE_LAYER =
-      "http://sampleserver5.arcgisonline.com/arcgis/rest/services/DamageAssessment/MapServer";
+      "https://sampleserver5.arcgisonline.com/arcgis/rest/services/DamageAssessment/MapServer";
 
   @Override
   public void start(Stage stage) {

--- a/map/map-reference-scale/src/main/java/com/esri/samples/map_reference_scale/MapReferenceScaleController.java
+++ b/map/map-reference-scale/src/main/java/com/esri/samples/map_reference_scale/MapReferenceScaleController.java
@@ -57,7 +57,7 @@ public class MapReferenceScaleController {
   private void initialize() {
 
     // access a web map as a portal item
-    Portal portal = new Portal("http://runtime.maps.arcgis.com");
+    Portal portal = new Portal("https://runtime.maps.arcgis.com");
     PortalItem portalItem = new PortalItem(portal, "3953413f3bd34e53a42bf70f2937a408");
 
     // create a map with the portal item

--- a/map/map-spatial-reference/src/main/java/com/esri/samples/map_spatial_reference/MapSpatialReferenceSample.java
+++ b/map/map-spatial-reference/src/main/java/com/esri/samples/map_spatial_reference/MapSpatialReferenceSample.java
@@ -32,7 +32,7 @@ public class MapSpatialReferenceSample extends Application {
   private MapView mapView;
 
   private static final String IMAGE_LAYER_URL =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer";
 
   @Override
   public void start(Stage stage) {

--- a/map_view/display-drawing-status/src/main/java/com/esri/samples/display_drawing_status/DisplayDrawingStatusSample.java
+++ b/map_view/display-drawing-status/src/main/java/com/esri/samples/display_drawing_status/DisplayDrawingStatusSample.java
@@ -74,7 +74,7 @@ public class DisplayDrawingStatusSample extends Application {
 
       // create a feature table from a service URL
       final ServiceFeatureTable featureTable = new ServiceFeatureTable(
-          "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
+          "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
 
       // create a feature layer from service table
       final FeatureLayer featureLayer = new FeatureLayer(featureTable);

--- a/map_view/display-layer-view-state/src/main/java/com/esri/samples/display_layer_view_state/DisplayLayerViewStateSample.java
+++ b/map_view/display-layer-view-state/src/main/java/com/esri/samples/display_layer_view_state/DisplayLayerViewStateSample.java
@@ -50,11 +50,11 @@ public class DisplayLayerViewStateSample extends Application {
   private static final int FEATURE_LAYER = 2;
 
   private static final String SERVICE_TIME_ZONES =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer";
   private static final String SERVICE_CENSUS =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer";
   private static final String SERVICE_RECREATION =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0";
 
   @Override
   public void start(Stage stage) {

--- a/network_analysis/closest-facility/src/main/java/com/esri/samples/closest_facility/ClosestFacilitySample.java
+++ b/network_analysis/closest-facility/src/main/java/com/esri/samples/closest_facility/ClosestFacilitySample.java
@@ -105,7 +105,7 @@ public class ClosestFacilitySample extends Application {
 
       // task to find the closest route between an incident and a facility 
       final String sanDiegoRegion =
-          "http://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/ClosestFacility";
+          "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/ClosestFacility";
       task = new ClosestFacilityTask(sanDiegoRegion);
       task.addDoneLoadingListener(() -> {
         if (task.getLoadStatus() == LoadStatus.LOADED) {
@@ -165,7 +165,7 @@ public class ClosestFacilitySample extends Application {
         new Facility(new Point(-1.3049023883956768E7, 3861993.789732541, spatialReference)));
 
     // image for displaying facility
-    String facilityUrl = "http://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png";
+    String facilityUrl = "https://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png";
     PictureMarkerSymbol facilitySymbol = new PictureMarkerSymbol(facilityUrl);
     facilitySymbol.setHeight(30);
     facilitySymbol.setWidth(30);

--- a/network_analysis/find-route/src/main/java/com/esri/samples/find_route/FindRouteSample.java
+++ b/network_analysis/find-route/src/main/java/com/esri/samples/find_route/FindRouteSample.java
@@ -74,7 +74,7 @@ public class FindRouteSample extends Application {
   private static final int BLUE_COLOR = 0xff0000ff;
 
   private static final String ROUTE_TASK_SANDIEGO =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route";
 
   @Override
   public void start(Stage stage) {

--- a/network_analysis/find-service-areas-for-multiple-facilities/src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java
+++ b/network_analysis/find-service-areas-for-multiple-facilities/src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java
@@ -106,7 +106,7 @@ public class FindServiceAreasForMultipleFacilitiesSample extends Application {
     FeatureLayer facilitiesFeatureLayer = new FeatureLayer(facilitiesTable);
 
     // create a symbol used to display the facilities
-    PictureMarkerSymbol facilitySymbol = new PictureMarkerSymbol("http://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png");
+    PictureMarkerSymbol facilitySymbol = new PictureMarkerSymbol("https://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png");
     facilitySymbol.setHeight(25);
     facilitySymbol.setWidth(25);
     // set the renderer of the facilities feature layer to use the facilities symbol

--- a/network_analysis/routing-around-barriers/src/main/java/com/esri/samples/routing_around_barriers/RoutingAroundBarriersController.java
+++ b/network_analysis/routing-around-barriers/src/main/java/com/esri/samples/routing_around_barriers/RoutingAroundBarriersController.java
@@ -110,7 +110,7 @@ public class RoutingAroundBarriersController {
     pinSymbol.loadAsync();
 
     // create route task from San Diego service
-    routeTask = new RouteTask("http://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route");
+    routeTask = new RouteTask("https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route");
     routeTask.loadAsync();
 
     // wait for the route task to load

--- a/ogc/open-street-map-layer/README.md
+++ b/ogc/open-street-map-layer/README.md
@@ -28,7 +28,7 @@ The attribution text will be set to the required OpenStreetMap attribution autom
 
 Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class. See [layer types described](https://developers.arcgis.com/java/latest/guide/layer-types-described.htm#ESRI_SECTION1_B995CCAB20584F91890B3614CF16CF43) in the *ArcGIS Runtime SDK for Java* documentation for more information on OpenStreetMap usage restrictions and alternatives.
 
-Esri now hosts an [OpenStreetMap vector layer on ArcGIS Online](http://www.arcgis.com/home/item.html?id=3e1a00aeae81496587988075fe529f71) that uses recent OpenStreetMap data in conjunction with a style matching the default OpenStreetMap style. This layer is not subject to the tile access restrictions that apply to tiles fetched from OpenStreetMap.org.
+Esri now hosts an [OpenStreetMap vector layer on ArcGIS Online](https://www.arcgis.com/home/item.html?id=3e1a00aeae81496587988075fe529f71) that uses recent OpenStreetMap data in conjunction with a style matching the default OpenStreetMap style. This layer is not subject to the tile access restrictions that apply to tiles fetched from OpenStreetMap.org.
 
 ## Tags
 

--- a/ogc/wmts-layer/src/main/java/com/esri/samples/wmts_layer/WmtsLayerSample.java
+++ b/ogc/wmts-layer/src/main/java/com/esri/samples/wmts_layer/WmtsLayerSample.java
@@ -57,7 +57,7 @@ public class WmtsLayerSample extends Application {
       mapView.setMap(map);
 
       // create a WMTS service from a URL
-      String serviceURL = "http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer/WMTS";
+      String serviceURL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer/WMTS";
       WmtsService wmtsService = new WmtsService(serviceURL);
       wmtsService.addDoneLoadingListener(() -> {
         if (wmtsService.getLoadStatus() == LoadStatus.LOADED) {

--- a/portal/integrated-windows-authentication/README.md
+++ b/portal/integrated-windows-authentication/README.md
@@ -37,7 +37,7 @@ This sample searches for web map portal items on a secure portal. To successfull
 
 More information about IWA and its use with ArcGIS can be found at the following links:
  * [IWA - Wikipedia](https://en.wikipedia.org/wiki/Integrated_Windows_Authentication)
- * [Use Integrated Windows Authentication with your portal](http://enterprise.arcgis.com/en/portal/latest/administer/windows/use-integrated-windows-authentication-with-your-portal.htm)
+ * [Use Integrated Windows Authentication with your portal](https://enterprise.arcgis.com/en/portal/latest/administer/windows/use-integrated-windows-authentication-with-your-portal.htm)
 
 ## Tags
 

--- a/portal/webmap-keyword-search/src/main/java/com/esri/samples/webmap_keyword_search/WebmapKeywordSearchController.java
+++ b/portal/webmap-keyword-search/src/main/java/com/esri/samples/webmap_keyword_search/WebmapKeywordSearchController.java
@@ -46,7 +46,7 @@ public class WebmapKeywordSearchController {
   @FXML
   private void initialize() {
     // load a portal for arcgis.com
-    portal = new Portal("http://arcgis.com");
+    portal = new Portal("https://arcgis.com");
     portal.loadAsync();
 
     resultsList.setCellFactory(c -> new PortalItemCell());

--- a/raster/raster-function/src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java
+++ b/raster/raster-function/src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java
@@ -63,7 +63,7 @@ public class RasterFunctionSample extends Application {
       mapView.setMap(map);
 
       // create an image service raster from an online raster service
-      ImageServiceRaster imageServiceRaster = new ImageServiceRaster("http://sampleserver6.arcgisonline" +
+      ImageServiceRaster imageServiceRaster = new ImageServiceRaster("https://sampleserver6.arcgisonline" +
           ".com/arcgis/rest/services/NLCDLandCover2001/ImageServer");
       imageServiceRaster.loadAsync();
       imageServiceRaster.addDoneLoadingListener(() -> {

--- a/raster/raster-layer-file/README.md
+++ b/raster/raster-layer-file/README.md
@@ -25,7 +25,7 @@ When the sample starts, a raster will be loaded from a file and displayed in the
 
 ## Additional information
 
-See the topic [What is raster data?](http://desktop.arcgis.com/en/arcmap/10.3/manage-data/raster-and-images/what-is-raster-data.htm) in the *ArcMap* documentation for more information about raster images.
+See the topic [What is raster data?](https://desktop.arcgis.com/en/arcmap/10.3/manage-data/raster-and-images/what-is-raster-data.htm) in the *ArcMap* documentation for more information about raster images.
 
 ## Tags
 

--- a/raster/raster-rendering-rule/src/main/java/com/esri/samples/raster_rendering_rule/RasterRenderingRuleSample.java
+++ b/raster/raster-rendering-rule/src/main/java/com/esri/samples/raster_rendering_rule/RasterRenderingRuleSample.java
@@ -106,7 +106,7 @@ public class RasterRenderingRuleSample extends Application {
       mapView.setMap(map);
 
       // create an Image Service Raster as a raster layer and add to map
-      final String ImageServiceRasterUri = "http://sampleserver6.arcgisonline.com/arcgis/rest/services/CharlotteLAS/ImageServer";
+      final String ImageServiceRasterUri = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/CharlotteLAS/ImageServer";
       final ImageServiceRaster imageServiceRaster = new ImageServiceRaster(ImageServiceRasterUri);
       final RasterLayer imageRasterLayer = new RasterLayer(imageServiceRaster);
       map.getOperationalLayers().add(imageRasterLayer);

--- a/scene/add-a-point-scene-layer/src/main/java/com/esri/samples/add_a_point_scene_layer/AddAPointSceneLayerSample.java
+++ b/scene/add-a-point-scene-layer/src/main/java/com/esri/samples/add_a_point_scene_layer/AddAPointSceneLayerSample.java
@@ -63,7 +63,7 @@ public class AddAPointSceneLayerSample extends Application {
 
       // set the base surface with world elevation
       Surface surface = new Surface();
-      surface.getElevationSources().add(new ArcGISTiledElevationSource("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
+      surface.getElevationSources().add(new ArcGISTiledElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
       scene.setBaseSurface(surface);
 
       // add a point scene layer with points at world airport locations

--- a/scene/add-an-integrated-mesh-layer/src/main/java/com/esri/samples/add_an_integrated_mesh_layer/AddAnIntegratedMeshLayerSample.java
+++ b/scene/add-an-integrated-mesh-layer/src/main/java/com/esri/samples/add_an_integrated_mesh_layer/AddAnIntegratedMeshLayerSample.java
@@ -61,7 +61,7 @@ public class AddAnIntegratedMeshLayerSample extends Application {
 
       // set the base surface with world elevation
       Surface surface = new Surface();
-      surface.getElevationSources().add(new ArcGISTiledElevationSource("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
+      surface.getElevationSources().add(new ArcGISTiledElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
       scene.setBaseSurface(surface);
 
       // add an integrated mesh layer of Yosemite National Park

--- a/scene/animate-3d-graphic/src/main/java/com/esri/samples/animate_3d_graphic/Animate3dGraphicController.java
+++ b/scene/animate-3d-graphic/src/main/java/com/esri/samples/animate_3d_graphic/Animate3dGraphicController.java
@@ -83,7 +83,7 @@ public class Animate3dGraphicController {
 
   private static final SpatialReference WGS84 = SpatialReferences.getWgs84();
   private static final String ELEVATION_IMAGE_SERVICE =
-      "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
+      "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
 
   /**
    * Called after FXML loads. Sets up scene and map and configures property bindings.

--- a/scene/change-atmosphere-effect/src/main/java/com/esri/samples/change_atmosphere_effect/ChangeAtmosphereEffectSample.java
+++ b/scene/change-atmosphere-effect/src/main/java/com/esri/samples/change_atmosphere_effect/ChangeAtmosphereEffectSample.java
@@ -67,8 +67,8 @@ public class ChangeAtmosphereEffectSample extends Application {
 
       // add base surface for elevation data
       Surface surface = new Surface();
-      ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource( "http://elevation3d.arcgis" +
-          ".com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer");
+      ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource(
+              "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer");
       surface.getElevationSources().add(elevationSource);
       scene.setBaseSurface(surface);
 

--- a/scene/choose-camera-controller/src/main/java/com/esri/samples/choose_camera_controller/ChooseCameraControllerSample.java
+++ b/scene/choose-camera-controller/src/main/java/com/esri/samples/choose_camera_controller/ChooseCameraControllerSample.java
@@ -78,7 +78,7 @@ public class ChooseCameraControllerSample extends Application {
 
       // add base surface for elevation data
       Surface surface = new Surface();
-      ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource("http://elevation3d.arcgis" +
+      ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource("https://elevation3d.arcgis" +
               ".com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer");
       surface.getElevationSources().add(elevationSource);
       scene.setBaseSurface(surface);

--- a/scene/display-scene/src/main/java/com/esri/samples/display_scene/DisplaySceneSample.java
+++ b/scene/display-scene/src/main/java/com/esri/samples/display_scene/DisplaySceneSample.java
@@ -32,7 +32,7 @@ public class DisplaySceneSample extends Application {
 
   private SceneView sceneView;
   private static final String ELEVATION_IMAGE_SERVICE =
-      "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
+      "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
 
   @Override
   public void start(Stage stage) {

--- a/scene/distance-composite-symbol/src/main/java/com/esri/samples/distance_composite_symbol/DistanceCompositeSymbolSample.java
+++ b/scene/distance-composite-symbol/src/main/java/com/esri/samples/distance_composite_symbol/DistanceCompositeSymbolSample.java
@@ -45,7 +45,7 @@ public class DistanceCompositeSymbolSample extends Application {
 
   private SceneView sceneView;
   private static final String ELEVATION_IMAGE_SERVICE =
-      "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
+      "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
 
   @Override
   public void start(Stage stage) {

--- a/scene/extrude-graphics/src/main/java/com/esri/samples/extrude_graphics/ExtrudeGraphicsSample.java
+++ b/scene/extrude-graphics/src/main/java/com/esri/samples/extrude_graphics/ExtrudeGraphicsSample.java
@@ -48,7 +48,7 @@ public class ExtrudeGraphicsSample extends Application {
 
   private SceneView sceneView;
   private static final String ELEVATION_IMAGE_SERVICE =
-      "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
+      "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
 
   @Override
   public void start(Stage stage) {

--- a/scene/feature-layer-rendering-mode-scene/src/main/java/com/esri/samples/feature_layer_rendering_mode_scene/FeatureLayerRenderingModeSceneSample.java
+++ b/scene/feature-layer-rendering-mode-scene/src/main/java/com/esri/samples/feature_layer_rendering_mode_scene/FeatureLayerRenderingModeSceneSample.java
@@ -81,9 +81,9 @@ public class FeatureLayerRenderingModeSceneSample extends Application {
       splitPane.getItems().add(sceneViewBottom);
 
       // create service feature table using a point, polyline, and polygon service
-      ServiceFeatureTable pointServiceFeatureTable = new ServiceFeatureTable("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/0");
-      ServiceFeatureTable polylineServiceFeatureTable = new ServiceFeatureTable("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/8");
-      ServiceFeatureTable polygonServiceFeatureTable = new ServiceFeatureTable("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9");
+      ServiceFeatureTable pointServiceFeatureTable = new ServiceFeatureTable("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/0");
+      ServiceFeatureTable polylineServiceFeatureTable = new ServiceFeatureTable("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/8");
+      ServiceFeatureTable polygonServiceFeatureTable = new ServiceFeatureTable("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9");
 
       // create feature layer from service feature tables
       FeatureLayer pointFeatureLayer = new FeatureLayer(pointServiceFeatureTable);

--- a/scene/get-elevation-at-a-point/src/main/java/com/esri/samples/get_elevation_at_a_point/GetElevationAtAPointSample.java
+++ b/scene/get-elevation-at-a-point/src/main/java/com/esri/samples/get_elevation_at_a_point/GetElevationAtAPointSample.java
@@ -74,7 +74,7 @@ public class GetElevationAtAPointSample extends Application {
 
       // add base surface for elevation data
       Surface surface = new Surface();
-      surface.getElevationSources().add(new ArcGISTiledElevationSource("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
+      surface.getElevationSources().add(new ArcGISTiledElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
       scene.setBaseSurface(surface);
 
       // create a point symbol and graphic to mark where elevation is being measured

--- a/scene/orbit-the-camera-around-an-object/src/main/java/com/esri/samples/orbit_the_camera_around_an_object/OrbitTheCameraAroundAnObjectController.java
+++ b/scene/orbit-the-camera-around-an-object/src/main/java/com/esri/samples/orbit_the_camera_around_an_object/OrbitTheCameraAroundAnObjectController.java
@@ -64,8 +64,7 @@ public class OrbitTheCameraAroundAnObjectController {
 
       // add a base surface with elevation data
       Surface surface = new Surface();
-      ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource("http://elevation3d.arcgis" +
-              ".com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer");
+      ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer");
       surface.getElevationSources().add(elevationSource);
       scene.setBaseSurface(surface);
 

--- a/scene/scene-layer-selection/src/main/java/com/esri/samples/scene_layer_selection/SceneLayerSelectionSample.java
+++ b/scene/scene-layer-selection/src/main/java/com/esri/samples/scene_layer_selection/SceneLayerSelectionSample.java
@@ -77,7 +77,7 @@ public class SceneLayerSelectionSample extends Application {
 
       // add base surface with elevation data
       Surface surface = new Surface();
-      final String elevationService = "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
+      final String elevationService = "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
       surface.getElevationSources().add(new ArcGISTiledElevationSource(elevationService));
       scene.setBaseSurface(surface);
 

--- a/scene/scene-layer/src/main/java/com/esri/samples/scene_layer/SceneLayerSample.java
+++ b/scene/scene-layer/src/main/java/com/esri/samples/scene_layer/SceneLayerSample.java
@@ -60,12 +60,12 @@ public class SceneLayerSample extends Application {
 
       // add base surface for elevation data
       Surface surface = new Surface();
-      final String localElevationImageService = "http://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer";
+      final String localElevationImageService = "https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer";
       surface.getElevationSources().add(new ArcGISTiledElevationSource(localElevationImageService));
       scene.setBaseSurface(surface);
 
       // add a scene layer
-      final String buildings = "http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0";
+      final String buildings = "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0";
       ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(buildings);
       scene.getOperationalLayers().add(sceneLayer);
 

--- a/scene/surface-placement/src/main/java/com/esri/samples/surface_placement/SurfacePlacementSample.java
+++ b/scene/surface-placement/src/main/java/com/esri/samples/surface_placement/SurfacePlacementSample.java
@@ -83,7 +83,7 @@ public class SurfacePlacementSample extends Application {
       // add base surface for elevation data
       Surface surface = new Surface();
       ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource(
-          "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer");
+          "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer");
       surface.getElevationSources().add(elevationSource);
       scene.setBaseSurface(surface);
 

--- a/scene/symbols/src/main/java/com/esri/samples/symbols/SymbolsSample.java
+++ b/scene/symbols/src/main/java/com/esri/samples/symbols/SymbolsSample.java
@@ -42,7 +42,7 @@ public class SymbolsSample extends Application {
 
   private SceneView sceneView;
   private static final String ELEVATION_IMAGE_SERVICE =
-      "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
+      "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
 
   @Override
   public void start(Stage stage) {

--- a/scene/terrain-exaggeration/src/main/java/com/esri/samples/terrain_exaggeration/TerrainExaggerationController.java
+++ b/scene/terrain-exaggeration/src/main/java/com/esri/samples/terrain_exaggeration/TerrainExaggerationController.java
@@ -47,7 +47,7 @@ public class TerrainExaggerationController {
       // add base surface for elevation data
       surface = new Surface();
       final String elevationImageService =
-              "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
+              "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
       surface.getElevationSources().add(new ArcGISTiledElevationSource(elevationImageService));
       scene.setBaseSurface(surface);
 

--- a/scene/view-point-cloud-data-offline/src/main/java/com/esri/samples/view_point_cloud_data_offline/ViewPointCloudDataOfflineSample.java
+++ b/scene/view-point-cloud-data-offline/src/main/java/com/esri/samples/view_point_cloud_data_offline/ViewPointCloudDataOfflineSample.java
@@ -64,7 +64,7 @@ public class ViewPointCloudDataOfflineSample extends Application {
 
       // set the base surface with world elevation
       Surface surface = new Surface();
-      surface.getElevationSources().add(new ArcGISTiledElevationSource("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
+      surface.getElevationSources().add(new ArcGISTiledElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"));
       scene.setBaseSurface(surface);
 
       // add a point cloud layer from a scene layer package of Balboa Park in San Diego

--- a/symbology/picture-marker-symbol/README.md
+++ b/symbology/picture-marker-symbol/README.md
@@ -24,7 +24,7 @@ When launched, this sample displays a map with three picture marker symbols. Pan
 ## About the data
 
 The picture marker symbols in this sample are all constructed from different types of resources:
- * [Campsite symbol constructed from a URL](http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae)
+ * [Campsite symbol constructed from a URL](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae)
  * Blue pin with a star and orange pin stored in the resources folder that comes with the application
 
 ## Tags

--- a/symbology/picture-marker-symbol/src/main/java/com/esri/samples/picture_marker_symbol/PictureMarkerSymbolSample.java
+++ b/symbology/picture-marker-symbol/src/main/java/com/esri/samples/picture_marker_symbol/PictureMarkerSymbolSample.java
@@ -47,7 +47,7 @@ public class PictureMarkerSymbolSample extends Application {
   private GraphicsOverlay graphicsOverlay;
 
   private static final String CAMPSITE_SYMBOL =
-      "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae";
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae";
 
   @Override
   public void start(Stage stage) {

--- a/symbology/unique-value-renderer/src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java
+++ b/symbology/unique-value-renderer/src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java
@@ -70,7 +70,7 @@ public class UniqueValueRendererSample extends Application {
       mapView.setMap(map);
 
       // create service feature table
-      String sampleServiceUrl = "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3";
+      String sampleServiceUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3";
       ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(sampleServiceUrl);
 
       // create the feature layer using the service feature table


### PR DESCRIPTION
I've gone ahead and updated the URLs to services to use HTTPS. This is particualrly important with samples that use authentication, since they might not be able to get past the auth challenges when the URL is specified as `http`.

URLs that I haven't updated:
`http://www.apache.org/licenses/LICENSE-2.0` (from the license comment at the top of each file
`url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'` from the build.gradle files
`<fx:root type="javafx.scene.control.Dialog" xmlns:fx="http://javafx.com/fxml">` in FXML files

These would probably work as HTTPS, but it isn't critical, I think.