### PR TITLE
Nearest Vertex / Convex Hull - normalise point for wrapping around date line

### DIFF
--- a/geometry/convex-hull/src/main/java/com/esri/samples/convex_hull/ConvexHullSample.java
+++ b/geometry/convex-hull/src/main/java/com/esri/samples/convex_hull/ConvexHullSample.java
@@ -133,12 +133,21 @@ public class ConvexHullSample extends Application {
       vBox.getStyleClass().add("panel-region");
       vBox.getChildren().addAll(convexHullButton, clearButton);
 
-      // add a point where the user clicks on the map
+      // create a point from where the user clicked
       mapView.setOnMouseClicked(e -> {
         if (e.isStillSincePress() && e.getButton() == MouseButton.PRIMARY) {
-          Point2D point2D = new Point2D(e.getX(), e.getY());
-          Point point = mapView.screenToLocation(point2D);
-          inputs.add(point);
+
+          Point2D point = new Point2D(e.getX(), e.getY());
+
+          // create a map point from a point
+          Point mapPoint = mapView.screenToLocation(point);
+
+          // for a wrapped around map, the point coordinates include the wrapped around value
+          // for a service in projected coordinate system, this wrapped around value has to be normalized
+          Point normalizedMapPoint = (Point) GeometryEngine.normalizeCentralMeridian(mapPoint);
+
+          // add a point where the user clicks on the map
+          inputs.add(normalizedMapPoint);
           // update the inputs graphic geometry
           Multipoint inputsGeometry = new Multipoint(new PointCollection(inputs));
           inputsGraphic.setGeometry(inputsGeometry);

--- a/geometry/convex-hull/src/main/java/com/esri/samples/convex_hull/ConvexHullSample.java
+++ b/geometry/convex-hull/src/main/java/com/esri/samples/convex_hull/ConvexHullSample.java
@@ -142,8 +142,7 @@ public class ConvexHullSample extends Application {
           // create a map point from a point
           Point mapPoint = mapView.screenToLocation(point);
 
-          // for a wrapped around map, the point coordinates include the wrapped around value
-          // for a service in projected coordinate system, this wrapped around value has to be normalized
+          // the map point should be normalized to the central meridian when wrapping around a map, so its value stays within the coordinate system of the map view
           Point normalizedMapPoint = (Point) GeometryEngine.normalizeCentralMeridian(mapPoint);
 
           // add a point where the user clicks on the map

--- a/geometry/nearest-vertex/src/main/java/com/esri/samples/nearest_vertex/NearestVertexSample.java
+++ b/geometry/nearest-vertex/src/main/java/com/esri/samples/nearest_vertex/NearestVertexSample.java
@@ -123,14 +123,21 @@ public class NearestVertexSample extends Application {
       // get the nearest vertex and coordinate where the user clicks
       mapView.setOnMouseClicked(e -> {
         if (e.isStillSincePress() && e.getButton() == MouseButton.PRIMARY) {
+          // create a point from where the user clicked
+          Point2D point = new Point2D(e.getX(), e.getY());
+
+          // create a map point from a point
+          Point mapPoint = mapView.screenToLocation(point);
+
+          // for a wrapped around map, the point coordinates include the wrapped around value
+          // for a service in projected coordinate system, this wrapped around value has to be normalized
+          Point normalizedMapPoint = (Point) GeometryEngine.normalizeCentralMeridian(mapPoint);
           // show where the user clicked
-          Point2D point2D = new Point2D(e.getX(), e.getY());
-          Point point = mapView.screenToLocation(point2D);
-          clickedLocationGraphic.setGeometry(point);
+          clickedLocationGraphic.setGeometry(normalizedMapPoint);
 
           // show the nearest coordinate and vertex
-          ProximityResult nearestCoordinateResult = GeometryEngine.nearestCoordinate(polygon, point);
-          ProximityResult nearestVertexResult = GeometryEngine.nearestVertex(polygon, point);
+          ProximityResult nearestCoordinateResult = GeometryEngine.nearestCoordinate(polygon, normalizedMapPoint);
+          ProximityResult nearestVertexResult = GeometryEngine.nearestVertex(polygon, normalizedMapPoint);
           nearestVertexGraphic.setGeometry(nearestVertexResult.getCoordinate());
           nearestCoordinateGraphic.setGeometry(nearestCoordinateResult.getCoordinate());
 

--- a/geometry/nearest-vertex/src/main/java/com/esri/samples/nearest_vertex/NearestVertexSample.java
+++ b/geometry/nearest-vertex/src/main/java/com/esri/samples/nearest_vertex/NearestVertexSample.java
@@ -129,8 +129,7 @@ public class NearestVertexSample extends Application {
           // create a map point from a point
           Point mapPoint = mapView.screenToLocation(point);
 
-          // for a wrapped around map, the point coordinates include the wrapped around value
-          // for a service in projected coordinate system, this wrapped around value has to be normalized
+          // the map point should be normalized to the central meridian when wrapping around a map, so its value stays within the coordinate system of the map view
           Point normalizedMapPoint = (Point) GeometryEngine.normalizeCentralMeridian(mapPoint);
           // show where the user clicked
           clickedLocationGraphic.setGeometry(normalizedMapPoint);


### PR DESCRIPTION
A quick modification to nearest vertex / convex hull, where panning across the dateline results in unexpected behaviour. This change introduces normalizing the clicked map points.
There's a similar workflow in `AddFeatures`.
