### PR TITLE
Update README.metadata.json files using script

### DIFF
--- a/analysis/analyze-hotspots/README.metadata.json
+++ b/analysis/analyze-hotspots/README.metadata.json
@@ -1,27 +1,33 @@
 {
-  "category": "Analysis",
-  "description": "Perform hotspot analysis using a geoprocessing service.",
-  "ignore": false,
-  "images": [
-    "AnalyzeHotspots.png"
-  ],
-  "keywords": [
-    "Geoprocessing",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult"
-  ],
-  "redirect_from": "/java/latest/sample-code/analyze-hotspots.htm",
-  "relevant_apis": [
-    "ArcGISMapImageLayer",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult",
-    "GeoprocessingString",
-    "GeoprocessingTask"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/analyze_hotspots/AnalyzeHotspotsSample.java"
-  ],
-  "title": "Analyze Hotspots"
+    "category": "Analysis",
+    "description": "Use a geoprocessing service and a set of features to identify statistically significant hot spots and cold spots.",
+    "ignore": false,
+    "images": [
+        "AnalyzeHotspots.png"
+    ],
+    "keywords": [
+        "analysis",
+        "density",
+        "geoprocessing",
+        "hot spots",
+        "hotspots",
+        "GeoprocessingJob",
+        "GeoprocessingParameters",
+        "GeoprocessingResult",
+        "GeoprocessingTask"
+    ],
+    "redirect_from": [
+        "/java/latest/sample-code/analyze-hotspots.htm"
+    ],
+    "relevant_apis": [
+        "GeoprocessingJob",
+        "GeoprocessingParameters",
+        "GeoprocessingResult",
+        "GeoprocessingTask"
+    ],
+    "snippets": [
+        "AnalyzeHotspotsLauncher.java",
+        "AnalyzeHotspotsSample.java"
+    ],
+    "title": "Analyze hotspots"
 }

--- a/analysis/analyze-hotspots/README.metadata.json
+++ b/analysis/analyze-hotspots/README.metadata.json
@@ -26,8 +26,7 @@
         "GeoprocessingTask"
     ],
     "snippets": [
-        "AnalyzeHotspotsLauncher.java",
-        "AnalyzeHotspotsSample.java"
+        "src/main/java/com/esri/samples/analyze_hotspots/AnalyzeHotspotsSample.java"
     ],
     "title": "Analyze hotspots"
 }

--- a/analysis/distance-measurement-analysis/README.metadata.json
+++ b/analysis/distance-measurement-analysis/README.metadata.json
@@ -21,9 +21,9 @@
         "LocationDistanceMeasurement"
     ],
     "snippets": [
-        "DistanceMeasurementAnalysisController.java",
-        "DistanceMeasurementAnalysisLauncher.java",
-        "DistanceMeasurementAnalysisSample.java"
+        "src/main/java/com/esri/samples/distance_measurement_analysis/DistanceMeasurementAnalysisController.java",
+        "src/main/java/com/esri/samples/distance_measurement_analysis/DistanceMeasurementAnalysisSample.java",
+        "src/main/resources/distance_measurement_analysis/main.fxml"
     ],
     "title": "Distance measurement analysis"
 }

--- a/analysis/distance-measurement-analysis/README.metadata.json
+++ b/analysis/distance-measurement-analysis/README.metadata.json
@@ -1,24 +1,29 @@
 {
-  "category": "Analysis",
-  "description": "Measure distances within a scene.",
-  "ignore": false,
-  "images": [
-    "DistanceMeasurementAnalysis.png"
-  ],
-  "keywords": [],
-  "redirect_from": "/java/latest/sample-code/distance-measurement-analysis.htm",
-  "relevant_apis": [
-    "ArcGISMapImageLayer",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult",
-    "GeoprocessingString",
-    "GeoprocessingTask"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/distance_measurement_analysis/DistanceMeasurementAnalysisSample.java",
-    "src/main/java/com/esri/samples/distance_measurement_analysis/DistanceMeasurementAnalysisController.java",
-    "src/main/resources/distance_measurement_analysis/main.fxml"
-  ],
-  "title": "Distance Measurement Analysis"
+    "category": "Analysis",
+    "description": "Measure distances between two points in 3D.",
+    "ignore": false,
+    "images": [
+        "DistanceMeasurementAnalysis.png"
+    ],
+    "keywords": [
+        "3D",
+        "analysis",
+        "distance",
+        "measure",
+        "AnalysisOverlay",
+        "LocationDistanceMeasurement"
+    ],
+    "redirect_from": [
+        "/java/latest/sample-code/distance-measurement-analysis.htm"
+    ],
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "LocationDistanceMeasurement"
+    ],
+    "snippets": [
+        "DistanceMeasurementAnalysisController.java",
+        "DistanceMeasurementAnalysisLauncher.java",
+        "DistanceMeasurementAnalysisSample.java"
+    ],
+    "title": "Distance measurement analysis"
 }

--- a/analysis/line-of-sight-geoelement/README.metadata.json
+++ b/analysis/line-of-sight-geoelement/README.metadata.json
@@ -3,7 +3,7 @@
     "description": "Show a line of sight between two moving objects.",
     "ignore": false,
     "images": [
-        "LineOfSightGeoElement.png"
+        "LineOfSightGeoElement.gif"
     ],
     "keywords": [
         "3D",
@@ -23,8 +23,7 @@
         "LineOfSight.getTargetVisibility"
     ],
     "snippets": [
-        "LineOfSightGeoElementLauncher.java",
-        "LineOfSightGeoElementSample.java"
+        "src/main/java/com/esri/samples/line_of_sight_geoelement/LineOfSightGeoElementSample.java"
     ],
     "title": "Line of sight geoelement"
 }

--- a/analysis/line-of-sight-geoelement/README.metadata.json
+++ b/analysis/line-of-sight-geoelement/README.metadata.json
@@ -1,22 +1,30 @@
 {
-  "category": "Analysis",
-  "description": "Show a line of sight between two moving objects.",
-  "ignore": false,
-  "images": [
-    "LineOfSightGeoElement.gif"
-  ],
-  "keywords": [],
-  "redirect_from": "/java/latest/sample-code/line-of-sight-geoelement.htm",
-  "relevant_apis": [
-    "ArcGISMapImageLayer",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult",
-    "GeoprocessingString",
-    "GeoprocessingTask"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/line_of_sight_geoelement/LineOfSightGeoElementSample.java"
-  ],
-  "title": "Line of Sight GeoElement"
+    "category": "Analysis",
+    "description": "Show a line of sight between two moving objects.",
+    "ignore": false,
+    "images": [
+        "LineOfSightGeoElement.png"
+    ],
+    "keywords": [
+        "3D",
+        "line of sight",
+        "visibility",
+        "visibility analysis",
+        "AnalysisOverlay",
+        "GeoElementLineOfSight",
+        "LineOfSight.getTargetVisibility"
+    ],
+    "redirect_from": [
+        "/java/latest/sample-code/line-of-sight-geoelement.htm"
+    ],
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "GeoElementLineOfSight",
+        "LineOfSight.getTargetVisibility"
+    ],
+    "snippets": [
+        "LineOfSightGeoElementLauncher.java",
+        "LineOfSightGeoElementSample.java"
+    ],
+    "title": "Line of sight geoelement"
 }

--- a/analysis/line-of-sight-location/README.metadata.json
+++ b/analysis/line-of-sight-location/README.metadata.json
@@ -3,7 +3,7 @@
     "description": "Perform a line of sight analysis between two points in real time.",
     "ignore": false,
     "images": [
-        "LineOfSightLocation.png"
+        "LineOfSightLocation.gif"
     ],
     "keywords": [
         "3D",
@@ -23,8 +23,7 @@
         "SceneView"
     ],
     "snippets": [
-        "LineOfSightLocationLauncher.java",
-        "LineOfSightLocationSample.java"
+        "src/main/java/com/esri/samples/line_of_sight_location/LineOfSightLocationSample.java"
     ],
     "title": "Line of sight location"
 }

--- a/analysis/line-of-sight-location/README.metadata.json
+++ b/analysis/line-of-sight-location/README.metadata.json
@@ -1,22 +1,30 @@
 {
-  "category": "Analysis",
-  "description": "Perform line of sight analysis in real-time.",
-  "ignore": false,
-  "images": [
-    "LineOfSightLocation.gif"
-  ],
-  "keywords": [],
-  "redirect_from": "/java/latest/sample-code/line-of-sight-location.htm",
-  "relevant_apis": [
-    "ArcGISMapImageLayer",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult",
-    "GeoprocessingString",
-    "GeoprocessingTask"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/line_of_sight_location/LineOfSightLocationSample.java"
-  ],
-  "title": "Line of Sight Location"
+    "category": "Analysis",
+    "description": "Perform a line of sight analysis between two points in real time.",
+    "ignore": false,
+    "images": [
+        "LineOfSightLocation.png"
+    ],
+    "keywords": [
+        "3D",
+        "line of sight",
+        "visibility",
+        "visibility analysis",
+        "AnalysisOverlay",
+        "LocationLineOfSight",
+        "SceneView"
+    ],
+    "redirect_from": [
+        "/java/latest/sample-code/line-of-sight-location.htm"
+    ],
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "LocationLineOfSight",
+        "SceneView"
+    ],
+    "snippets": [
+        "LineOfSightLocationLauncher.java",
+        "LineOfSightLocationSample.java"
+    ],
+    "title": "Line of sight location"
 }

--- a/analysis/viewshed-camera/README.metadata.json
+++ b/analysis/viewshed-camera/README.metadata.json
@@ -3,7 +3,7 @@
     "description": "Analyze the viewshed for a camera. A viewshed shows the visible and obstructed areas from an observer's vantage point.",
     "ignore": false,
     "images": [
-        "ViewshedCamera.png"
+        "ViewshedCamera.gif"
     ],
     "keywords": [
         "3D",
@@ -31,8 +31,7 @@
         "SceneView"
     ],
     "snippets": [
-        "ViewshedCameraLauncher.java",
-        "ViewshedCameraSample.java"
+        "src/main/java/com/esri/samples/viewshed_camera/ViewshedCameraSample.java"
     ],
     "title": "Viewshed camera"
 }

--- a/analysis/viewshed-camera/README.metadata.json
+++ b/analysis/viewshed-camera/README.metadata.json
@@ -1,22 +1,38 @@
 {
-  "category": "Analysis",
-  "description": "Create a viewshed using the current camera viewpoint.",
-  "ignore": false,
-  "images": [
-    "ViewshedCamera.gif"
-  ],
-  "keywords": [],
-  "redirect_from": "/java/latest/sample-code/viewshed-camera.htm",
-  "relevant_apis": [
-    "ArcGISMapImageLayer",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult",
-    "GeoprocessingString",
-    "GeoprocessingTask"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/viewshed_camera/ViewshedCameraSample.java"
-  ],
-  "title": "Viewshed Camera"
+    "category": "Analysis",
+    "description": "Analyze the viewshed for a camera. A viewshed shows the visible and obstructed areas from an observer's vantage point.",
+    "ignore": false,
+    "images": [
+        "ViewshedCamera.png"
+    ],
+    "keywords": [
+        "3D",
+        "Scene",
+        "viewshed",
+        "visibility analysis",
+        "AnalysisOverlay",
+        "ArcGISScene",
+        "ArcGISSceneLayer",
+        "ArcGISTiledElevationSource",
+        "Camera",
+        "LocationViewshed",
+        "SceneView"
+    ],
+    "redirect_from": [
+        "/java/latest/sample-code/viewshed-camera.htm"
+    ],
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "ArcGISScene",
+        "ArcGISSceneLayer",
+        "ArcGISTiledElevationSource",
+        "Camera",
+        "LocationViewshed",
+        "SceneView"
+    ],
+    "snippets": [
+        "ViewshedCameraLauncher.java",
+        "ViewshedCameraSample.java"
+    ],
+    "title": "Viewshed camera"
 }

--- a/analysis/viewshed-geoelement/README.metadata.json
+++ b/analysis/viewshed-geoelement/README.metadata.json
@@ -3,7 +3,7 @@
     "description": "Analyze the viewshed for an object (GeoElement) in a scene.",
     "ignore": false,
     "images": [
-        "ViewshedGeoElement.png"
+        "ViewshedGeoElement.gif"
     ],
     "keywords": [
         "3D",
@@ -14,8 +14,8 @@
         "viewshed",
         "visibility analysis",
         "AnalysisOverlay",
-        "GeoElementViewshed",
         "GeodeticDistanceResult",
+        "GeoElementViewshed",
         "GeometryEngine.distanceGeodetic (used to animate the vehicle)",
         "ModelSceneSymbol",
         "OrbitGeoElementCameraController"
@@ -25,15 +25,14 @@
     ],
     "relevant_apis": [
         "AnalysisOverlay",
-        "GeoElementViewshed",
         "GeodeticDistanceResult",
+        "GeoElementViewshed",
         "GeometryEngine.distanceGeodetic (used to animate the vehicle)",
         "ModelSceneSymbol",
         "OrbitGeoElementCameraController"
     ],
     "snippets": [
-        "ViewshedGeoElementLauncher.java",
-        "ViewshedGeoElementSample.java"
+        "src/main/java/com/esri/samples/viewshed_geoelement/ViewshedGeoElementSample.java"
     ],
     "title": "Viewshed geoelement"
 }

--- a/analysis/viewshed-geoelement/README.metadata.json
+++ b/analysis/viewshed-geoelement/README.metadata.json
@@ -16,7 +16,7 @@
         "AnalysisOverlay",
         "GeodeticDistanceResult",
         "GeoElementViewshed",
-        "GeometryEngine.distanceGeodetic (used to animate the vehicle)",
+        "GeometryEngine.distanceGeodetic",
         "ModelSceneSymbol",
         "OrbitGeoElementCameraController"
     ],
@@ -27,7 +27,7 @@
         "AnalysisOverlay",
         "GeodeticDistanceResult",
         "GeoElementViewshed",
-        "GeometryEngine.distanceGeodetic (used to animate the vehicle)",
+        "GeometryEngine.distanceGeodetic",
         "ModelSceneSymbol",
         "OrbitGeoElementCameraController"
     ],

--- a/analysis/viewshed-geoelement/README.metadata.json
+++ b/analysis/viewshed-geoelement/README.metadata.json
@@ -1,22 +1,39 @@
 {
-  "category": "Analysis",
-  "description": "Attach a viewshed to an object to visualize what it sees.",
-  "ignore": false,
-  "images": [
-    "ViewshedGeoElement.gif"
-  ],
-  "keywords": [],
-  "redirect_from": "/java/latest/sample-code/viewshed-geoelement.htm",
-  "relevant_apis": [
-    "ArcGISMapImageLayer",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult",
-    "GeoprocessingString",
-    "GeoprocessingTask"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/viewshed_geoelement/ViewshedGeoElementSample.java"
-  ],
-  "title": "Viewshed GeoElement"
+    "category": "Analysis",
+    "description": "Analyze the viewshed for an object (GeoElement) in a scene.",
+    "ignore": false,
+    "images": [
+        "ViewshedGeoElement.png"
+    ],
+    "keywords": [
+        "3D",
+        "analysis",
+        "buildings",
+        "model",
+        "scene",
+        "viewshed",
+        "visibility analysis",
+        "AnalysisOverlay",
+        "GeoElementViewshed",
+        "GeodeticDistanceResult",
+        "GeometryEngine.distanceGeodetic (used to animate the vehicle)",
+        "ModelSceneSymbol",
+        "OrbitGeoElementCameraController"
+    ],
+    "redirect_from": [
+        "/java/latest/sample-code/viewshed-geoelement.htm"
+    ],
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "GeoElementViewshed",
+        "GeodeticDistanceResult",
+        "GeometryEngine.distanceGeodetic (used to animate the vehicle)",
+        "ModelSceneSymbol",
+        "OrbitGeoElementCameraController"
+    ],
+    "snippets": [
+        "ViewshedGeoElementLauncher.java",
+        "ViewshedGeoElementSample.java"
+    ],
+    "title": "Viewshed geoelement"
 }

--- a/analysis/viewshed-geoprocessing/README.metadata.json
+++ b/analysis/viewshed-geoprocessing/README.metadata.json
@@ -29,8 +29,7 @@
         "GeoprocessingTask"
     ],
     "snippets": [
-        "ViewshedGeoprocessingLauncher.java",
-        "ViewshedGeoprocessingSample.java"
+        "src/main/java/com/esri/samples/viewshed_geoprocessing/ViewshedGeoprocessingSample.java"
     ],
     "title": "Viewshed geoprocessing"
 }

--- a/analysis/viewshed-geoprocessing/README.metadata.json
+++ b/analysis/viewshed-geoprocessing/README.metadata.json
@@ -1,27 +1,36 @@
 {
-  "category": "Analysis",
-  "description": "Calculate a viewshed against terrain using a geoprocessing service.",
-  "ignore": false,
-  "images": [
-    "ViewshedGeoprocessing.png"
-  ],
-  "keywords": [
-    "Geoprocessing",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult"
-  ],
-  "redirect_from": "/java/latest/sample-code/viewshed_geoprocessing.htm",
-  "relevant_apis": [
-    "ArcGISMapImageLayer",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult",
-    "GeoprocessingString",
-    "GeoprocessingTask"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/viewshed_geoprocessing/ViewshedGeoprocessingSample.java"
-  ],
-  "title": "Viewshed Geoprocessing"
+    "category": "Analysis",
+    "description": "Calculate a viewshed using a geoprocessing service, in this case showing what parts of a landscape are visible from points on mountainous terrain.",
+    "ignore": false,
+    "images": [
+        "ViewshedGeoprocessing.png"
+    ],
+    "keywords": [
+        "geoprocessing",
+        "heat map",
+        "heatmap",
+        "viewshed",
+        "FeatureCollectionTable",
+        "GeoprocessingFeatures",
+        "GeoprocessingJob",
+        "GeoprocessingParameters",
+        "GeoprocessingResult",
+        "GeoprocessingTask"
+    ],
+    "redirect_from": [
+        "/java/latest/sample-code/viewshed_geoprocessing.htm"
+    ],
+    "relevant_apis": [
+        "FeatureCollectionTable",
+        "GeoprocessingFeatures",
+        "GeoprocessingJob",
+        "GeoprocessingParameters",
+        "GeoprocessingResult",
+        "GeoprocessingTask"
+    ],
+    "snippets": [
+        "ViewshedGeoprocessingLauncher.java",
+        "ViewshedGeoprocessingSample.java"
+    ],
+    "title": "Viewshed geoprocessing"
 }

--- a/analysis/viewshed-location/README.metadata.json
+++ b/analysis/viewshed-location/README.metadata.json
@@ -28,9 +28,9 @@
         "Viewshed"
     ],
     "snippets": [
-        "ViewshedLocationController.java",
-        "ViewshedLocationLauncher.java",
-        "ViewshedLocationSample.java"
+        "src/main/java/com/esri/samples/viewshed_location/ViewshedLocationController.java",
+        "src/main/java/com/esri/samples/viewshed_location/ViewshedLocationSample.java",
+        "src/main/resources/viewshed_location/main.fxml"
     ],
     "title": "Viewshed location"
 }

--- a/analysis/viewshed-location/README.metadata.json
+++ b/analysis/viewshed-location/README.metadata.json
@@ -1,29 +1,36 @@
 {
-  "category": "Analysis",
-  "description": "Adjust the position, angles, range, and style of a viewshed.",
-  "ignore": false,
-  "images": [
-    "ViewshedLocation.png"
-  ],
-  "keywords": [
-    "Geoprocessing",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult"
-  ],
-  "redirect_from": "/java/latest/sample-code/viewshed-location.htm",
-  "relevant_apis": [
-    "ArcGISMapImageLayer",
-    "GeoprocessingJob",
-    "GeoprocessingParameters",
-    "GeoprocessingResult",
-    "GeoprocessingString",
-    "GeoprocessingTask"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/viewshed_location/ViewshedLocationSample.java",
-    "src/main/java/com/esri/samples/viewshed_location/ViewshedLocationController.java",
-    "src/main/resources/viewshed_location/main.fxml"
-  ],
-  "title": "Viewshed Location"
+    "category": "Analysis",
+    "description": "Perform a viewshed analysis from a defined vantage point.",
+    "ignore": false,
+    "images": [
+        "ViewshedLocation.png"
+    ],
+    "keywords": [
+        "3D",
+        "Scene",
+        "frustum",
+        "viewshed",
+        "visibility analysis",
+        "AnalysisOverlay",
+        "ArcGISSceneLayer",
+        "ArcGISTiledElevationSource",
+        "LocationViewshed",
+        "Viewshed"
+    ],
+    "redirect_from": [
+        "/java/latest/sample-code/viewshed-location.htm"
+    ],
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "ArcGISSceneLayer",
+        "ArcGISTiledElevationSource",
+        "LocationViewshed",
+        "Viewshed"
+    ],
+    "snippets": [
+        "ViewshedLocationController.java",
+        "ViewshedLocationLauncher.java",
+        "ViewshedLocationSample.java"
+    ],
+    "title": "Viewshed location"
 }

--- a/display_information/add-graphics-with-renderer/README.metadata.json
+++ b/display_information/add-graphics-with-renderer/README.metadata.json
@@ -1,6 +1,6 @@
 {
     "category": "Display information",
-    "description": "A renderer allows you to change the style of all graphics in a graphics overlay by referencing a single symbol style. A renderer will only effect graphics that do not specify their own symbol style.",
+    "description": "A renderer allows you to change the style of all graphics in a graphics overlay by referencing a single symbol style. A renderer will only affect graphics that do not specify their own symbol style.",
     "ignore": false,
     "images": [
         "AddGraphicsWithRenderer.png"

--- a/display_information/add-graphics-with-renderer/README.metadata.json
+++ b/display_information/add-graphics-with-renderer/README.metadata.json
@@ -1,28 +1,32 @@
 {
     "category": "Display information",
-    "description": "Specify a graphic's symbol with a renderer.",
+    "description": "A renderer allows you to change the style of all graphics in a graphics overlay by referencing a single symbol style. A renderer will only effect graphics that do not specify their own symbol style.",
     "ignore": false,
     "images": [
         "AddGraphicsWithRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "display",
+        "graphics",
+        "marker",
+        "overlay",
+        "renderer",
+        "symbol",
+        "Geometry",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
-        "Point",
         "SimpleFillSymbol",
         "SimpleLineSymbol",
         "SimpleMarkerSymbol",
         "SimpleRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/add-graphics-with-renderer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/add-graphics-with-renderer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
+        "Geometry",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
-        "Point",
         "SimpleFillSymbol",
         "SimpleLineSymbol",
         "SimpleMarkerSymbol",
@@ -31,5 +35,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/add_graphics_with_renderer/AddGraphicsWithRendererSample.java"
     ],
-    "title": "Add Graphics with Renderer"
+    "title": "Add graphics with renderer"
 }

--- a/display_information/add-graphics-with-symbols/README.metadata.json
+++ b/display_information/add-graphics-with-symbols/README.metadata.json
@@ -1,33 +1,35 @@
 {
     "category": "Display information",
-    "description": "Draw simple graphics with marker, line, polygon, and text symbols.",
+    "description": "Use a symbol style to display a graphic on a graphics overlay.",
     "ignore": false,
     "images": [
         "AddGraphicsWithSymbols.png"
     ],
     "keywords": [
+        "display",
+        "fill",
+        "graphics",
+        "line",
+        "marker",
+        "overlay",
+        "point",
+        "symbol",
+        "Geometry",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
-        "Point",
-        "PointCollection",
-        "Polygon",
-        "Polyline",
-        "SimepleFillSymbol",
+        "SimpleFillSymbol",
         "SimpleLineSymbol",
         "SimpleMarkerSymbol",
         "TextSymbol"
     ],
-    "redirect_from": "/java/latest/sample-code/add-graphics-with-symbols.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/add-graphics-with-symbols.htm"
+    ],
     "relevant_apis": [
+        "Geometry",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
-        "Point",
-        "PointCollection",
-        "Polygon",
-        "Polyline",
-        "SimepleFillSymbol",
+        "SimpleFillSymbol",
         "SimpleLineSymbol",
         "SimpleMarkerSymbol",
         "TextSymbol"
@@ -35,5 +37,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/add_graphics_with_symbols/AddGraphicsWithSymbolsSample.java"
     ],
-    "title": "Add Graphics with Symbols"
+    "title": "Add graphics with symbols"
 }

--- a/display_information/control-annotation-sublayer-visibility/README.metadata.json
+++ b/display_information/control-annotation-sublayer-visibility/README.metadata.json
@@ -6,11 +6,18 @@
         "ControlAnnotationSublayerVisibility.png"
     ],
     "keywords": [
+        "annotation",
         "scale",
         "text",
-        "utilities"
+        "utilities",
+        "visualization",
+        "AnnotationLayer",
+        "AnnotationSublayer",
+        "LayerContent"
     ],
-    "redirect_from": "",
+    "redirect_from": [
+        ""
+    ],
     "relevant_apis": [
         "AnnotationLayer",
         "AnnotationSublayer",

--- a/display_information/dictionary-renderer-graphics-overlay/README.metadata.json
+++ b/display_information/dictionary-renderer-graphics-overlay/README.metadata.json
@@ -1,17 +1,19 @@
 {
     "category": "Display information",
-    "description": "Display mil2525d symbols.",
+    "description": "Create graphics using a local mil2525d style file and an XML file with key/value pairs for each graphic.",
     "ignore": false,
     "images": [
         "DictionaryRendererGraphicsOverlay.png"
     ],
     "keywords": [
-        "dictionary renderer",
-        "dictionary symbol style",
-        "military",
-        "symbol"
+        "visualization",
+        "DictionaryRenderer",
+        "DictionarySymbolStyle",
+        "GraphicsOverlay"
     ],
-    "redirect_from": "/java/latest/sample-code/dictionary-renderer-with-graphics-overlay.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/dictionary-renderer-with-graphics-overlay.htm"
+    ],
     "relevant_apis": [
         "DictionaryRenderer",
         "DictionarySymbolStyle",
@@ -20,5 +22,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/dictionary_renderer_graphics_overlay/DictionaryRendererGraphicsOverlaySample.java"
     ],
-    "title": "Dictionary Renderer with Graphics Overlay"
+    "title": "Dictionary renderer with graphics overlay"
 }

--- a/display_information/display-annotation/README.metadata.json
+++ b/display_information/display-annotation/README.metadata.json
@@ -16,7 +16,7 @@
         "AnnotationLayer",
         "FeatureLayer"
     ],
-    "redirect_from": [""],
+    "redirect_from": "",
     "relevant_apis": [
         "AnnotationLayer",
         "FeatureLayer"

--- a/display_information/display-annotation/README.metadata.json
+++ b/display_information/display-annotation/README.metadata.json
@@ -16,7 +16,7 @@
         "AnnotationLayer",
         "FeatureLayer"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "AnnotationLayer",
         "FeatureLayer"

--- a/display_information/display-annotation/README.metadata.json
+++ b/display_information/display-annotation/README.metadata.json
@@ -1,7 +1,6 @@
 {
     "category": "Display information",
     "description": "Display annotation from a feature service URL.",
-    "formal_name": "DisplayAnnotation",
     "ignore": false,
     "images": [
         "DisplayAnnotation.png"
@@ -13,9 +12,11 @@
         "placement",
         "reference scale",
         "text",
-        "utility"
+        "utility",
+        "AnnotationLayer",
+        "FeatureLayer"
     ],
-    "offline_data": [],
+    "redirect_from": [],
     "relevant_apis": [
         "AnnotationLayer",
         "FeatureLayer"

--- a/display_information/display-grid/README.metadata.json
+++ b/display_information/display-grid/README.metadata.json
@@ -1,11 +1,22 @@
 {
     "category": "Display information",
-    "description": "Display a variety of grids on a map.",
+    "description": "Display coordinate system grids including Latitude/Longitude, MGRS, UTM and USNG on a map view. Also, toggle label visibility and change the color of grid lines and grid labels.",
     "ignore": false,
     "images": [
         "DisplayGrid.png"
     ],
     "keywords": [
+        "MGRS",
+        "USNG",
+        "UTM",
+        "coordinates",
+        "degrees",
+        "graticule",
+        "grid",
+        "latitude",
+        "longitude",
+        "minutes",
+        "seconds",
         "Grid",
         "LatitudeLongitudeGrid",
         "LineSymbol",
@@ -16,7 +27,9 @@
         "UsngGrid",
         "UtmGrid"
     ],
-    "redirect_from": "/java/latest/sample-code/display-grid.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/display-grid.htm"
+    ],
     "relevant_apis": [
         "Grid",
         "LatitudeLongitudeGrid",
@@ -29,9 +42,9 @@
         "UtmGrid"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/display_grid/DisplayGridSample.java",
         "src/main/java/com/esri/samples/display_grid/DisplayGridController.java",
+        "src/main/java/com/esri/samples/display_grid/DisplayGridSample.java",
         "src/main/resources/display_grid/main.fxml"
     ],
-    "title": "Display Grid"
+    "title": "Display grid"
 }

--- a/display_information/format-coordinates/README.metadata.json
+++ b/display_information/format-coordinates/README.metadata.json
@@ -1,29 +1,30 @@
 {
     "category": "Display information",
-    "description": "Write coordinates in a variety of common formats.",
+    "description": "Format coordinates in a variety of common notations.",
     "ignore": false,
     "images": [
         "FormatCoordinates.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "ArcGISTiledLayer",
-        "Basemap",
-        "Callout",
-        "CoordinateFormatter",
-        "MapView"
+        "USNG",
+        "UTM",
+        "convert",
+        "coordinate",
+        "decimal degrees",
+        "degree minutes seconds",
+        "format",
+        "latitude",
+        "longitude",
+        "CoordinateFormatter"
     ],
-    "redirect_from": "/java/latest/sample-code/format-coordinates.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/format-coordinates.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "ArcGISTiledLayer",
-        "Basemap",
-        "Callout",
-        "CoordinateFormatter",
-        "MapView"
+        "CoordinateFormatter"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/format_coordinates/FormatCoordinatesSample.java"
     ],
-    "title": "Format Coordinates"
+    "title": "Format coordinates"
 }

--- a/display_information/identify-graphics/README.metadata.json
+++ b/display_information/identify-graphics/README.metadata.json
@@ -1,29 +1,29 @@
 {
     "category": "Display information",
-    "description": "Determine if a graphic was clicked.",
+    "description": "Identify a graphic to get further information about the object.",
     "ignore": false,
     "images": [
         "IdentifyGraphics.png"
     ],
     "keywords": [
+        "graphics",
+        "identify",
         "Graphic",
         "GraphicsOverlay",
         "MapView",
-        "PointCollection",
-        "Polygon",
-        "SimpleFillSymbol"
+        "Point"
     ],
-    "redirect_from": "/java/latest/sample-code/identify-graphics.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/identify-graphics.htm"
+    ],
     "relevant_apis": [
         "Graphic",
         "GraphicsOverlay",
         "MapView",
-        "PointCollection",
-        "Polygon",
-        "SimpleFillSymbol"
+        "Point"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/identify_graphics/IdentifyGraphicsSample.java"
     ],
-    "title": "Identify Graphics"
+    "title": "Identify graphics"
 }

--- a/display_information/show-callout/README.md
+++ b/display_information/show-callout/README.md
@@ -26,7 +26,6 @@ Click anywhere on the map. A callout showing the WGS84 coordinates for the click
 * Callout
 * MapView
 * Point
-* Point2D
 
 ## Tags
 

--- a/display_information/show-callout/README.metadata.json
+++ b/display_information/show-callout/README.metadata.json
@@ -1,25 +1,33 @@
 {
     "category": "Display information",
-    "description": "Show a callout at the clicked location.",
+    "description": "Show a callout with the latitude and longitude of user-clicked points.",
     "ignore": false,
     "images": [
         "ShowCallout.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "balloon",
+        "bubble",
+        "callout",
+        "click",
+        "flyout",
+        "flyover",
+        "info window",
+        "popup",
         "Callout",
         "MapView",
-        "Point"
+        "Point",
+        "Point2D"
     ],
-    "redirect_from": "/java/latest/sample-code/show-callout.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/show-callout.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Callout",
         "MapView",
-        "Point"
+        "Point",
+        "Point2D"
     ],
-    "snippets": [
-        "src/main/java/com/esri/samples/show_callout/ShowCalloutSample.java"
-    ],
-    "title": "Show Callout"
+    "snippets": [],
+    "title": "Show callout"
 }

--- a/display_information/show-callout/README.metadata.json
+++ b/display_information/show-callout/README.metadata.json
@@ -16,8 +16,7 @@
         "popup",
         "Callout",
         "MapView",
-        "Point",
-        "Point2D"
+        "Point"
     ],
     "redirect_from": [
         "/java/latest/sample-code/show-callout.htm"
@@ -28,6 +27,8 @@
         "Point",
         "Point2D"
     ],
-    "snippets": [],
+    "snippets": [
+        "src/main/java/com/esri/samples/show_callout/ShowCalloutSample.java"
+    ],
     "title": "Show callout"
 }

--- a/display_information/show-labels-on-layer/README.md
+++ b/display_information/show-labels-on-layer/README.md
@@ -1,4 +1,4 @@
-# Show labels on layers
+# Show labels on layer
 
 Display custom labels on a feature layer.
 

--- a/display_information/show-labels-on-layer/README.metadata.json
+++ b/display_information/show-labels-on-layer/README.metadata.json
@@ -29,5 +29,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/show_labels_on_layer/ShowLabelsOnLayerSample.java"
     ],
-    "title": "Show labels on layers"
+    "title": "Show labels on layer"
 }

--- a/display_information/show-labels-on-layer/README.metadata.json
+++ b/display_information/show-labels-on-layer/README.metadata.json
@@ -1,16 +1,26 @@
 {
     "category": "Display information",
-    "description": "Add custom labels to a layer.",
+    "description": "Display custom labels on a feature layer.",
     "ignore": false,
     "images": [
         "ShowLabelsOnLayer.png"
     ],
     "keywords": [
+        "attribute",
+        "deconfliction",
+        "label",
+        "labeling",
+        "string",
+        "symbol",
+        "text",
+        "visualization",
         "FeatureLayer",
         "LabelDefinition",
         "TextSymbol"
     ],
-    "redirect_from": "/java/latest/sample-code/show-labels-on-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/show-labels-on-layer.htm"
+    ],
     "relevant_apis": [
         "FeatureLayer",
         "LabelDefinition",
@@ -19,5 +29,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/show_labels_on_layer/ShowLabelsOnLayerSample.java"
     ],
-    "title": "Show Labels on Layer"
+    "title": "Show labels on layers"
 }

--- a/display_information/sketch-on-map/README.metadata.json
+++ b/display_information/sketch-on-map/README.metadata.json
@@ -1,6 +1,6 @@
 {
     "category": "Display information",
-    "description": "Use the Sketch Editor to edit, or sketch a new point, line, or polygon geometry on to a map.",
+    "description": "Use the Sketch Editor to edit or sketch a new point, line, or polygon geometry on to a map.",
     "ignore": false,
     "images": [
         "SketchOnMap.png"
@@ -11,16 +11,13 @@
         "Geometry",
         "Graphic",
         "GraphicsOverlay",
-        "SketchCreationMode",
-        "SketchEditor",
-        "Geometry",
-        "Graphic",
-        "GraphicsOverlay",
         "MapView",
         "SketchCreationMode",
         "SketchEditor"
     ],
-    "redirect_from": "/java/latest/sample-code/sketch-on-map.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/sketch-on-map.htm"
+    ],
     "relevant_apis": [
         "Geometry",
         "Graphic",
@@ -30,9 +27,9 @@
         "SketchEditor"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/sketch_on_map/SketchOnMapSample.java",
         "src/main/java/com/esri/samples/sketch_on_map/SketchOnMapController.java",
+        "src/main/java/com/esri/samples/sketch_on_map/SketchOnMapSample.java",
         "src/main/resources/sketch_on_map/main.fxml"
     ],
-    "title": "Sketch on Map"
+    "title": "Sketch on map"
 }

--- a/display_information/update-graphics/README.md
+++ b/display_information/update-graphics/README.md
@@ -1,4 +1,4 @@
-# Update Graphics
+# Update graphics
 
 Change a graphic's symbol, attributes, and geometry.
 

--- a/display_information/update-graphics/README.metadata.json
+++ b/display_information/update-graphics/README.metadata.json
@@ -33,5 +33,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/update_graphics/UpdateGraphicsSample.java"
     ],
-    "title": "Update Graphics"
+    "title": "Update graphics"
 }

--- a/display_information/update-graphics/README.metadata.json
+++ b/display_information/update-graphics/README.metadata.json
@@ -6,13 +6,23 @@
         "UpdateGraphics.gif"
     ],
     "keywords": [
+        "adjust",
+        "attributes",
+        "description",
+        "geometry",
+        "location",
+        "marker",
+        "modify",
+        "symbol",
         "ArcGISMap",
         "Graphic",
         "GraphicsOverlay",
         "MapView",
         "SimpleMarkerSymbol"
     ],
-    "redirect_from": "/java/latest/sample-code/update-graphics.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/update-graphics.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "Graphic",

--- a/editing/add-features/README.metadata.json
+++ b/editing/add-features/README.metadata.json
@@ -1,29 +1,30 @@
 {
     "category": "Editing",
-    "description": "Add new features to an online feature service.",
+    "description": "Add features to a feature layer.",
     "ignore": false,
     "images": [
         "AddFeatures.gif"
     ],
     "keywords": [
-        "ArcGISMap",
+        "edit",
+        "feature",
+        "online service",
         "Feature",
         "FeatureEditResult",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/add-features.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/add-features.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Feature",
         "FeatureEditResult",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/add_features/AddFeaturesSample.java"
     ],
-    "title": "Add Features"
+    "title": "Add features"
 }

--- a/editing/delete-features/README.metadata.json
+++ b/editing/delete-features/README.metadata.json
@@ -6,22 +6,25 @@
         "DeleteFeatures.gif"
     ],
     "keywords": [
-        "ArcGISMap",
+        "Service",
+        "deletion",
+        "feature",
+        "online",
+        "table",
         "Feature",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/delete-features.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/delete-features.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Feature",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java"
     ],
-    "title": "Delete Features"
+    "title": "Delete features"
 }

--- a/editing/edit-and-sync-features/README.metadata.json
+++ b/editing/edit-and-sync-features/README.metadata.json
@@ -19,7 +19,9 @@
         "SyncGeodatabaseParameters",
         "SyncLayerOption"
     ],
-    "redirect_from": "/java/latest/sample-code/edit-and-sync-features.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/edit-and-sync-features.htm"
+    ],
     "relevant_apis": [
         "FeatureLayer",
         "FeatureTable",
@@ -31,8 +33,8 @@
         "SyncLayerOption"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/edit_and_sync_features/EditAndSyncFeaturesSample.java",
         "src/main/java/com/esri/samples/edit_and_sync_features/EditAndSyncFeaturesController.java",
+        "src/main/java/com/esri/samples/edit_and_sync_features/EditAndSyncFeaturesSample.java",
         "src/main/resources/edit_and_sync_features/main.fxml"
     ],
     "title": "Edit and sync features"

--- a/editing/edit-feature-attachments/README.metadata.json
+++ b/editing/edit-feature-attachments/README.metadata.json
@@ -1,31 +1,32 @@
 {
     "category": "Editing",
-    "description": "Add or remove feature attachments.",
+    "description": "Add, delete, and download attachments for features from a service.",
     "ignore": false,
     "images": [
         "EditFeatureAttachments.gif"
     ],
     "keywords": [
+        "Edit and Manage Data",
+        "JPEG",
+        "PDF",
+        "PNG",
+        "TXT",
+        "image",
+        "picture",
         "ArcGISFeature",
-        "ArcGISMap",
-        "Attachment",
-        "Feature",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/edit-feature-attachments.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/edit-feature-attachments.htm"
+    ],
     "relevant_apis": [
         "ArcGISFeature",
-        "ArcGISMap",
-        "Attachment",
-        "Feature",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java"
     ],
-    "title": "Edit Feature Attachments"
+    "title": "Edit feature attachments"
 }

--- a/editing/update-attributes/README.metadata.json
+++ b/editing/update-attributes/README.metadata.json
@@ -6,22 +6,28 @@
         "UpdateAttributes.gif"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Feature",
+        "amend",
+        "attribute",
+        "details",
+        "edit",
+        "editing",
+        "information",
+        "update",
+        "value",
+        "ArcGISFeature",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/update-attributes.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/update-attributes.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Feature",
+        "ArcGISFeature",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java"
     ],
-    "title": "Update Attributes"
+    "title": "Update attributes"
 }

--- a/editing/update-geometries/README.metadata.json
+++ b/editing/update-geometries/README.metadata.json
@@ -6,22 +6,26 @@
         "UpdateGeometries.gif"
     ],
     "keywords": [
-        "ArcGISMap",
+        "editing",
+        "feature layer",
+        "feature table",
+        "moving",
+        "service",
+        "updating",
         "Feature",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/update-geometries.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/update-geometries.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Feature",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java"
     ],
-    "title": "Update Geometries"
+    "title": "Update geometries (feature service)"
 }

--- a/feature_layers/change-feature-layer-renderer/README.metadata.json
+++ b/feature_layers/change-feature-layer-renderer/README.metadata.json
@@ -1,29 +1,28 @@
 {
     "category": "Feature layers",
-    "description": "Change how a feature layer looks with a renderer.",
+    "description": "Change the appearance of a feature layer with a renderer.",
     "ignore": false,
     "images": [
         "ChangeFeatureLayerRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "feature layer",
+        "renderer",
+        "visualization",
         "FeatureLayer",
-        "MapView",
-        "Renderer",
         "ServiceFeatureTable",
         "SimpleRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/change-feature-layer-renderer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/change-feature-layer-renderer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "FeatureLayer",
-        "MapView",
-        "Renderer",
         "ServiceFeatureTable",
         "SimpleRenderer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/change_feature_layer_renderer/ChangeFeatureLayerRendererSample.java"
     ],
-    "title": "Change Feature Layer Renderer"
+    "title": "Change feature layer renderer"
 }

--- a/feature_layers/display-subtype-feature-layer/README.metadata.json
+++ b/feature_layers/display-subtype-feature-layer/README.metadata.json
@@ -19,7 +19,7 @@
         "SubtypeFeatureLayer",
         "SubtypeSublayer"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "LabelDefinition",
         "ServiceFeatureTable",

--- a/feature_layers/display-subtype-feature-layer/README.metadata.json
+++ b/feature_layers/display-subtype-feature-layer/README.metadata.json
@@ -1,30 +1,35 @@
 {
-  "category": "Feature layers",
-  "description": "Display a composite layer of all the subtype values in a feature class.",
-  "ignore": false,
-  "images": [
-    "DisplaySubtypeFeatureLayer.png"
-  ],
-  "keywords": [
-    "asset group",
-    "feature layer",
-    "labeling",
-    "sublayer",
-    "subtype",
-    "symbology",
-    "utility network",
-    "visible scale range"
-  ],
-  "relevant_apis": [
-    "LabelDefinition",
-    "ServiceFeatureTable",
-    "SubtypeFeatureLayer",
-    "SubtypeSublayer"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/display_subtype_feature_layer/DisplaySubtypeFeatureLayerSample.java",
-    "src/main/java/com/esri/samples/display_subtype_feature_layer/DisplaySubtypeFeatureLayerController.java",
-    "src/main/resources/display_subtype_feature_layer/main.fxml"
-  ],
-  "title": "Display subtype feature layer"
+    "category": "Feature layers",
+    "description": "Displays a composite layer of all the subtype values in a feature class.",
+    "ignore": false,
+    "images": [
+        "DisplaySubtypeFeatureLayer.png"
+    ],
+    "keywords": [
+        "asset group",
+        "feature layer",
+        "labeling",
+        "sublayer",
+        "subtype",
+        "symbology",
+        "utility network",
+        "visible scale range",
+        "LabelDefinition",
+        "ServiceFeatureTable",
+        "SubtypeFeatureLayer",
+        "SubtypeSublayer"
+    ],
+    "redirect_from": [],
+    "relevant_apis": [
+        "LabelDefinition",
+        "ServiceFeatureTable",
+        "SubtypeFeatureLayer",
+        "SubtypeSublayer"
+    ],
+    "snippets": [
+        "src/main/java/com/esri/samples/display_subtype_feature_layer/DisplaySubtypeFeatureLayerController.java",
+        "src/main/java/com/esri/samples/display_subtype_feature_layer/DisplaySubtypeFeatureLayerSample.java",
+        "src/main/resources/display_subtype_feature_layer/main.fxml"
+    ],
+    "title": "Display subtype feature layer"
 }

--- a/feature_layers/display-subtype-feature-layer/README.metadata.json
+++ b/feature_layers/display-subtype-feature-layer/README.metadata.json
@@ -19,7 +19,7 @@
         "SubtypeFeatureLayer",
         "SubtypeSublayer"
     ],
-    "redirect_from": [""],
+    "redirect_from": "",
     "relevant_apis": [
         "LabelDefinition",
         "ServiceFeatureTable",

--- a/feature_layers/feature-collection-layer-from-portal/README.metadata.json
+++ b/feature_layers/feature-collection-layer-from-portal/README.metadata.json
@@ -19,7 +19,7 @@
         "Portal",
         "PortalItem"
     ],
-    "redirect_from": [""],
+    "redirect_from": "",
     "relevant_apis": [
         "Feature",
         "FeatureCollection",

--- a/feature_layers/feature-collection-layer-from-portal/README.metadata.json
+++ b/feature_layers/feature-collection-layer-from-portal/README.metadata.json
@@ -6,16 +6,22 @@
         "FeatureCollectionLayerFromPortal.png"
     ],
     "keywords": [
-        "collection", 
-        "feature collection", 
-        "feature collection layer", 
-        "id", 
-        "item", 
-        "map",
-        "notes",
-        "portal"
+        "collection",
+        "feature collection",
+        "feature collection layer",
+        "id",
+        "item",
+        "map notes",
+        "portal",
+        "Feature",
+        "FeatureCollection",
+        "FeatureCollectionLayer",
+        "Portal",
+        "PortalItem"
     ],
+    "redirect_from": [],
     "relevant_apis": [
+        "Feature",
         "FeatureCollection",
         "FeatureCollectionLayer",
         "Portal",
@@ -24,5 +30,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/feature_collection_layer_from_portal/FeatureCollectionLayerFromPortalSample.java"
     ],
-    "title": "Feature Collection Layer from Portal"
+    "title": "Feature Collection Layer From Portal"
 }

--- a/feature_layers/feature-collection-layer-from-portal/README.metadata.json
+++ b/feature_layers/feature-collection-layer-from-portal/README.metadata.json
@@ -19,7 +19,7 @@
         "Portal",
         "PortalItem"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "Feature",
         "FeatureCollection",

--- a/feature_layers/feature-collection-layer-query/README.metadata.json
+++ b/feature_layers/feature-collection-layer-query/README.metadata.json
@@ -1,38 +1,39 @@
 {
     "category": "Feature layers",
-    "description": "Create a feature collection layer which shows the result of a SQL query from a service feature table.",
+    "description": "Create a feature collection layer to show a query result from a service feature table.",
     "ignore": false,
     "images": [
         "FeatureCollectionLayerQuery.png"
     ],
     "keywords": [
-        "FeatureQueryResult",
-        "FeatureCollection",
-        "FeatureCollectionLayer",
-        "FeatureCollectionTable",
+        "layer",
         "query",
+        "search",
+        "table",
         "FeatureCollection",
         "FeatureCollectionLayer",
         "FeatureCollectionTable",
         "FeatureLayer",
-        "FeatureTable",
         "FeatureQueryResult",
+        "FeatureTable",
         "QueryParameters",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-collection-layer-query.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-collection-layer-query.htm"
+    ],
     "relevant_apis": [
         "FeatureCollection",
         "FeatureCollectionLayer",
         "FeatureCollectionTable",
         "FeatureLayer",
-        "FeatureTable",
         "FeatureQueryResult",
+        "FeatureTable",
         "QueryParameters",
         "ServiceFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_collection_layer_query/FeatureCollectionLayerQuerySample.java"
     ],
-    "title": "Feature Collection Layer Query"
+    "title": "Feature collection layer query"
 }

--- a/feature_layers/feature-collection-layer/README.metadata.json
+++ b/feature_layers/feature-collection-layer/README.metadata.json
@@ -1,35 +1,35 @@
 {
     "category": "Feature layers",
-    "description": "Combine feature tables with different geometries into a single layer.",
+    "description": "Create a feature collection layer from a feature collection table, and add it to a map.",
     "ignore": false,
     "images": [
         "FeatureCollectionLayer.png"
     ],
     "keywords": [
+        "collection",
+        "feature",
+        "layers",
+        "table",
+        "ArcGISFeature",
         "FeatureCollection",
         "FeatureCollectionLayer",
         "FeatureCollectionTable",
-        "Feature",
         "Field",
-        "SimpleFillSymbol",
-        "SimpleLineSymbol",
-        "SimpleMarkerSymbol",
         "SimpleRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-collection-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-collection-layer.htm"
+    ],
     "relevant_apis": [
+        "ArcGISFeature",
         "FeatureCollection",
         "FeatureCollectionLayer",
         "FeatureCollectionTable",
-        "Feature",
         "Field",
-        "SimpleFillSymbol",
-        "SimpleLineSymbol",
-        "SimpleMarkerSymbol",
         "SimpleRenderer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_collection_layer/FeatureCollectionLayerSample.java"
     ],
-    "title": "Feature Collection Layer"
+    "title": "Feature collection layer"
 }

--- a/feature_layers/feature-layer-definition-expression/README.metadata.json
+++ b/feature_layers/feature-layer-definition-expression/README.metadata.json
@@ -1,25 +1,30 @@
 {
     "category": "Feature layers",
-    "description": "Filter which features are shown using an expression.",
+    "description": "Limit the features displayed on a map with a definition expression.",
     "ignore": false,
     "images": [
-        "FeatureLayerDefinitionExpression.gif"
+        "FeatureLayerDefinitionExpression.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "SQL",
+        "definition expression",
+        "filter",
+        "limit data",
+        "query",
+        "restrict data",
+        "where clause",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-layer-definition-expression.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-layer-definition-expression.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_definition_expression/FeatureLayerDefinitionExpressionSample.java"
     ],
-    "title": "Feature Layer Definition Expression"
+    "title": "Feature layer definition expression"
 }

--- a/feature_layers/feature-layer-dictionary-renderer/README.metadata.json
+++ b/feature_layers/feature-layer-dictionary-renderer/README.metadata.json
@@ -6,30 +6,21 @@
         "FeatureLayerDictionaryRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "dictionary",
+        "military",
+        "symbol",
         "DictionaryRenderer",
-        "Envelope",
-        "FeatureLayer",
-        "Geodatabase",
-        "GeometryEngine",
-        "MapView",
-        "SymbolDictionary"
+        "DictionarySymbolStyle"
     ],
-    "redirect_from": "/java/latest/sample-code/dictionary-renderer-with-feature-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/dictionary-renderer-with-feature-layer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "DictionaryRenderer",
-        "Envelope",
-        "FeatureLayer",
-        "Geodatabase",
-        "GeometryEngine",
-        "MapView",
-        "SymbolDictionary"
+        "DictionarySymbolStyle"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java"
     ],
-    "title": "Dictionary Renderer with Feature Layer"
+    "title": "Dictionary renderer with feature layer"
 }

--- a/feature_layers/feature-layer-extrusion/README.metadata.json
+++ b/feature_layers/feature-layer-extrusion/README.metadata.json
@@ -6,20 +6,35 @@
         "FeatureLayerExtrusion.gif"
     ],
     "keywords": [
+        "3D",
+        "extrude",
+        "extrusion",
+        "extrusion expression",
+        "height",
+        "renderer",
+        "scene",
+        "ExtrusionExpression",
+        "ExtrusionMode",
+        "FeatureLayer",
         "FeatureLayer",
         "SceneProperties",
         "ServiceFeatureTable",
-        "FeatureLayer"
+        "SimpleRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-layer-extrusion.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-layer-extrusion.htm"
+    ],
     "relevant_apis": [
+        "ExtrusionExpression",
+        "ExtrusionMode",
+        "FeatureLayer",
         "FeatureLayer",
         "SceneProperties",
         "ServiceFeatureTable",
-        "FeatureLayer"
+        "SimpleRenderer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_extrusion/FeatureLayerExtrusionSample.java"
     ],
-    "title": "Feature Layer Extrusion"
+    "title": "Feature layer extrusion"
 }

--- a/feature_layers/feature-layer-feature-service/README.metadata.json
+++ b/feature_layers/feature-layer-feature-service/README.metadata.json
@@ -3,17 +3,25 @@
     "description": "Show features from an online feature service.",
     "ignore": false,
     "images": [
-        "FeatureLayerFeatureService.png"
+        "screenshot.png"
     ],
     "keywords": [
+        "feature table",
+        "layer",
+        "layers",
+        "service",
         "ArcGISMap",
+        "Basemap",
         "FeatureLayer",
         "MapView",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-layer-feature-service.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-layer-feature-service.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
+        "Basemap",
         "FeatureLayer",
         "MapView",
         "ServiceFeatureTable"
@@ -21,5 +29,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_feature_service/FeatureLayerFeatureServiceSample.java"
     ],
-    "title": "Feature Layer Feature Service"
+    "title": "Feature layer (feature service)"
 }

--- a/feature_layers/feature-layer-geodatabase/README.metadata.json
+++ b/feature_layers/feature-layer-geodatabase/README.metadata.json
@@ -6,24 +6,23 @@
         "FeatureLayerGeodatabase.png"
     ],
     "keywords": [
-        "Basemap",
+        "geodatabase",
+        "mobile",
+        "offline",
         "FeatureLayer",
         "Geodatabase",
-        "GeodatabaseFeatureTable",
-        "Map",
-        "MapView"
+        "GeodatabaseFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-layer-geodatabase-.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-layer-geodatabase-.htm"
+    ],
     "relevant_apis": [
-        "Basemap",
         "FeatureLayer",
         "Geodatabase",
-        "GeodatabaseFeatureTable",
-        "Map",
-        "MapView"
+        "GeodatabaseFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_geodatabase/FeatureLayerGeodatabaseSample.java"
     ],
-    "title": "Feature Layer (Geodatabase)"
+    "title": "Feature layer (geodatabase)"
 }

--- a/feature_layers/feature-layer-geopackage/README.metadata.json
+++ b/feature_layers/feature-layer-geopackage/README.metadata.json
@@ -6,24 +6,28 @@
         "FeatureLayerGeoPackage.png"
     ],
     "keywords": [
+        "OGC",
+        "feature table",
+        "geopackage",
+        "gpkg",
+        "package",
+        "standards",
         "ArcGISMap",
-        "Basemap",
         "FeatureLayer",
         "GeoPackage",
-        "GeoPackageFeatureTable",
-        "MapView"
+        "GeoPackageFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-layer-geopackage.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-layer-geopackage.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
-        "Basemap",
         "FeatureLayer",
         "GeoPackage",
-        "GeoPackageFeatureTable",
-        "MapView"
+        "GeoPackageFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_geopackage/FeatureLayerGeoPackageSample.java"
     ],
-    "title": "Feature Layer GeoPackage"
+    "title": "Feature layer (GeoPackage)"
 }

--- a/feature_layers/feature-layer-query/README.metadata.json
+++ b/feature_layers/feature-layer-query/README.metadata.json
@@ -1,29 +1,28 @@
 {
     "category": "Feature layers",
-    "description": "Find features matching a SQL query.",
+    "description": "Find features in a feature table which match an SQL query.",
     "ignore": false,
     "images": [
         "FeatureLayerQuery.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "search",
         "FeatureLayer",
         "FeatureQueryResult",
-        "MapView",
         "QueryParameters",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-layer-query.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-layer-query.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "FeatureLayer",
         "FeatureQueryResult",
-        "MapView",
         "QueryParameters",
         "ServiceFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_query/FeatureLayerQuerySample.java"
     ],
-    "title": "Feature Layer Query"
+    "title": "Feature layer query"
 }

--- a/feature_layers/feature-layer-rendering-mode-map/README.metadata.json
+++ b/feature_layers/feature-layer-rendering-mode-map/README.metadata.json
@@ -1,35 +1,32 @@
 {
     "category": "Feature layers",
-    "description": "Render features statically or dynamically.",
+    "description": "Render features statically or dynamically by setting the feature layer rendering mode.",
     "ignore": false,
     "images": [
         "FeatureLayerRenderingModeMap.gif"
     ],
     "keywords": [
+        "dynamic",
+        "feature layer",
+        "features",
+        "rendering",
+        "static",
         "ArcGISMap",
         "FeatureLayer",
-        "FeatureLayer.RenderingMode",
         "LoadSettings",
-        "Point",
-        "Polyline",
-        "Polygon",
-        "ServiceFeatureTable",
-        "Viewpoint"
+        "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-layer-rendering-mode-map-.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-layer-rendering-mode-map-.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "FeatureLayer",
-        "FeatureLayer.RenderingMode",
         "LoadSettings",
-        "Point",
-        "Polyline",
-        "Polygon",
-        "ServiceFeatureTable",
-        "Viewpoint"
+        "MapView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_rendering_mode_map/FeatureLayerRenderingModeMapSample.java"
     ],
-    "title": "Feature Layer Rendering Mode (Map)"
+    "title": "Feature layer rendering mode (map)"
 }

--- a/feature_layers/feature-layer-selection/README.metadata.json
+++ b/feature_layers/feature-layer-selection/README.metadata.json
@@ -1,27 +1,30 @@
 {
     "category": "Feature layers",
-    "description": "Select clicked features.",
+    "description": "Select features in a feature layer.",
     "ignore": false,
     "images": [
         "FeatureLayerSelection.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "features",
+        "layers",
+        "select",
+        "selection",
+        "tolerance",
         "Feature",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-layer-selection.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-layer-selection.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Feature",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_selection/FeatureLayerSelectionSample.java"
     ],
-    "title": "Feature Layer Selection"
+    "title": "Feature layer selection"
 }

--- a/feature_layers/feature-layer-shapefile/README.metadata.json
+++ b/feature_layers/feature-layer-shapefile/README.metadata.json
@@ -1,15 +1,21 @@
 {
     "category": "Feature layers",
-    "description": "Display features from a local shapefile.",
+    "description": "Open a shapefile stored on the device and display it as a feature layer with default symbology.",
     "ignore": false,
     "images": [
         "FeatureLayerShapefile.png"
     ],
     "keywords": [
+        "Layers",
+        "shapefile",
+        "shp",
+        "vector",
         "FeatureLayer",
         "ShapefileFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-layer-shapefile.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-layer-shapefile.htm"
+    ],
     "relevant_apis": [
         "FeatureLayer",
         "ShapefileFeatureTable"
@@ -17,5 +23,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_shapefile/FeatureLayerShapefileSample.java"
     ],
-    "title": "Feature Layer Shapefile"
+    "title": "Feature layer shapefile"
 }

--- a/feature_layers/generate-geodatabase/README.metadata.json
+++ b/feature_layers/generate-geodatabase/README.metadata.json
@@ -6,26 +6,26 @@
         "GenerateGeodatabase.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "FeatureLayer",
-        "Geodatabase",
+        "disconnected",
+        "local geodatabase",
+        "offline",
+        "sync",
         "GenerateGeodatabaseJob",
         "GenerateGeodatabaseParameters",
-        "MapView",
-        "ServiceFeatureTable"
+        "Geodatabase",
+        "GeodatabaseSyncTask"
     ],
-    "redirect_from": "/java/latest/sample-code/generate-geodatabase.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/generate-geodatabase.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "FeatureLayer",
-        "Geodatabase",
         "GenerateGeodatabaseJob",
         "GenerateGeodatabaseParameters",
-        "MapView",
-        "ServiceFeatureTable"
+        "Geodatabase",
+        "GeodatabaseSyncTask"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/generate_geodatabase/GenerateGeodatabaseSample.java"
     ],
-    "title": "Generate Geodatabase"
+    "title": "Generate geodatabase"
 }

--- a/feature_layers/list-related-features/README.metadata.json
+++ b/feature_layers/list-related-features/README.metadata.json
@@ -1,35 +1,35 @@
 {
     "category": "Feature layers",
-    "description": "Find features related to the selected feature.",
+    "description": "List features related to the selected feature.",
     "ignore": false,
     "images": [
         "ListRelatedFeatures.png"
     ],
     "keywords": [
+        "features",
+        "identify",
+        "query",
+        "related",
+        "relationship",
+        "search",
         "ArcGISFeature",
         "ArcGISFeatureTable",
-        "ArcGISMap",
-        "Feature",
-        "FeatureLayer",
         "FeatureQueryResult",
         "FeatureTable",
-        "MapView",
         "RelatedFeatureQueryResult"
     ],
-    "redirect_from": "/java/latest/sample-code/list-related-features.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/list-related-features.htm"
+    ],
     "relevant_apis": [
         "ArcGISFeature",
         "ArcGISFeatureTable",
-        "ArcGISMap",
-        "Feature",
-        "FeatureLayer",
         "FeatureQueryResult",
         "FeatureTable",
-        "MapView",
         "RelatedFeatureQueryResult"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/list_related_features/ListRelatedFeaturesSample.java"
     ],
-    "title": "List Related Features"
+    "title": "List related features"
 }

--- a/feature_layers/service-feature-table-cache/README.metadata.json
+++ b/feature_layers/service-feature-table-cache/README.metadata.json
@@ -1,27 +1,28 @@
 {
     "category": "Feature layers",
-    "description": "Cache features on the client when the user interacts.",
+    "description": "Display a feature layer from a service using the **on interaction cache** feature request mode.",
     "ignore": false,
     "images": [
         "ServiceFeatureTableCache.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "cache",
+        "feature request mode",
+        "performance",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable",
         "ServiceFeatureTable.FeatureRequestMode"
     ],
-    "redirect_from": "/java/latest/sample-code/service-feature-table-cache-.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/service-feature-table-cache-.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable",
         "ServiceFeatureTable.FeatureRequestMode"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/service_feature_table_cache/ServiceFeatureTableCacheSample.java"
     ],
-    "title": "Service Feature Table (Cache)"
+    "title": "Service feature table (cache)"
 }

--- a/feature_layers/service-feature-table-manual-cache/README.metadata.json
+++ b/feature_layers/service-feature-table-manual-cache/README.metadata.json
@@ -1,27 +1,28 @@
 {
     "category": "Feature layers",
-    "description": "Request features on demand.",
+    "description": "Display a feature layer from a service using the **manual cache** feature request mode.",
     "ignore": false,
     "images": [
         "ServiceFeatureTableManualCache.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "cache",
+        "feature request mode",
+        "performance",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable",
         "ServiceFeatureTable.FeatureRequestMode"
     ],
-    "redirect_from": "/java/latest/sample-code/service-feature-table-manual-cache-.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/service-feature-table-manual-cache-.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable",
         "ServiceFeatureTable.FeatureRequestMode"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/service_feature_table_manual_cache/ServiceFeatureTableManualCacheSample.java"
     ],
-    "title": "Service Feature Table (Manual Cache)"
+    "title": "Service feature table (manual cache)"
 }

--- a/feature_layers/service-feature-table-no-cache/README.metadata.json
+++ b/feature_layers/service-feature-table-no-cache/README.metadata.json
@@ -1,27 +1,28 @@
 {
     "category": "Feature layers",
-    "description": "Show features without caching.",
+    "description": "Display a feature layer from a service using the **no cache** feature request mode.",
     "ignore": false,
     "images": [
         "ServiceFeatureTableNoCache.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "cache",
+        "feature request mode",
+        "performance",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable",
         "ServiceFeatureTable.FeatureRequestMode"
     ],
-    "redirect_from": "/java/latest/sample-code/service-feature-table-no-cache-.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/service-feature-table-no-cache-.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable",
         "ServiceFeatureTable.FeatureRequestMode"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/service_feature_table_no_cache/ServiceFeatureTableNoCacheSample.java"
     ],
-    "title": "Service Feature Table (No Cache)"
+    "title": "Service feature table (no cache)"
 }

--- a/feature_layers/statistical-query-group-and-sort/README.metadata.json
+++ b/feature_layers/statistical-query-group-and-sort/README.metadata.json
@@ -1,23 +1,49 @@
 {
     "category": "Feature layers",
-    "description": "Group and sort feature statistics by different fields.",
+    "description": "Query a feature table for statistics, grouping and sorting by different fields.",
     "ignore": false,
     "images": [
         "StatisticalQueryGroupAndSort.png"
     ],
     "keywords": [
-        "*** PLEASE ADD ADDITIONAL KEYWORDS ***"
+        "correlation",
+        "data",
+        "fields",
+        "filter",
+        "group",
+        "sort",
+        "statistics",
+        "table",
+        "Field",
+        "QueryParameters",
+        "QueryParameters.OrderBy",
+        "ServiceFeatureTable",
+        "StatisticDefinition",
+        "StatisticRecord",
+        "StatisticsQueryParameters",
+        "StatisticsQueryResult",
+        "StatisticType"
     ],
-    "redirect_from": "/java/latest/sample-code/statistical-query-group-and-sort.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/statistical-query-group-and-sort.htm"
+    ],
     "relevant_apis": [
-        "*** PLEASE ADD RELEVANT APIS ***"
+        "Field",
+        "QueryParameters",
+        "QueryParameters.OrderBy",
+        "ServiceFeatureTable",
+        "StatisticDefinition",
+        "StatisticRecord",
+        "StatisticsQueryParameters",
+        "StatisticsQueryResult",
+        "StatisticType"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/statistical_query_group_and_sort/StatisticalQueryGroupAndSortSample.java",
-        "src/main/java/com/esri/samples/statistical_query_group_and_sort/StatisticalQueryGroupAndSortController.java",
         "src/main/java/com/esri/samples/statistical_query_group_and_sort/GroupField.java",
         "src/main/java/com/esri/samples/statistical_query_group_and_sort/OrderByField.java",
+        "src/main/java/com/esri/samples/statistical_query_group_and_sort/StatisticalQueryGroupAndSortController.java",
+        "src/main/java/com/esri/samples/statistical_query_group_and_sort/StatisticalQueryGroupAndSortSample.java",
         "src/main/resources/statistical_query_group_and_sort/main.fxml"
     ],
-    "title": "Statistical Query Group And Sort"
+    "title": "Statistical query group and sort"
 }

--- a/feature_layers/statistical-query/README.metadata.json
+++ b/feature_layers/statistical-query/README.metadata.json
@@ -1,35 +1,47 @@
 {
     "category": "Feature layers",
-    "description": "Get aggregated feature statistics for a specified field.",
+    "description": "Query a table to get aggregated statistics back for a specific field.",
     "ignore": false,
     "images": [
         "StatisticalQuery.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "FeatureLayer",
+        "analysis",
+        "average",
+        "bounding geometry",
+        "filter",
+        "intersect",
+        "maximum",
+        "mean",
+        "minimum",
+        "query",
+        "spatial query",
+        "standard deviation",
+        "statistics",
+        "sum",
+        "variance",
         "QueryParameters",
         "ServiceFeatureTable",
         "StatisticDefinition",
         "StatisticRecord",
-        "StatisticType",
         "StatisticsQueryParameters",
-        "StatisticsQueryResult"
+        "StatisticsQueryResult",
+        "StatisticType"
     ],
-    "redirect_from": "/java/latest/sample-code/statistical-query.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/statistical-query.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "FeatureLayer",
         "QueryParameters",
         "ServiceFeatureTable",
         "StatisticDefinition",
         "StatisticRecord",
-        "StatisticType",
         "StatisticsQueryParameters",
-        "StatisticsQueryResult"
+        "StatisticsQueryResult",
+        "StatisticType"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/statistical_query/StatisticalQuerySample.java"
     ],
-    "title": "Statistical Query"
+    "title": "Statistical query"
 }

--- a/feature_layers/time-based-query/README.metadata.json
+++ b/feature_layers/time-based-query/README.metadata.json
@@ -1,25 +1,22 @@
 {
     "category": "Feature layers",
-    "description": "Filter features within a time range.",
+    "description": "Query data using a time extent.",
     "ignore": false,
     "images": [
         "TimeBasedQuery.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
-        "FeatureLayer",
-        "MapView",
+        "query",
+        "time",
+        "time extent",
         "QueryParameters",
         "ServiceFeatureTable",
         "TimeExtent"
     ],
-    "redirect_from": "/java/latest/sample-code/time-based-query.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/time-based-query.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
-        "FeatureLayer",
-        "MapView",
         "QueryParameters",
         "ServiceFeatureTable",
         "TimeExtent"
@@ -27,5 +24,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/time_based_query/TimeBasedQuerySample.java"
     ],
-    "title": "Time Based Query"
+    "title": "Time-based query"
 }

--- a/geometry/buffer-list/README.metadata.json
+++ b/geometry/buffer-list/README.metadata.json
@@ -1,18 +1,24 @@
 {
     "category": "Geometry",
-    "description": "Combine buffers from multiple points individual buffer distances.",
+    "description": "Generate multiple individual buffers or a single unioned buffer around multiple points.",
     "ignore": false,
     "images": [
         "BufferList.png"
     ],
     "keywords": [
-        "Analysis",
-        "Buffer",
-        "GeometryEngine"
+        "analysis",
+        "buffer",
+        "geometry",
+        "planar",
+        "GeometryEngine",
+        "SpatialReference"
     ],
-    "redirect_from": "/java/latest/sample-code/buffer-list.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/buffer-list.htm"
+    ],
     "relevant_apis": [
-        "GeometryEngine"
+        "GeometryEngine",
+        "SpatialReference"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/buffer_list/BufferListSample.java"

--- a/geometry/buffer/README.metadata.json
+++ b/geometry/buffer/README.metadata.json
@@ -1,22 +1,26 @@
 {
     "category": "Geometry",
-    "description": "Create geodesic and planar buffers around a point.",
+    "description": "Create a buffer around a map point and display the results as a `Graphic`",
     "ignore": false,
     "images": [
         "Buffer.png"
     ],
     "keywords": [
+        "analysis",
+        "buffer",
+        "euclidean",
+        "geodesic",
+        "geometry",
+        "planar",
         "GeometryEngine",
-        "GraphicsOverlay",
-        "Point",
-        "Polygon"
+        "GraphicsOverlay"
     ],
-    "redirect_from": "/java/latest/sample-code/buffer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/buffer.htm"
+    ],
     "relevant_apis": [
         "GeometryEngine",
-        "GraphicsOverlay",
-        "Point",
-        "Polygon"
+        "GraphicsOverlay"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/buffer/BufferSample.java"

--- a/geometry/clip-geometry/README.metadata.json
+++ b/geometry/clip-geometry/README.metadata.json
@@ -1,47 +1,32 @@
 {
     "category": "Geometry",
-    "description": "Clip a geometry to an envelope.",
+    "description": "Clip a geometry with another geometry.",
     "ignore": false,
     "images": [
         "ClipGeometry.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "analysis",
+        "clip",
+        "geometry",
         "Envelope",
         "Geometry",
         "GeometryEngine",
         "Graphic",
-        "GraphicsOverlay",
-        "MapView",
-        "Point",
-        "PointCollection",
-        "Polygon",
-        "Polyline",
-        "SimpleFillSymbol",
-        "SimpleLineSymbol",
-        "SpatialReferences"
+        "GraphicsOverlay"
     ],
-    "redirect_from": "/java/latest/sample-code/clip-geometry.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/clip-geometry.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "Envelope",
         "Geometry",
         "GeometryEngine",
         "Graphic",
-        "GraphicsOverlay",
-        "MapView",
-        "Point",
-        "PointCollection",
-        "Polygon",
-        "Polyline",
-        "SimpleFillSymbol",
-        "SimpleLineSymbol",
-        "SpatialReferences"
+        "GraphicsOverlay"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/clip_geometry/ClipGeometrySample.java"
     ],
-    "title": "Clip Geometry"
+    "title": "Clip geometry"
 }

--- a/geometry/convex-hull-list/README.metadata.json
+++ b/geometry/convex-hull-list/README.metadata.json
@@ -6,21 +6,25 @@
         "ConvexHullList.png"
     ],
     "keywords": [
-        "Analysis",
-        "ConvexHull",
+        "analysis",
+        "geometry",
+        "outline",
+        "perimeter",
+        "union",
         "GeometryEngine",
-        "GeometryEngine.ConvexHull",
-        "GraphicsOverlay",
-        "PointCollection"
+        "Graphic",
+        "GraphicsOverlay"
     ],
-    "redirect_from": "/java/latest/sample-code/convex-hull-list.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/convex-hull-list.htm"
+    ],
     "relevant_apis": [
         "GeometryEngine",
-        "GraphicsOverlay",
-        "PointCollection"
+        "Graphic",
+        "GraphicsOverlay"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/convex_hull_list/ConvexHullListSample.java"
     ],
-    "title": "Convex Hull List"
+    "title": "Convex hull list"
 }

--- a/geometry/convex-hull/README.metadata.json
+++ b/geometry/convex-hull/README.metadata.json
@@ -1,19 +1,26 @@
 {
     "category": "Geometry",
-    "description": "Calculate the convex hull for a set of points.",
+    "description": "Create a convex hull for a given set of points. The convex hull is a polygon with shortest perimeter that encloses a set of points. As a visual analogy, consider a set of points as nails in a board. The convex hull of the points would be like a rubber band stretched around the outermost nails.",
     "ignore": false,
     "images": [
         "ConvexHull.png"
     ],
     "keywords": [
+        "convex hull",
+        "geometry",
+        "spatial analysis",
+        "Geometry",
         "GeometryEngine"
     ],
-    "redirect_from": "/java/latest/sample-code/convex-hull.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/convex-hull.htm"
+    ],
     "relevant_apis": [
+        "Geometry",
         "GeometryEngine"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/convex_hull/ConvexHullSample.java"
     ],
-    "title": "Convex Hull"
+    "title": "Convex hull"
 }

--- a/geometry/create-geometries/README.metadata.json
+++ b/geometry/create-geometries/README.metadata.json
@@ -6,18 +6,24 @@
         "CreateGeometries.png"
     ],
     "keywords": [
+        "area",
+        "boundary",
+        "line",
+        "marker",
+        "path",
+        "shape",
         "Envelope",
-        "Graphic",
         "Multipoint",
         "Point",
         "PointCollection",
         "Polygon",
         "Polyline"
     ],
-    "redirect_from": "/java/latest/sample-code/create-geometries.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/create-geometries.htm"
+    ],
     "relevant_apis": [
         "Envelope",
-        "Graphic",
         "Multipoint",
         "Point",
         "PointCollection",
@@ -27,5 +33,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/create_geometries/CreateGeometriesSample.java"
     ],
-    "title": "Create Geometries"
+    "title": "Create geometries"
 }

--- a/geometry/cut-geometry/README.metadata.json
+++ b/geometry/cut-geometry/README.metadata.json
@@ -6,40 +6,23 @@
         "CutGeometry.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
-        "Geometry",
+        "cut",
+        "geometry",
+        "split",
         "GeometryEngine",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
-        "Point",
-        "PointCollection",
         "Polygon",
-        "Polyline",
-        "SimpleFillSymbol",
-        "SimpleLineSymbol",
-        "SpatialReferences"
+        "Polyline"
     ],
-    "redirect_from": "/java/latest/sample-code/cut-geometry.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/cut-geometry.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
-        "Geometry",
         "GeometryEngine",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
-        "Point",
-        "PointCollection",
         "Polygon",
-        "Polyline",
-        "SimpleFillSymbol",
-        "SimpleLineSymbol",
-        "SpatialReferences"
+        "Polyline"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/cut_geometry/CutGeometrySample.java"
     ],
-    "title": "Cut Geometry"
+    "title": "Cut geometry"
 }

--- a/geometry/densify-and-generalize/README.metadata.json
+++ b/geometry/densify-and-generalize/README.metadata.json
@@ -1,45 +1,39 @@
 {
     "category": "Geometry",
-    "description": "Modify a polyline while preserving its general shape.",
+    "description": "A multipart geometry can be densified by adding interpolated points at regular intervals. Generalizing multipart geometry simplifies it while preserving its general shape. Densifying a multipart geometry adds more vertices at regular intervals.",
     "ignore": false,
     "images": [
         "DensifyAndGeneralize.gif"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "Edit and Manage Data",
+        "densify",
+        "generalize",
+        "simplify",
         "GeometryEngine",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
         "Multipoint",
         "Point",
         "PointCollection",
         "Polyline",
         "SimpleLineSymbol",
-        "SimpleMarkerSymbol",
         "SpatialReference"
     ],
-    "redirect_from": "/java/latest/sample-code/densify-and-generalize.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/densify-and-generalize.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "GeometryEngine",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
         "Multipoint",
         "Point",
         "PointCollection",
         "Polyline",
         "SimpleLineSymbol",
-        "SimpleMarkerSymbol",
         "SpatialReference"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/densify_and_generalize/DensifyAndGeneralizeSample.java",
         "src/main/java/com/esri/samples/densify_and_generalize/DensifyAndGeneralizeController.java",
+        "src/main/java/com/esri/samples/densify_and_generalize/DensifyAndGeneralizeSample.java",
         "src/main/resources/densify_and_generalize/main.fxml"
     ],
-    "title": "Densify and Generalize"
+    "title": "Densify and generalize"
 }

--- a/geometry/geodesic-operations/README.metadata.json
+++ b/geometry/geodesic-operations/README.metadata.json
@@ -1,45 +1,25 @@
 {
     "category": "Geometry",
-    "description": "Calculate the geodesic path and distance between two points.",
+    "description": "Calculate a geodesic path between two points and measure its distance.",
     "ignore": false,
     "images": [
         "GeodesicOperations.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "GeodeticCurveType",
-        "Geometry",
-        "GeometryEngine",
-        "Graphic",
-        "GraphicsOverlay",
-        "LinearUnit",
-        "LinearUnitId",
-        "MapView",
-        "Point",
-        "PointCollection",
-        "Polyline",
-        "SimpleLineSymbol",
-        "SimpleMarkerSymbol"
+        "densify",
+        "distance",
+        "geodesic",
+        "geodetic",
+        "GeometryEngine"
     ],
-    "redirect_from": "/java/latest/sample-code/geodesic-operations.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/geodesic-operations.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "GeodeticCurveType",
-        "Geometry",
-        "GeometryEngine",
-        "Graphic",
-        "GraphicsOverlay",
-        "LinearUnit",
-        "LinearUnitId",
-        "MapView",
-        "Point",
-        "PointCollection",
-        "Polyline",
-        "SimpleLineSymbol",
-        "SimpleMarkerSymbol"
+        "GeometryEngine"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/geodesic_operations/GeodesicOperationsSample.java"
     ],
-    "title": "Geodesic Operations"
+    "title": "Geodesic operations"
 }

--- a/geometry/geodesic-sector-and-ellipse/README.metadata.json
+++ b/geometry/geodesic-sector-and-ellipse/README.metadata.json
@@ -1,17 +1,23 @@
 {
     "category": "Geometry",
-    "description": "Create geodesic sectors and ellipses.",
+    "description": "Create and display geodesic sectors and ellipses.",
     "ignore": false,
     "images": [
         "GeodesicSectorAndEllipse.png"
     ],
     "keywords": [
+        "ellipse",
+        "geodesic",
+        "geometry",
+        "sector",
         "GeodesicEllipseParameters",
         "GeodesicSectorParameters",
         "GeometryEngine",
         "GeometryType"
     ],
-    "redirect_from": "/java/latest/sample-code/geodesic-sector-and-ellipse.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/geodesic-sector-and-ellipse.htm"
+    ],
     "relevant_apis": [
         "GeodesicEllipseParameters",
         "GeodesicSectorParameters",
@@ -19,9 +25,9 @@
         "GeometryType"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/geodesic_sector_and_ellipse/GeodesicSectorAndEllipseSample.java",
         "src/main/java/com/esri/samples/geodesic_sector_and_ellipse/GeodesicSectorAndEllipseController.java",
+        "src/main/java/com/esri/samples/geodesic_sector_and_ellipse/GeodesicSectorAndEllipseSample.java",
         "src/main/resources/geodesic_sector_and_ellipse/main.fxml"
     ],
-    "title": "Geodesic Sector and Ellipse"
+    "title": "Geodesic sector and ellipse"
 }

--- a/geometry/geometry-engine-simplify/README.metadata.json
+++ b/geometry/geometry-engine-simplify/README.metadata.json
@@ -6,13 +6,17 @@
         "GeometryEngineSimplify.png"
     ],
     "keywords": [
+        "geometry",
+        "polygon",
+        "simplify",
+        "spatial operations",
+        "topology",
         "Geometry",
-        "Polygon",
-        "Simplify",
-        "Spatial operations",
-        "Topology"
+        "GeometryEngine"
     ],
-    "redirect_from": "/java/latest/sample-code/geometry-engine-simplify.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/geometry-engine-simplify.htm"
+    ],
     "relevant_apis": [
         "Geometry",
         "GeometryEngine"
@@ -20,5 +24,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/geometry_engine_simplify/GeometryEngineSimplifySample.java"
     ],
-    "title": "Geometry Engine Simplify"
+    "title": "Geometry engine simplify"
 }

--- a/geometry/list-transformations-by-suitability/README.metadata.json
+++ b/geometry/list-transformations-by-suitability/README.metadata.json
@@ -1,35 +1,30 @@
 {
     "category": "Geometry",
-    "description": "Find transformations to other spatial references suitable to the point's location.",
+    "description": "Get a list of suitable transformations for projecting a geometry between two spatial references with different horizontal datums.",
     "ignore": false,
     "images": [
         "ListTransformationsBySuitability.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "datum",
+        "geodesy",
+        "projection",
+        "spatial reference",
+        "transformation",
         "DatumTransformation",
         "GeometryEngine",
-        "Graphic",
-        "GraphicsOverlay",
-        "Point",
-        "SimpleMarkerSymbol",
         "TransformationCatalog"
     ],
-    "redirect_from": "/java/latest/sample-code/list-transformations-by-suitability.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/list-transformations-by-suitability.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "DatumTransformation",
         "GeometryEngine",
-        "Graphic",
-        "GraphicsOverlay",
-        "Point",
-        "SimpleMarkerSymbol",
         "TransformationCatalog"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/list_transformations_by_suitability/ListTransformationsBySuitabilitySample.java"
     ],
-    "title": "List Transformations By Suitability"
+    "title": "List transformations by suitability"
 }

--- a/geometry/nearest-vertex/README.metadata.json
+++ b/geometry/nearest-vertex/README.metadata.json
@@ -1,15 +1,23 @@
 {
     "category": "Geometry",
-    "description": "Get the vertex of a geometry closest to a point.",
+    "description": "Find the closest vertex and coordinate of a geometry to a point.",
     "ignore": false,
     "images": [
         "NearestVertex.png"
     ],
     "keywords": [
+        "analysis",
+        "coordinate",
+        "geometry",
+        "nearest",
+        "proximity",
+        "vertex",
         "GeometryEngine",
         "ProximityResult"
     ],
-    "redirect_from": "/java/latest/sample-code/nearest-vertex.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/nearest-vertex.htm"
+    ],
     "relevant_apis": [
         "GeometryEngine",
         "ProximityResult"
@@ -17,5 +25,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/nearest_vertex/NearestVertexSample.java"
     ],
-    "title": "Nearest Vertex"
+    "title": "Nearest vertex"
 }

--- a/geometry/project/README.metadata.json
+++ b/geometry/project/README.metadata.json
@@ -1,22 +1,34 @@
 {
     "category": "Geometry",
-    "description": "Project a point to another spatial reference.",
+    "description": "Project a point from one spatial reference to another.",
     "ignore": false,
     "images": [
         "Project.png"
     ],
     "keywords": [
+        "WGS 84",
+        "Web Mercator",
+        "coordinate system",
+        "coordinates",
+        "latitude",
+        "longitude",
+        "projected",
+        "projection",
+        "spatial reference",
         "GeometryEngine",
         "Point",
         "SpatialReference"
     ],
-    "redirect_from": "/java/latest/sample-code/project.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/project.htm"
+    ],
     "relevant_apis": [
         "GeometryEngine",
         "Point",
         "SpatialReference"
     ],
     "snippets": [
+        "ProjectSample.java",
         "src/main/java/com/esri/samples/project/ProjectSample.java"
     ],
     "title": "Project"

--- a/geometry/spatial-operations/README.metadata.json
+++ b/geometry/spatial-operations/README.metadata.json
@@ -6,16 +6,26 @@
         "SpatialOperations.png"
     ],
     "keywords": [
+        "combine",
+        "difference",
+        "edit",
+        "intersect",
+        "intersection",
+        "modify",
+        "symmetric difference",
+        "union",
         "Geometry",
         "Graphic",
         "GraphicsOverlay",
         "MapView",
         "Point",
         "PointCollection",
-        "SimpleLineSymbol",
-        "SimpleFillSymbol"
+        "SimpleFillSymbol",
+        "SimpleLineSymbol"
     ],
-    "redirect_from": "/java/latest/sample-code/spatial-operations.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/spatial-operations.htm"
+    ],
     "relevant_apis": [
         "Geometry",
         "Graphic",
@@ -23,11 +33,11 @@
         "MapView",
         "Point",
         "PointCollection",
-        "SimpleLineSymbol",
-        "SimpleFillSymbol"
+        "SimpleFillSymbol",
+        "SimpleLineSymbol"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/spatial_operations/SpatialOperationsSample.java"
     ],
-    "title": "Spatial Operations"
+    "title": "Spatial operations"
 }

--- a/geometry/spatial-relationships/README.metadata.json
+++ b/geometry/spatial-relationships/README.metadata.json
@@ -6,42 +6,31 @@
         "SpatialRelationships.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "geometries",
+        "relationship",
+        "spatial analysis",
         "Geometry",
         "GeometryEngine",
         "GeometryType",
         "Graphic",
-        "GraphicsOverlay",
-        "MapView",
         "Point",
-        "PointCollection",
         "Polygon",
-        "Polyline",
-        "SimpleFillSymbol",
-        "SimpleLineSymbol",
-        "SimpleMarkerSymbol"
+        "Polyline"
     ],
-    "redirect_from": "/java/latest/sample-code/spatial-relationships.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/spatial-relationships.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "Geometry",
         "GeometryEngine",
         "GeometryType",
         "Graphic",
-        "GraphicsOverlay",
-        "MapView",
         "Point",
-        "PointCollection",
         "Polygon",
-        "Polyline",
-        "SimpleFillSymbol",
-        "SimpleLineSymbol",
-        "SimpleMarkerSymbol"
+        "Polyline"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/spatial_relationships/SpatialRelationshipsSample.java"
     ],
-    "title": "Spatial Relationships"
+    "title": "Spatial relationships"
 }

--- a/group_layers/group-layers/README.metadata.json
+++ b/group_layers/group-layers/README.metadata.json
@@ -6,11 +6,13 @@
         "GroupLayers.png"
     ],
     "keywords": [
-        "Layers",
         "group layer",
+        "layers",
         "GroupLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/group-layers.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/group-layers.htm"
+    ],
     "relevant_apis": [
         "GroupLayer"
     ],

--- a/hydrography/add-enc-exchange-set/README.metadata.json
+++ b/hydrography/add-enc-exchange-set/README.metadata.json
@@ -17,7 +17,7 @@
         "EncExchangeSet",
         "EncLayer"
     ],
-    "redirect_from": [""],
+    "redirect_from": "",
     "relevant_apis": [
         "EncCell",
         "EncDataset",

--- a/hydrography/add-enc-exchange-set/README.metadata.json
+++ b/hydrography/add-enc-exchange-set/README.metadata.json
@@ -17,7 +17,7 @@
         "EncExchangeSet",
         "EncLayer"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "EncCell",
         "EncDataset",

--- a/hydrography/add-enc-exchange-set/README.metadata.json
+++ b/hydrography/add-enc-exchange-set/README.metadata.json
@@ -1,23 +1,23 @@
 {
     "category": "Hydrography",
-    "description": "Display nautical charts conforming to the ENC specification.",
+    "description": "Display nautical charts per the ENC specification.",
     "ignore": false,
     "images": [
         "AddEncExchangeSet.png"
     ],
     "keywords": [
-        "Data",
         "ENC",
+        "data",
+        "hydrographic",
+        "layers",
         "maritime",
         "nautical chart",
-        "layers",
-        "hydrographic",
         "EncCell",
         "EncDataset",
         "EncExchangeSet",
         "EncLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/add-enc-exchange-set.htm",
+    "redirect_from": [],
     "relevant_apis": [
         "EncCell",
         "EncDataset",

--- a/image_layers/change-sublayer-renderer/README.metadata.json
+++ b/image_layers/change-sublayer-renderer/README.metadata.json
@@ -6,34 +6,27 @@
         "ChangeSublayerRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "class breaks",
+        "dynamic layer",
+        "dynamic rendering",
+        "renderer",
+        "sublayer",
+        "symbology",
+        "visualization",
         "ArcGISMapImageLayer",
-        "ArcGISMapImageSublayer",
-        "Basemap",
-        "ClassBreaksRenderer",
-        "ClassBreaksRenderer.ClassBreak",
-        "LoadStatus",
-        "MapView",
-        "SimpleFillSymbol",
-        "SimpleLineSymbol",
-        "SublayerList"
+        "ArcGISMapImageSubLayer",
+        "ClassBreaksRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/change-sublayer-renderer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/change-sublayer-renderer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "ArcGISMapImageLayer",
-        "ArcGISMapImageSublayer",
-        "Basemap",
-        "ClassBreaksRenderer",
-        "ClassBreaksRenderer.ClassBreak",
-        "LoadStatus",
-        "MapView",
-        "SimpleFillSymbol",
-        "SimpleLineSymbol",
-        "SublayerList"
+        "ArcGISMapImageSubLayer",
+        "ClassBreaksRenderer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/change_sublayer_renderer/ChangeSublayerRendererSample.java"
     ],
-    "title": "Change Sublayer Renderer"
+    "title": "Change sublayer renderer"
 }

--- a/image_layers/map-image-layer-sublayer-visibility/README.metadata.json
+++ b/image_layers/map-image-layer-sublayer-visibility/README.metadata.json
@@ -6,22 +6,21 @@
         "MapImageLayerSublayerVisibility.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "layer",
+        "sublayer",
+        "visibility",
         "ArcGISMapImageLayer",
-        "Basemap",
-        "MapView",
         "SubLayerList"
     ],
-    "redirect_from": "/java/latest/sample-code/map-image-layer-sublayer-visibility.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/map-image-layer-sublayer-visibility.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "ArcGISMapImageLayer",
-        "Basemap",
-        "MapView",
         "SubLayerList"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/map_image_layer_sublayer_visibility/MapImageLayerSublayerVisibilitySample.java"
     ],
-    "title": "Map Image Layer Sublayer Visibility"
+    "title": "Map image layer sublayer visibility"
 }

--- a/image_layers/map-image-layer-tables/README.metadata.json
+++ b/image_layers/map-image-layer-tables/README.metadata.json
@@ -6,6 +6,10 @@
         "MapImageLayerTables.png"
     ],
     "keywords": [
+        "features",
+        "query",
+        "related features",
+        "search",
         "ArcGISFeature",
         "ArcGISMapImageLayer",
         "Feature",
@@ -16,7 +20,9 @@
         "RelationshipInfo",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/map-image-layer-tables.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/map-image-layer-tables.htm"
+    ],
     "relevant_apis": [
         "ArcGISFeature",
         "ArcGISMapImageLayer",
@@ -31,5 +37,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/map_image_layer_tables/MapImageLayerTablesSample.java"
     ],
-    "title": "Map Image Layer Tables"
+    "title": "Map image layer tables"
 }

--- a/image_layers/map-image-layer/README.metadata.json
+++ b/image_layers/map-image-layer/README.metadata.json
@@ -6,18 +6,20 @@
         "MapImageLayer.png"
     ],
     "keywords": [
-        "ArcGISMapImageLayer",
-        "ArcGISMap",
-        "MapView"
+        "display",
+        "image",
+        "layer",
+        "map",
+        "ArcGISMapImageLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/map-image-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/map-image-layer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMapImageLayer",
-        "ArcGISMap",
-        "MapView"
+        "ArcGISMapImageLayer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/map_image_layer/MapImageLayerSample.java"
     ],
-    "title": "Map Image Layer"
+    "title": "Map image layer"
 }

--- a/image_layers/query-map-image-sublayer/README.metadata.json
+++ b/image_layers/query-map-image-sublayer/README.metadata.json
@@ -6,12 +6,16 @@
         "QueryMapImageSublayer.png"
     ],
     "keywords": [
+        "query",
+        "search",
         "ArcGISMapImageLayer",
         "ArcGISMapImageSublayer",
         "QueryParameters",
         "ServiceFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/query-map-image-sublayer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/query-map-image-sublayer.htm"
+    ],
     "relevant_apis": [
         "ArcGISMapImageLayer",
         "ArcGISMapImageSublayer",
@@ -21,5 +25,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/query_map_image_sublayer/QueryMapImageSublayerSample.java"
     ],
-    "title": "Query Map Image Sublayer"
+    "title": "Query map image sublayer"
 }

--- a/kml/create-and-save-kml-file/README.metadata.json
+++ b/kml/create-and-save-kml-file/README.metadata.json
@@ -6,12 +6,22 @@
         "CreateAndSaveKMLFile.png"
     ],
     "keywords": [
-        "Keyhole",
         "KML",
         "KMZ",
-        "OGC"
+        "Keyhole",
+        "OGC",
+        "GeometryEngine.Project",
+        "KmlDataset",
+        "KmlDocument",
+        "KmlGeometry",
+        "KmlLayer",
+        "KmlPlacemark",
+        "KmlStyle",
+        "SketchEditor"
     ],
+    "redirect_from": [],
     "relevant_apis": [
+        "GeometryEngine.Project",
         "KmlDataset",
         "KmlDocument",
         "KmlGeometry",
@@ -21,7 +31,9 @@
         "SketchEditor"
     ],
     "snippets": [
+        "src/main/java/com/esri/samples/create_and_save_kml_file/CreateAndSaveKMLFileController.java",
         "src/main/java/com/esri/samples/create_and_save_kml_file/CreateAndSaveKMLFileSample.java",
+        "src/main/java/com/esri/samples/create_and_save_kml_file/ImageURLListCell.java",
         "src/main/resources/create_and_save_kml_file/main.fxml"
     ],
     "title": "Create and save KML file"

--- a/kml/create-and-save-kml-file/README.metadata.json
+++ b/kml/create-and-save-kml-file/README.metadata.json
@@ -19,7 +19,7 @@
         "KmlStyle",
         "SketchEditor"
     ],
-    "redirect_from": [""],
+    "redirect_from": "",
     "relevant_apis": [
         "GeometryEngine.Project",
         "KmlDataset",

--- a/kml/create-and-save-kml-file/README.metadata.json
+++ b/kml/create-and-save-kml-file/README.metadata.json
@@ -19,7 +19,7 @@
         "KmlStyle",
         "SketchEditor"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "GeometryEngine.Project",
         "KmlDataset",

--- a/kml/display-kml-network-links/README.metadata.json
+++ b/kml/display-kml-network-links/README.metadata.json
@@ -1,6 +1,6 @@
 {
     "category": "KML",
-    "description": "Display KML that automatically refreshes every few seconds.",
+    "description": "Display a file with a KML network link, including displaying any network link control messages at launch.",
     "ignore": false,
     "images": [
         "DisplayKMLNetworkLinks.png"
@@ -8,15 +8,17 @@
     "keywords": [
         "KML",
         "KMZ",
-        "OGC",
         "Keyhole",
         "Network Link",
         "Network Link Control",
+        "OGC",
         "KmlDataset",
         "KmlLayer",
         "KmlNetworkLinkMessageReceivedEvent"
     ],
-    "redirect_from": "/java/latest/sample-code/display-kml-network-links.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/display-kml-network-links.htm"
+    ],
     "relevant_apis": [
         "KmlDataset",
         "KmlLayer",
@@ -25,5 +27,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/display_kml_network_links/DisplayKMLNetworkLinksSample.java"
     ],
-    "title": "Display KML Network Links"
+    "title": "Display KML network links"
 }

--- a/kml/display-kml/README.metadata.json
+++ b/kml/display-kml/README.metadata.json
@@ -1,22 +1,24 @@
 {
     "category": "KML",
-    "description": "Display a KML layer from a URL, portal item, or local KML file.",
+    "description": "Display KML from a URL, portal item, or local KML file.",
     "ignore": false,
     "images": [
         "DisplayKML.png"
     ],
     "keywords": [
+        "KML",
+        "KMZ",
+        "OGC",
+        "keyhole",
         "KmlDataset",
-        "KmlLayer",
-        "Portal",
-        "PortalItem"
+        "KmlLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/display-kml.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/display-kml.htm"
+    ],
     "relevant_apis": [
         "KmlDataset",
-        "KmlLayer",
-        "Portal",
-        "PortalItem"
+        "KmlLayer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/display_kml/DisplayKMLSample.java"

--- a/kml/edit-kml-ground-overlay/README.metadata.json
+++ b/kml/edit-kml-ground-overlay/README.metadata.json
@@ -16,7 +16,7 @@
         "KmlIcon",
         "KmlLayer"
     ],
-    "redirect_from": [""],
+    "redirect_from": "",
     "relevant_apis": [
         "KmlDataset",
         "KmlGroundOverlay",

--- a/kml/edit-kml-ground-overlay/README.metadata.json
+++ b/kml/edit-kml-ground-overlay/README.metadata.json
@@ -16,7 +16,7 @@
         "KmlIcon",
         "KmlLayer"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "KmlDataset",
         "KmlGroundOverlay",

--- a/kml/edit-kml-ground-overlay/README.metadata.json
+++ b/kml/edit-kml-ground-overlay/README.metadata.json
@@ -6,12 +6,17 @@
         "EditKMLGroundOverlay.png"
     ],
     "keywords": [
-        "imagery",
-        "Keyhole",
         "KML",
         "KMZ",
-        "OGC"
+        "Keyhole",
+        "OGC",
+        "imagery",
+        "KmlDataset",
+        "KmlGroundOverlay",
+        "KmlIcon",
+        "KmlLayer"
     ],
+    "redirect_from": [],
     "relevant_apis": [
         "KmlDataset",
         "KmlGroundOverlay",
@@ -21,5 +26,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/edit_kml_ground_overlay/EditKMLGroundOverlaySample.java"
     ],
-    "title": "Edit KML Ground Overlay"
+    "title": "Edit KML ground overlay"
 }

--- a/kml/identify-kml-features/README.metadata.json
+++ b/kml/identify-kml-features/README.metadata.json
@@ -1,25 +1,34 @@
 {
     "category": "KML",
-    "description": "Get clicked features in a KML Layer.",
+    "description": "Show a callout with formatted content for a KML feature.",
     "ignore": false,
     "images": [
         "IdentifyKMLFeatures.png"
     ],
     "keywords": [
+        "KML",
+        "KMZ",
+        "Keyhole",
+        "NOAA",
+        "NWS",
+        "OGC",
+        "weather",
         "IdentifyLayerResult",
-        "KmlDataset",
         "KmlLayer",
-        "KmlPlacemark"
+        "KmlPlacemark",
+        "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/identify-kml-features.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/identify-kml-features.htm"
+    ],
     "relevant_apis": [
         "IdentifyLayerResult",
-        "KmlDataset",
         "KmlLayer",
-        "KmlPlacemark"
+        "KmlPlacemark",
+        "MapView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/identify_kml_features/IdentifyKMLFeaturesSample.java"
     ],
-    "title": "Identify KML Features"
+    "title": "Identify KML features"
 }

--- a/kml/list-kml-contents/README.metadata.json
+++ b/kml/list-kml-contents/README.metadata.json
@@ -1,6 +1,6 @@
 {
     "category": "KML",
-    "description": "Show KML nodes in their nested hierarchy.",
+    "description": "List the contents of a KML file.",
     "ignore": false,
     "images": [
         "ListKMLContents.png"
@@ -8,8 +8,9 @@
     "keywords": [
         "KML",
         "KMZ",
-        "OGC",
         "Keyhole",
+        "OGC",
+        "layers",
         "KmlContainer",
         "KmlDataset",
         "KmlDocument",
@@ -21,7 +22,9 @@
         "KmlPlacemark",
         "KmlScreenOverlay"
     ],
-    "redirect_from": "/java/latest/sample-code/list-kml-contents.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/list-kml-contents.htm"
+    ],
     "relevant_apis": [
         "KmlContainer",
         "KmlDataset",
@@ -37,5 +40,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/list_kml_contents/ListKMLContentsSample.java"
     ],
-    "title": "List KML Contents"
+    "title": "List KML contents"
 }

--- a/kml/play-a-kml-tour/README.metadata.json
+++ b/kml/play-a-kml-tour/README.metadata.json
@@ -7,27 +7,25 @@
     ],
     "keywords": [
         "KML",
-        "tour",
-        "story",
+        "animation",
         "interactive",
         "narration",
-        "play",
         "pause",
-        "animation",
-        "KmlDataset",
+        "play",
+        "story",
+        "tour",
         "KmlTour",
-        "KmlTourController",
-        "KmlTourStatus"
+        "KmlTourController"
     ],
-    "redirect_from": "/java/latest/sample-code/play-a-kml-tour.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/play-a-kml-tour.htm"
+    ],
     "relevant_apis": [
-        "KmlDataset",
         "KmlTour",
-        "KmlTourController",
-        "KmlTourStatus"
+        "KmlTourController"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/play_a_kml_tour/PlayAKMLTourSample.java"
     ],
-    "title": "Play a KML Tour"
+    "title": "Play KML Tour"
 }

--- a/local_server/local-server-feature-layer/README.metadata.json
+++ b/local_server/local-server-feature-layer/README.metadata.json
@@ -6,13 +6,20 @@
         "LocalServerFeatureLayer.png"
     ],
     "keywords": [
+        "feature service",
+        "local",
+        "offline",
+        "server",
+        "service",
         "FeatureLayer",
         "LocalFeatureService",
         "LocalServer",
         "LocalServerStatus",
         "StatusChangedEvent"
     ],
-    "redirect_from": "/java/latest/sample-code/local-server-feature-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/local-server-feature-layer.htm"
+    ],
     "relevant_apis": [
         "FeatureLayer",
         "LocalFeatureService",
@@ -23,5 +30,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/local_server_feature_layer/LocalServerFeatureLayerSample.java"
     ],
-    "title": "Local Server Feature Layer"
+    "title": "Local Server feature layer"
 }

--- a/local_server/local-server-geoprocessing/README.metadata.json
+++ b/local_server/local-server-geoprocessing/README.metadata.json
@@ -1,11 +1,18 @@
 {
     "category": "Local server",
-    "description": "Create contour lines from local raster data and Local Server.",
+    "description": "Create contour lines from local raster data using a local geoprocessing package `.gpk` and the contour geoprocessing tool.",
     "ignore": false,
     "images": [
         "LocalServerGeoprocessing.png"
     ],
     "keywords": [
+        "",
+        "geoprocessing",
+        "local",
+        "offline",
+        "parameters",
+        "processing",
+        "service",
         "GeoprocessingDouble",
         "GeoprocessingJob",
         "GeoprocessingParameter",
@@ -16,7 +23,9 @@
         "LocalServer",
         "LocalServerStatus"
     ],
-    "redirect_from": "/java/latest/sample-code/local-server-geoprocessing.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/local-server-geoprocessing.htm"
+    ],
     "relevant_apis": [
         "GeoprocessingDouble",
         "GeoprocessingJob",
@@ -29,9 +38,9 @@
         "LocalServerStatus"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/local_server_geoprocessing/LocalServerGeoprocessingSample.java",
         "src/main/java/com/esri/samples/local_server_geoprocessing/LocalServerGeoprocessingController.java",
+        "src/main/java/com/esri/samples/local_server_geoprocessing/LocalServerGeoprocessingSample.java",
         "src/main/resources/local_server_geoprocessing/main.fxml"
     ],
-    "title": "Local Server Geoprocessing"
+    "title": "Local Server geoprocessing"
 }

--- a/local_server/local-server-map-image-layer/README.metadata.json
+++ b/local_server/local-server-map-image-layer/README.metadata.json
@@ -1,27 +1,32 @@
 {
     "category": "Local server",
-    "description": "Create a local map imagery service and show its tiles in a map.",
+    "description": "Start the Local Server and Local Map Service, create an ArcGIS Map Image Layer from the Local Map Service, and add it to a map.",
     "ignore": false,
     "images": [
         "LocalServerMapImageLayer.png"
     ],
     "keywords": [
+        "image",
+        "layer",
+        "local",
+        "offline",
+        "server",
         "ArcGISMapImageLayer",
         "LocalMapService",
         "LocalServer",
-        "LocalServerStatus",
-        "StatusChangedEvent"
+        "LocalServerStatus"
     ],
-    "redirect_from": "/java/latest/sample-code/local-server-map-image-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/local-server-map-image-layer.htm"
+    ],
     "relevant_apis": [
         "ArcGISMapImageLayer",
         "LocalMapService",
         "LocalServer",
-        "LocalServerStatus",
-        "StatusChangedEvent"
+        "LocalServerStatus"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/local_server_map_image_layer/LocalServerMapImageLayerSample.java"
     ],
-    "title": "Local Server Map Image Layer"
+    "title": "Local Server map image layer"
 }

--- a/local_server/local-server-services/README.metadata.json
+++ b/local_server/local-server-services/README.metadata.json
@@ -1,33 +1,39 @@
 {
     "category": "Local server",
-    "description": "Manage multiple running services in Local Server.",
+    "description": "Demonstrates how to start and stop the Local Server and start and stop a local map, feature, and geoprocessing service running on the Local Server.",
     "ignore": false,
     "images": [
         "LocalServerServices.png"
     ],
     "keywords": [
+        "feature",
+        "geoprocessing",
+        "local services",
+        "map",
+        "server",
+        "service",
         "LocalFeatureService",
         "LocalGeoprocessingService",
         "LocalMapService",
         "LocalServer",
-        "StatusChangedEvent",
         "LocalServerStatus",
         "LocalService"
     ],
-    "redirect_from": "/java/latest/sample-code/local-server-services.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/local-server-services.htm"
+    ],
     "relevant_apis": [
         "LocalFeatureService",
         "LocalGeoprocessingService",
         "LocalMapService",
         "LocalServer",
-        "StatusChangedEvent",
         "LocalServerStatus",
         "LocalService"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/local_server_services/LocalServerServicesSample.java",
         "src/main/java/com/esri/samples/local_server_services/LocalServerServicesController.java",
+        "src/main/java/com/esri/samples/local_server_services/LocalServerServicesSample.java",
         "src/main/resources/local_server_services/main.fxml"
     ],
-    "title": "Local Server Services"
+    "title": "Local Server services"
 }

--- a/map/access-load-status/README.md
+++ b/map/access-load-status/README.md
@@ -30,4 +30,4 @@ The `LoadStatus` is `LOADED` when any of the following criteria are met:
 
 ## Tags
 
-LoadStatus, Map, Loadable pattern
+LoadStatus, map, loadable pattern

--- a/map/access-load-status/README.metadata.json
+++ b/map/access-load-status/README.metadata.json
@@ -1,25 +1,26 @@
 {
     "category": "Map",
-    "description": "Determine when a map has finished loading.",
+    "description": "Determine the map's load status which can be: `NOT_LOADED`, `FAILED_TO_LOAD`, `LOADING`, `LOADED`.",
     "ignore": false,
     "images": [
         "AccessLoadStatus.png"
     ],
     "keywords": [
+        "LoadStatus",
+        "Loadable pattern",
+        "Map",
         "ArcGISMap",
-        "Basemap",
-        "MapView",
-        "LoadStatus"
+        "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/access-load-status.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/access-load-status.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
-        "Basemap",
-        "MapView",
-        "LoadStatus"
+        "MapView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java"
     ],
-    "title": "Access Load Status"
+    "title": "Access load status"
 }

--- a/map/access-load-status/README.metadata.json
+++ b/map/access-load-status/README.metadata.json
@@ -7,8 +7,8 @@
     ],
     "keywords": [
         "LoadStatus",
-        "Loadable pattern",
-        "Map",
+        "loadable pattern",
+        "map",
         "ArcGISMap",
         "MapView"
     ],

--- a/map/apply-scheduled-updates-to-preplanned-map-area/README.metadata.json
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/README.metadata.json
@@ -7,12 +7,20 @@
     ],
     "keywords": [
         "offline",
-        "preplanned",
         "pre-planned",
+        "preplanned",
         "synchronize",
-        "update"
+        "update",
+        "MobileMapPackage",
+        "OfflineMapSyncJob",
+        "OfflineMapSyncParameters",
+        "OfflineMapSyncResult",
+        "OfflineMapSyncTask",
+        "OfflineMapUpdatesInfo"
     ],
-    "redirect_from": "",
+    "redirect_from": [
+        ""
+    ],
     "relevant_apis": [
         "MobileMapPackage",
         "OfflineMapSyncJob",

--- a/map/apply-scheduled-updates-to-preplanned-map-area/README.metadata.json
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/README.metadata.json
@@ -18,9 +18,7 @@
         "OfflineMapSyncTask",
         "OfflineMapUpdatesInfo"
     ],
-    "redirect_from": [
-        ""
-    ],
+    "redirect_from": "",
     "relevant_apis": [
         "MobileMapPackage",
         "OfflineMapSyncJob",

--- a/map/change-basemap/README.metadata.json
+++ b/map/change-basemap/README.metadata.json
@@ -1,25 +1,27 @@
 {
     "category": "Map",
-    "description": "Change a map's basemap.",
+    "description": "Change a map's basemap. A basemap is beneath all layers on an `ArcGISMap` and is used to provide visual reference for the operational layers.",
     "ignore": false,
     "images": [
         "ChangeBasemap.png"
     ],
     "keywords": [
+        "basemap",
+        "map",
         "ArcGISMap",
         "Basemap",
-        "Basemap.Type",
         "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/change-basemap.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/change-basemap.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "Basemap",
-        "Basemap.Type",
         "MapView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java"
     ],
-    "title": "Change Basemap"
+    "title": "Change basemap"
 }

--- a/map/create-and-save-map/README.metadata.json
+++ b/map/create-and-save-map/README.metadata.json
@@ -1,41 +1,33 @@
 {
     "category": "Map",
-    "description": "Create and save a map to your own portal.",
+    "description": "Create and save a map as an ArcGIS `PortalItem` (i.e. web map).",
     "ignore": false,
     "images": [
         "CreateAndSaveMap.png"
     ],
     "keywords": [
-        "AuthenticationChallengeHandler",
+        "ArcGIS Online",
+        "ArcGIS Pro",
+        "portal",
+        "publish",
+        "share",
+        "web map",
         "ArcGISMap",
-        "ArcGISMapImageLayer",
-        "Basemap",
-        "MapView",
-        "OAuthConfiguration",
-        "Portal",
-        "PortalFolder",
-        "PortalItem",
-        "PortalUserContent"
+        "Portal"
     ],
-    "redirect_from": "/java/latest/sample-code/create-and-save-map.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/create-and-save-map.htm"
+    ],
     "relevant_apis": [
-        "AuthenticationChallengeHandler",
         "ArcGISMap",
-        "ArcGISMapImageLayer",
-        "Basemap",
-        "MapView",
-        "OAuthConfiguration",
-        "Portal",
-        "PortalFolder",
-        "PortalItem",
-        "PortalUserContent"
+        "Portal"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/create_and_save_map/CreateAndSaveMapSample.java",
-        "src/main/java/com/esri/samples/create_and_save_map/CreateAndSaveMapController.java",
         "src/main/java/com/esri/samples/create_and_save_map/AuthenticationDialog.java",
-        "src/main/resources/create_and_save_map/main.fxml",
-        "src/main/resources/create_and_save_map/auth_dialog.fxml"
+        "src/main/java/com/esri/samples/create_and_save_map/CreateAndSaveMapController.java",
+        "src/main/java/com/esri/samples/create_and_save_map/CreateAndSaveMapSample.java",
+        "src/main/resources/create_and_save_map/auth_dialog.fxml",
+        "src/main/resources/create_and_save_map/main.fxml"
     ],
-    "title": "Create and Save Map"
+    "title": "Create and save map"
 }

--- a/map/display-map/README.metadata.json
+++ b/map/display-map/README.metadata.json
@@ -1,16 +1,20 @@
 {
     "category": "Map",
-    "description": "Display a map with some imagery.",
+    "description": "Display a map with an imagery basemap.",
     "ignore": false,
     "images": [
         "DisplayMap.png"
     ],
     "keywords": [
+        "basemap",
+        "map",
         "ArcGISMap",
         "Basemap",
         "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/display-a-map.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/display-a-map.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "Basemap",
@@ -19,5 +23,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/display_map/DisplayMapSample.java"
     ],
-    "title": "Display a Map"
+    "title": "Display map"
 }

--- a/map/download-preplanned-map/README.metadata.json
+++ b/map/download-preplanned-map/README.metadata.json
@@ -16,9 +16,7 @@
         "OfflineMapTask",
         "PreplannedMapArea"
     ],
-    "redirect_from": [
-        ""
-    ],
+    "redirect_from": "",
     "relevant_apis": [
         "DownloadPreplannedOfflineMapJob",
         "DownloadPreplannedOfflineMapParameters",

--- a/map/download-preplanned-map/README.metadata.json
+++ b/map/download-preplanned-map/README.metadata.json
@@ -8,10 +8,17 @@
     "keywords": [
         "map area",
         "offline",
+        "pre-planned",
         "preplanned",
-        "pre-planned"
+        "DownloadPreplannedOfflineMapJob",
+        "DownloadPreplannedOfflineMapParameters",
+        "DownloadPreplannedOfflineMapResult",
+        "OfflineMapTask",
+        "PreplannedMapArea"
     ],
-    "redirect_from": "",
+    "redirect_from": [
+        ""
+    ],
     "relevant_apis": [
         "DownloadPreplannedOfflineMapJob",
         "DownloadPreplannedOfflineMapParameters",
@@ -26,5 +33,5 @@
         "src/main/java/com/esri/samples/download_preplanned_map/PreplannedMapAreaListCell.java",
         "src/main/resources/download_preplanned_map/main.fxml"
     ],
-    "title": "Download a Preplanned Map Area"
+    "title": "Download a preplanned map area"
 }

--- a/map/generate-offline-map-overrides/README.metadata.json
+++ b/map/generate-offline-map-overrides/README.metadata.json
@@ -6,7 +6,17 @@
         "GenerateOfflineMapOverrides.png"
     ],
     "keywords": [
-        "Offline",
+        "LOD",
+        "adjust",
+        "download",
+        "extent",
+        "filter",
+        "offline",
+        "override",
+        "parameters",
+        "reduce",
+        "scale range",
+        "setting",
         "ExportTileCacheParameters",
         "GenerateGeodatabaseParameters",
         "GenerateLayerOption",
@@ -17,7 +27,9 @@
         "OfflineMapParametersKey",
         "OfflineMapTask"
     ],
-    "redirect_from": "/java/latest/sample-code/generate-offline-map-overrides-.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/generate-offline-map-overrides-.htm"
+    ],
     "relevant_apis": [
         "ExportTileCacheParameters",
         "GenerateGeodatabaseParameters",
@@ -30,9 +42,9 @@
         "OfflineMapTask"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/generate_offline_map_overrides/GenerateOfflineMapOverridesSample.java",
         "src/main/java/com/esri/samples/generate_offline_map_overrides/GenerateOfflineMapOverridesController.java",
+        "src/main/java/com/esri/samples/generate_offline_map_overrides/GenerateOfflineMapOverridesSample.java",
         "src/main/resources/generate_offline_map_overrides/main.fxml"
     ],
-    "title": "Generate Offline Map (Overrides)"
+    "title": "Generate offline map (overrides)"
 }

--- a/map/generate-offline-map-with-local-basemap/README.metadata.json
+++ b/map/generate-offline-map-with-local-basemap/README.metadata.json
@@ -1,31 +1,34 @@
 {
     "category": "Map",
-    "description": "Take a web map offline, but instead of downloading an online basemap, use one which is already on the device.",
+    "description": "Take a web map offline using a local basemap on the device.",
     "ignore": false,
     "images": [
         "GenerateOfflineMapWithLocalBasemap.png"
     ],
     "keywords": [
+        "basemap",
+        "download",
+        "local",
         "offline",
-        "local basemap",
-        "OfflineMapTask",
-        "OfflineMapTask",
-        "GenerateOfflineMapParameters",
-        "GenerateOfflineMapParameterOverrides",
+        "save",
+        "web map",
         "GenerateOfflineMapJob",
-        "GenerateOfflineMapResult"
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapResult",
+        "OfflineMapTask"
     ],
-    "redirect_from": "/java/latest/sample-code/generate-offline-map-with-local-basemap.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/generate-offline-map-with-local-basemap.htm"
+    ],
     "relevant_apis": [
-        "OfflineMapTask",
-        "GenerateOfflineMapParameters",
-        "GenerateOfflineMapParameterOverrides",
         "GenerateOfflineMapJob",
-        "GenerateOfflineMapResult"
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapResult",
+        "OfflineMapTask"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/generate_offline_map_with_local_basemap/GenerateOfflineMapWithLocalBasemapSample.java",
         "src/main/java/com/esri/samples/generate_offline_map_with_local_basemap/GenerateOfflineMapDialog.java",
+        "src/main/java/com/esri/samples/generate_offline_map_with_local_basemap/GenerateOfflineMapWithLocalBasemapSample.java",
         "src/main/resources/generate_offline_map_with_local_basemap/basemap_dialog.fxml"
     ],
     "title": "Generate offline map with local basemap"

--- a/map/generate-offline-map/README.metadata.json
+++ b/map/generate-offline-map/README.metadata.json
@@ -1,25 +1,33 @@
 {
     "category": "Map",
-    "description": "Take an extent of a web map offline.",
+    "description": "Take a web map offline.",
     "ignore": false,
     "images": [
         "GenerateOfflineMap.png"
     ],
     "keywords": [
+        "download",
+        "offline",
+        "save",
+        "web map",
         "GenerateOfflineMapJob",
         "GenerateOfflineMapParameters",
         "GenerateOfflineMapResult",
-        "OfflineMapTask"
+        "OfflineMapTask",
+        "Portal"
     ],
-    "redirect_from": "/java/latest/sample-code/generate-offline-map.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/generate-offline-map.htm"
+    ],
     "relevant_apis": [
         "GenerateOfflineMapJob",
         "GenerateOfflineMapParameters",
         "GenerateOfflineMapResult",
-        "OfflineMapTask"
+        "OfflineMapTask",
+        "Portal"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/generate_offline_map/GenerateOfflineMapSample.java"
     ],
-    "title": "Generate Offline Map"
+    "title": "Generate offline map"
 }

--- a/map/honor-mobile-map-package-expiration-date/README.metadata.json
+++ b/map/honor-mobile-map-package-expiration-date/README.metadata.json
@@ -11,9 +11,7 @@
         "Expiration",
         "MobileMapPackage"
     ],
-    "redirect_from": [
-        ""
-    ],
+    "redirect_from": "",
     "relevant_apis": [
         "Expiration",
         "MobileMapPackage"

--- a/map/honor-mobile-map-package-expiration-date/README.metadata.json
+++ b/map/honor-mobile-map-package-expiration-date/README.metadata.json
@@ -7,9 +7,13 @@
     ],
     "keywords": [
         "expiration",
-        "mmpk"
+        "mmpk",
+        "Expiration",
+        "MobileMapPackage"
     ],
-    "redirect_from": "",
+    "redirect_from": [
+        ""
+    ],
     "relevant_apis": [
         "Expiration",
         "MobileMapPackage"

--- a/map/manage-bookmarks/README.metadata.json
+++ b/map/manage-bookmarks/README.metadata.json
@@ -1,29 +1,29 @@
 {
     "category": "Map",
-    "description": "Use bookmarks in a map.",
+    "description": "Access and create bookmarks on a map.",
     "ignore": false,
     "images": [
         "ManageBookmarks.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "bookmark",
+        "extent",
+        "location",
+        "zoom",
         "Bookmark",
         "BookmarkList",
-        "MapView",
         "Viewpoint"
     ],
-    "redirect_from": "/java/latest/sample-code/manage-bookmarks.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/manage-bookmarks.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "Bookmark",
         "BookmarkList",
-        "MapView",
         "Viewpoint"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/manage_bookmarks/ManageBookmarksSample.java"
     ],
-    "title": "Manage Bookmarks"
+    "title": "Manage bookmarks"
 }

--- a/map/manage-operational-layers/README.metadata.json
+++ b/map/manage-operational-layers/README.metadata.json
@@ -1,27 +1,30 @@
 {
     "category": "Map",
-    "description": "Add, remove and reorder operational layers in a map.",
+    "description": "Add, remove, and reorder operational layers in a map.",
     "ignore": false,
     "images": [
         "ManageOperationalLayers.png"
     ],
     "keywords": [
+        "add",
+        "delete",
+        "layer",
+        "map",
+        "remove",
         "ArcGISMap",
         "ArcGISMapImageLayer",
-        "Basemap",
-        "LayerList",
-        "MapView"
+        "LayerList"
     ],
-    "redirect_from": "/java/latest/sample-code/manage-operational-layers.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/manage-operational-layers.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "ArcGISMapImageLayer",
-        "Basemap",
-        "LayerList",
-        "MapView"
+        "LayerList"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/manage_operational_layers/ManageOperationalLayersSample.java"
     ],
-    "title": "Manage Operational Layers"
+    "title": "Manage operational layers"
 }

--- a/map/map-initial-extent/README.metadata.json
+++ b/map/map-initial-extent/README.metadata.json
@@ -1,18 +1,24 @@
 {
     "category": "Map",
-    "description": "Display the map at an initial viewpoint.",
+    "description": "Display the map at an initial viewpoint representing a bounding geometry.",
     "ignore": false,
     "images": [
         "MapInitialExtent.png"
     ],
     "keywords": [
+        "envelope",
+        "extent",
+        "initial viewpoint",
+        "zoom",
         "ArcGISMap",
         "Envelope",
         "MapView",
         "Point",
         "Viewpoint"
     ],
-    "redirect_from": "/java/latest/sample-code/map-initial-extent.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/map-initial-extent.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "Envelope",
@@ -23,5 +29,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/map_initial_extent/MapInitialExtentSample.java"
     ],
-    "title": "Map Initial Extent"
+    "title": "Map initial extent"
 }

--- a/map/map-reference-scale/README.metadata.json
+++ b/map/map-reference-scale/README.metadata.json
@@ -1,24 +1,27 @@
 {
     "category": "Map",
-    "description": "Set the map's reference scale and choose which feature layers should honor the reference scale.",
+    "description": "Set the map's reference scale and which feature layers should honor the reference scale.",
     "ignore": false,
     "images": [
         "MapReferenceScale.png"
     ],
     "keywords": [
-        "Maps and Scenes",
+        "map",
         "reference scale",
+        "scene",
         "ArcGISMap",
         "FeatureLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/map-reference-scale.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/map-reference-scale.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "FeatureLayer"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/map_reference_scale/MapReferenceScaleSample.java",
         "src/main/java/com/esri/samples/map_reference_scale/MapReferenceScaleController.java",
+        "src/main/java/com/esri/samples/map_reference_scale/MapReferenceScaleSample.java",
         "src/main/resources/map_reference_scale/main.fxml"
     ],
     "title": "Map reference scale"

--- a/map/map-spatial-reference/README.metadata.json
+++ b/map/map-spatial-reference/README.metadata.json
@@ -6,13 +6,18 @@
         "MapSpatialReference.png"
     ],
     "keywords": [
+        "WKID",
+        "project",
+        "spatial reference",
         "ArcGISMap",
         "ArcGISMapImageLayer",
         "Basemap",
         "MapView",
         "SpatialReference"
     ],
-    "redirect_from": "/java/latest/sample-code/map-spatial-reference.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/map-spatial-reference.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "ArcGISMapImageLayer",
@@ -23,5 +28,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/map_spatial_reference/MapSpatialReferenceSample.java"
     ],
-    "title": "Map Spatial Reference"
+    "title": "Map spatial reference"
 }

--- a/map/min-max-scale/README.metadata.json
+++ b/map/min-max-scale/README.metadata.json
@@ -1,17 +1,25 @@
 {
     "category": "Map",
-    "description": "Restrict zooming to a specific scale range.",
+    "description": "Restrict zooming between specific scale ranges.",
     "ignore": false,
     "images": [
         "MinMaxScale.png"
     ],
     "keywords": [
+        "area of interest",
+        "level of detail",
+        "maximum",
+        "minimum",
+        "scale",
+        "viewpoint",
         "ArcGISMap",
         "Basemap",
         "MapView",
         "Viewpoint"
     ],
-    "redirect_from": "/java/latest/sample-code/min-max-scale.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/min-max-scale.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "Basemap",
@@ -21,5 +29,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/min_max_scale/MinMaxScaleSample.java"
     ],
-    "title": "Min Max Scale"
+    "title": "Min max scale"
 }

--- a/map/mobile-map-search-and-route/README.metadata.json
+++ b/map/mobile-map-search-and-route/README.metadata.json
@@ -1,14 +1,20 @@
 {
     "category": "Map",
-    "description": "Use locators and networks saved in an offline map.",
+    "description": "Display maps and use locators to enable search and routing offline using a mobile map package.",
     "ignore": false,
     "images": [
         "MobileMapSearchAndRoute.png"
     ],
     "keywords": [
-        "Offline",
-        "Routing",
-        "Search",
+        "disconnected",
+        "field mobility",
+        "geocode",
+        "network",
+        "network analysis",
+        "offline",
+        "routing",
+        "search",
+        "transportation",
         "GeocodeResult",
         "MobileMapPackage",
         "ReverseGeocodeParameters",
@@ -18,7 +24,9 @@
         "RouteTask",
         "TransportationNetworkDataset"
     ],
-    "redirect_from": "/java/latest/sample-code/mobile-map-search-and-route.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/mobile-map-search-and-route.htm"
+    ],
     "relevant_apis": [
         "GeocodeResult",
         "MobileMapPackage",
@@ -32,5 +40,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/mobile_map_search_and_route/MobileMapSearchAndRouteSample.java"
     ],
-    "title": "Mobile Map Search And Route"
+    "title": "Mobile map (search and route)"
 }

--- a/map/open-map-url/README.metadata.json
+++ b/map/open-map-url/README.metadata.json
@@ -6,12 +6,16 @@
         "OpenMapURL.png"
     ],
     "keywords": [
+        "portal item",
+        "web map",
         "ArcGISMap",
         "MapView",
         "Portal",
         "PortalItem"
     ],
-    "redirect_from": "/java/latest/sample-code/open-map-url-.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/open-map-url-.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "MapView",
@@ -21,5 +25,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/open_map_url/OpenMapURLSample.java"
     ],
-    "title": "Open Map (URL)"
+    "title": "Open map (URL)"
 }

--- a/map/open-mobile-map-package/README.metadata.json
+++ b/map/open-mobile-map-package/README.metadata.json
@@ -6,10 +6,15 @@
         "OpenMobileMapPackage.png"
     ],
     "keywords": [
+        "mmpk",
+        "mobile map package",
+        "offline",
         "MapView",
         "MobileMapPackage"
     ],
-    "redirect_from": "/java/latest/sample-code/open-mobile-map-package.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/open-mobile-map-package.htm"
+    ],
     "relevant_apis": [
         "MapView",
         "MobileMapPackage"
@@ -17,5 +22,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/open_mobile_map_package/OpenMobileMapPackageSample.java"
     ],
-    "title": "Open Mobile Map Package"
+    "title": "Open mobile map package"
 }

--- a/map/read-geopackage/README.metadata.json
+++ b/map/read-geopackage/README.metadata.json
@@ -1,31 +1,33 @@
 {
     "category": "Map",
-    "description": "Display rasters and features from local GeoPackages.",
+    "description": "Add rasters and feature tables from a GeoPackage to a map.",
     "ignore": false,
     "images": [
         "ReadGeoPackage.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
-        "FeatureLayer",
+        "OGC",
+        "container",
+        "geopackage",
+        "layer",
+        "map",
+        "package",
+        "raster",
+        "table",
         "GeoPackage",
-        "Layer",
-        "MapView",
-        "RasterLayer"
+        "GeoPackageFeatureTable",
+        "GeoPackageRaster"
     ],
-    "redirect_from": "/java/latest/sample-code/read-geopackage.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/read-geopackage.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
-        "FeatureLayer",
         "GeoPackage",
-        "Layer",
-        "MapView",
-        "RasterLayer"
+        "GeoPackageFeatureTable",
+        "GeoPackageRaster"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/read_geopackage/ReadGeoPackageSample.java"
     ],
-    "title": "Read GeoPackage"
+    "title": "Read a GeoPackage"
 }

--- a/map/set-initial-map-location/README.md
+++ b/map/set-initial-map-location/README.md
@@ -20,7 +20,7 @@ When the map loads, note the specific location and scale of the initial map view
 ## Relevant API
 
 * Basemap
-* Map
+* ArcGISMap
 * MapView
 
 ## About the data

--- a/map/set-initial-map-location/README.metadata.json
+++ b/map/set-initial-map-location/README.metadata.json
@@ -28,8 +28,8 @@
         "/java/latest/sample-code/set-initial-map-location.htm"
     ],
     "relevant_apis": [
+        "ArcGISMap",
         "Basemap",
-        "Map",
         "MapView"
     ],
     "snippets": [

--- a/map/set-initial-map-location/README.metadata.json
+++ b/map/set-initial-map-location/README.metadata.json
@@ -1,25 +1,39 @@
 {
     "category": "Map",
-    "description": "Display a map centered at a latitude and longitude plus zoom level.",
+    "description": "Display a basemap centered at an initial location and scale.",
     "ignore": false,
     "images": [
         "SetInitialMapLocation.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "LOD",
+        "basemap",
+        "center",
+        "envelope",
+        "extent",
+        "initial",
+        "lat",
+        "latitude",
+        "level of detail",
+        "location",
+        "long",
+        "longitude",
+        "scale",
+        "zoom level",
         "Basemap",
-        "Basemap.Type",
+        "Map",
         "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/set-initial-map-location.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/set-initial-map-location.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Basemap",
-        "Basemap.Type",
+        "Map",
         "MapView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/set_initial_map_location/SetInitialMapLocationSample.java"
     ],
-    "title": "Set Initial Map Location"
+    "title": "Set initial map location"
 }

--- a/map/set-initial-map-location/README.metadata.json
+++ b/map/set-initial-map-location/README.metadata.json
@@ -20,8 +20,8 @@
         "longitude",
         "scale",
         "zoom level",
+        "ArcGISMap",
         "Basemap",
-        "Map",
         "MapView"
     ],
     "redirect_from": [

--- a/map_view/change-viewpoint/README.metadata.json
+++ b/map_view/change-viewpoint/README.metadata.json
@@ -1,27 +1,36 @@
 {
     "category": "Map view",
-    "description": "Set or animate to a new viewpoint.",
+    "description": "Set the map view to a new viewpoint.",
     "ignore": false,
     "images": [
         "ChangeViewpoint.png"
     ],
     "keywords": [
+        "animate",
+        "extent",
+        "pan",
+        "rotate",
+        "scale",
+        "view",
+        "zoom",
         "ArcGISMap",
-        "Basemap",
+        "Geometry",
+        "MapView",
         "Point",
-        "SpatialReference",
         "Viewpoint"
     ],
-    "redirect_from": "/java/latest/sample-code/change-viewpoint.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/change-viewpoint.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
-        "Basemap",
+        "Geometry",
+        "MapView",
         "Point",
-        "SpatialReference",
         "Viewpoint"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/change_viewpoint/ChangeViewpointSample.java"
     ],
-    "title": "Change Viewpoint"
+    "title": "Change viewpoint"
 }

--- a/map_view/display-drawing-status/README.metadata.json
+++ b/map_view/display-drawing-status/README.metadata.json
@@ -1,33 +1,33 @@
 {
     "category": "Map view",
-    "description": "Determine if a layer is done drawing.",
+    "description": "Get the draw status of your map view or scene view to know when all layers in the map or scene have finished drawing.",
     "ignore": false,
     "images": [
         "DisplayDrawingStatus.png"
     ],
     "keywords": [
+        "draw",
+        "loading",
+        "map",
+        "render",
         "ArcGISMap",
-        "Basemap",
         "DrawStatus",
         "DrawStatusChangedEvent",
-        "Envelope",
-        "FeatureLayer",
-        "MapView",
-        "Point"
+        "DrawStatusChangedListener",
+        "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/display-drawing-status.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/display-drawing-status.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
-        "Basemap",
         "DrawStatus",
         "DrawStatusChangedEvent",
-        "Envelope",
-        "FeatureLayer",
-        "MapView",
-        "Point"
+        "DrawStatusChangedListener",
+        "MapView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/display_drawing_status/DisplayDrawingStatusSample.java"
     ],
-    "title": "Display Drawing Status"
+    "title": "Display draw status"
 }

--- a/map_view/display-layer-view-state/README.metadata.json
+++ b/map_view/display-layer-view-state/README.metadata.json
@@ -1,31 +1,37 @@
 {
     "category": "Map view",
-    "description": "Determine if a layer is currently visible.",
+    "description": "Determine if a layer is currently being viewed.",
     "ignore": false,
     "images": [
         "DisplayLayerViewState.png"
     ],
     "keywords": [
+        "layer",
+        "map",
+        "status",
+        "view",
         "ArcGISMap",
         "ArcGISMapImageLayer",
         "Layer",
-        "LayerViewStatus",
         "LayerViewStateChangedEvent",
-        "MapView",
-        "Viewpoint"
+        "LayerViewStateChangedListener",
+        "LayerViewStatus",
+        "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/display-layer-view-state.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/display-layer-view-state.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "ArcGISMapImageLayer",
         "Layer",
-        "LayerViewStatus",
         "LayerViewStateChangedEvent",
-        "MapView",
-        "Viewpoint"
+        "LayerViewStateChangedListener",
+        "LayerViewStatus",
+        "MapView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/display_layer_view_state/DisplayLayerViewStateSample.java"
     ],
-    "title": "Display Layer View State"
+    "title": "Display layer view state"
 }

--- a/map_view/identify-layers/README.metadata.json
+++ b/map_view/identify-layers/README.metadata.json
@@ -1,27 +1,27 @@
 {
     "category": "Map view",
-    "description": "Get clicked features from multiple layers.",
+    "description": "Identify features in all layers in a map.",
     "ignore": false,
     "images": [
         "IdentifyLayers.png"
     ],
     "keywords": [
-        "ArcGISMapImageLayer",
-        "FeatureLayer",
-        "FeatureTable",
+        "identify",
+        "recursion",
+        "recursive",
+        "sublayers",
         "IdentifyLayerResult",
         "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/identify-layers.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/identify-layers.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMapImageLayer",
-        "FeatureLayer",
-        "FeatureTable",
         "IdentifyLayerResult",
         "MapView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/identify_layers/IdentifyLayersSample.java"
     ],
-    "title": "Identify Layers"
+    "title": "Identify layers"
 }

--- a/map_view/map-rotation/README.metadata.json
+++ b/map_view/map-rotation/README.metadata.json
@@ -6,22 +6,22 @@
         "MapRotation.png"
     ],
     "keywords": [
+        "compass",
+        "rotate",
+        "rotation",
+        "viewpoint",
         "ArcGISMap",
-        "Compass",
-        "Envelope",
-        "MapView",
-        "Point"
+        "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/map-rotation.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/map-rotation.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
-        "Compass",
-        "Envelope",
-        "MapView",
-        "Point"
+        "MapView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/map_rotation/MapRotationSample.java"
     ],
-    "title": "Map Rotation"
+    "title": "Map rotation"
 }

--- a/map_view/scale-bar/README.metadata.json
+++ b/map_view/scale-bar/README.metadata.json
@@ -1,20 +1,23 @@
 {
     "category": "Map view",
-    "description": "Adds a scale bar to visually gauge distances on a map.",
+    "description": "Add a scale bar to visually gauge distances on a map.",
     "ignore": false,
     "images": [
         "ScaleBar.png"
     ],
     "keywords": [
-        "Map",
-        "Scale Bar",
-        "Toolkit",
+        "map",
+        "measure",
+        "scale",
+        "toolkit",
         "ArcGISMap",
         "MapView",
         "Scalebar",
         "UnitSystem"
     ],
-    "redirect_from": "/java/latest/sample-code/scale-bar.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/scale-bar.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "MapView",
@@ -24,5 +27,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/scale_bar/ScaleBarSample.java"
     ],
-    "title": "Scale Bar"
+    "title": "Scale bar"
 }

--- a/map_view/take-screenshot/README.metadata.json
+++ b/map_view/take-screenshot/README.metadata.json
@@ -1,15 +1,25 @@
 {
     "category": "Map view",
-    "description": "Export an area of the map as an image.",
+    "description": "Take a screenshot of the map.",
     "ignore": false,
     "images": [
         "TakeScreenshot.png"
     ],
     "keywords": [
+        "capture",
+        "export",
+        "image",
+        "print",
+        "screen capture",
+        "screenshot",
+        "share",
+        "shot",
         "ArcGISMap",
         "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/take-screen-shot.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/take-screen-shot.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "MapView"

--- a/network_analysis/closest-facility-static/README.metadata.json
+++ b/network_analysis/closest-facility-static/README.metadata.json
@@ -20,7 +20,9 @@
         "GraphicsOverlay",
         "Incident"
     ],
-    "redirect_from": "/java/latest/sample-code/closest-facility-static-.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/closest-facility-static-.htm"
+    ],
     "relevant_apis": [
         "ClosestFacilityParameters",
         "ClosestFacilityResult",
@@ -34,5 +36,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/closest_facility_static/ClosestFacilityStaticSample.java"
     ],
-    "title": "Closest Facility (Static)"
+    "title": "Closest facility (static)"
 }

--- a/network_analysis/closest-facility/README.metadata.json
+++ b/network_analysis/closest-facility/README.metadata.json
@@ -6,6 +6,10 @@
         "ClosestFacility.png"
     ],
     "keywords": [
+        "incident",
+        "network analysis",
+        "route",
+        "search",
         "ClosestFacilityParameters",
         "ClosestFacilityResult",
         "ClosestFacilityRoute",
@@ -16,7 +20,9 @@
         "Incident",
         "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/closest-facility.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/closest-facility.htm"
+    ],
     "relevant_apis": [
         "ClosestFacilityParameters",
         "ClosestFacilityResult",
@@ -31,5 +37,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/closest_facility/ClosestFacilitySample.java"
     ],
-    "title": "Closest Facility"
+    "title": "Closest facility"
 }

--- a/network_analysis/find-route/README.metadata.json
+++ b/network_analysis/find-route/README.metadata.json
@@ -1,39 +1,40 @@
 {
     "category": "Network analysis",
-    "description": "Get a route between two stops with directions.",
+    "description": "Display directions for a route between two points.",
     "ignore": false,
     "images": [
         "FindRoute.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "directions",
+        "driving",
+        "navigation",
+        "network",
+        "network analysis",
+        "route",
+        "routing",
+        "shortest path",
+        "turn-by-turn",
         "DirectionManeuver",
-        "DirectionMessage",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
         "Route",
-        "RouteTask",
         "RouteParameters",
         "RouteResult",
+        "RouteTask",
         "Stop"
     ],
-    "redirect_from": "/java/latest/sample-code/find-route.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/find-route.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "DirectionManeuver",
-        "DirectionMessage",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
         "Route",
-        "RouteTask",
         "RouteParameters",
         "RouteResult",
+        "RouteTask",
         "Stop"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/find_route/FindRouteSample.java"
     ],
-    "title": "Find Route"
+    "title": "Find route"
 }

--- a/network_analysis/find-service-areas-for-multiple-facilities/README.metadata.json
+++ b/network_analysis/find-service-areas-for-multiple-facilities/README.metadata.json
@@ -17,7 +17,7 @@
         "ServiceAreaResult",
         "ServiceAreaTask"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "ServiceAreaParameters",
         "ServiceAreaPolygon",

--- a/network_analysis/find-service-areas-for-multiple-facilities/README.metadata.json
+++ b/network_analysis/find-service-areas-for-multiple-facilities/README.metadata.json
@@ -17,7 +17,7 @@
         "ServiceAreaResult",
         "ServiceAreaTask"
     ],
-    "redirect_from": [""],
+    "redirect_from": "",
     "relevant_apis": [
         "ServiceAreaParameters",
         "ServiceAreaPolygon",

--- a/network_analysis/find-service-areas-for-multiple-facilities/README.metadata.json
+++ b/network_analysis/find-service-areas-for-multiple-facilities/README.metadata.json
@@ -1,26 +1,31 @@
 {
-  "category": "Network analysis",
-  "description": "Find the service areas of several facilities from a feature service.",
-  "ignore": false,
-  "images": [
-    "FindServiceAreasForMultipleFacilities.png"
-  ],
-  "keywords": [
-    "facilities" ,
-    "feature service",
-    "impedance",
-    "network analysis",
-    "service area",
-    "travel time"
-  ],
-  "relevant_apis": [
-    "ServiceAreaParameters",
-    "ServiceAreaPolygon",
-    "ServiceAreaResult",
-    "ServiceAreaTask"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java"
-  ],
-  "title": "Find Service Areas for Multiple Facilities"
+    "category": "Network analysis",
+    "description": "Find the service areas of several facilities from a feature service.",
+    "ignore": false,
+    "images": [
+        "FindServiceAreasForMultipleFacilities.png"
+    ],
+    "keywords": [
+        "facilities",
+        "feature service",
+        "impedance",
+        "network analysis",
+        "service area",
+        "travel time",
+        "ServiceAreaParameters",
+        "ServiceAreaPolygon",
+        "ServiceAreaResult",
+        "ServiceAreaTask"
+    ],
+    "redirect_from": [],
+    "relevant_apis": [
+        "ServiceAreaParameters",
+        "ServiceAreaPolygon",
+        "ServiceAreaResult",
+        "ServiceAreaTask"
+    ],
+    "snippets": [
+        "src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java"
+    ],
+    "title": "Find service areas for multiple facilities"
 }

--- a/network_analysis/offline-routing/README.md
+++ b/network_analysis/offline-routing/README.md
@@ -35,4 +35,4 @@ This sample uses a pre-packaged sample dataset consisting of a geodatabase with 
 
 ## Tags
 
-connectivity, disconnected, fastest, locator, navigation, network analysis, offline, routing, routing, shortest, turn-by-turn
+connectivity, disconnected, fastest, locator, navigation, network analysis, offline, routing, shortest, turn-by-turn

--- a/network_analysis/offline-routing/README.metadata.json
+++ b/network_analysis/offline-routing/README.metadata.json
@@ -1,43 +1,39 @@
 {
     "category": "Network analysis",
-    "description": "Solve a route on-the-fly using only offline data.",
+    "description": "Solve a route on-the-fly using offline data.",
     "ignore": false,
     "images": [
         "OfflineRouting.gif"
     ],
     "keywords": [
-        "ArcGISMap",
-        "ArcGISTiledLayer",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
-        "Route",
-        "RouteTask",
+        "connectivity",
+        "disconnected",
+        "fastest",
+        "locator",
+        "navigation",
+        "network analysis",
+        "offline",
+        "routing",
+        "shortest",
+        "turn-by-turn",
         "RouteParameters",
         "RouteResult",
-        "SimpleLineSymbol",
+        "RouteTask",
         "Stop",
-        "TextSymbol",
-        "TileCache"
+        "TravelMode"
     ],
-    "redirect_from": "/java/latest/sample-code/offline-routing.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/offline-routing.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "ArcGISTiledLayer",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
-        "Route",
-        "RouteTask",
         "RouteParameters",
         "RouteResult",
-        "SimpleLineSymbol",
+        "RouteTask",
         "Stop",
-        "TextSymbol",
-        "TileCache"
+        "TravelMode"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/offline_routing/OfflineRoutingSample.java"
     ],
-    "title": "Offline Routing"
+    "title": "Offline routing"
 }

--- a/network_analysis/routing-around-barriers/README.metadata.json
+++ b/network_analysis/routing-around-barriers/README.metadata.json
@@ -23,7 +23,7 @@
         "RouteTask",
         "Stop"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "DirectionManeuver",
         "PolygonBarrier",

--- a/network_analysis/routing-around-barriers/README.metadata.json
+++ b/network_analysis/routing-around-barriers/README.metadata.json
@@ -1,34 +1,42 @@
 {
-  "category": "Network analysis",
-  "description": "Find a route with multiple stops and barriers.",
-  "ignore": false,
-  "images": [
-    "RoutingAroundBarriers.png"
-  ],
-  "keywords": [
-    "barriers",
-    "best sequence",
-    "directions",
-    "maneuver",
-    "network analysis",
-    "routing",
-    "sequence",
-    "stop order",
-    "stops"
-  ],
-  "relevant_apis": [
-    "DirectionManeuver",
-    "PolygonBarrier",
-    "Route",
-    "RouteParameters",
-    "RouteResult",
-    "RouteTask",
-    "Stop"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/routing_around_barriers/RoutingAroundBarriersSample.java",
-    "src/main/java/com/esri/samples/routing_around_barriers/RoutingAroundBarriersController.java",
-    "src/main/resources/routing_around_barriers/main.fxml"
-  ],
-  "title": "Routing Around Barriers"
+    "category": "Network analysis",
+    "description": "Find a route that reaches all stops without crossing any barriers.",
+    "ignore": false,
+    "images": [
+        "RoutingAroundBarriers.png"
+    ],
+    "keywords": [
+        "barriers",
+        "best sequence",
+        "directions",
+        "maneuver",
+        "network analysis",
+        "routing",
+        "sequence",
+        "stop order",
+        "stops",
+        "DirectionManeuver",
+        "PolygonBarrier",
+        "Route",
+        "RouteParameters",
+        "RouteResult",
+        "RouteTask",
+        "Stop"
+    ],
+    "redirect_from": [],
+    "relevant_apis": [
+        "DirectionManeuver",
+        "PolygonBarrier",
+        "Route",
+        "RouteParameters",
+        "RouteResult",
+        "RouteTask",
+        "Stop"
+    ],
+    "snippets": [
+        "src/main/java/com/esri/samples/routing_around_barriers/RoutingAroundBarriersController.java",
+        "src/main/java/com/esri/samples/routing_around_barriers/RoutingAroundBarriersSample.java",
+        "src/main/resources/routing_around_barriers/main.fxml"
+    ],
+    "title": "Routing around barriers"
 }

--- a/network_analysis/routing-around-barriers/README.metadata.json
+++ b/network_analysis/routing-around-barriers/README.metadata.json
@@ -23,7 +23,7 @@
         "RouteTask",
         "Stop"
     ],
-    "redirect_from": [""],
+    "redirect_from": "",
     "relevant_apis": [
         "DirectionManeuver",
         "PolygonBarrier",

--- a/network_analysis/service-area-task/README.metadata.json
+++ b/network_analysis/service-area-task/README.metadata.json
@@ -1,39 +1,38 @@
 {
     "category": "Network analysis",
-    "description": "Find the service area for a point.",
+    "description": "Find the service area within a network from a given point.",
     "ignore": false,
     "images": [
         "ServiceAreaTask.gif"
     ],
     "keywords": [
-        "ArcGISMap",
-        "GraphicsOverlay",
-        "MapView",
+        "barriers",
+        "facilities",
+        "impedance",
+        "logistics",
+        "routing",
         "PolylineBarrier",
         "ServiceAreaFacility",
         "ServiceAreaParameters",
         "ServiceAreaPolygon",
         "ServiceAreaResult",
-        "ServiceAreaTask",
-        "PolylineBuilder"
+        "ServiceAreaTask"
     ],
-    "redirect_from": "/java/latest/sample-code/service-area-task.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/service-area-task.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "GraphicsOverlay",
-        "MapView",
         "PolylineBarrier",
         "ServiceAreaFacility",
         "ServiceAreaParameters",
         "ServiceAreaPolygon",
         "ServiceAreaResult",
-        "ServiceAreaTask",
-        "PolylineBuilder"
+        "ServiceAreaTask"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/service_area_task/ServiceAreaTaskSample.java",
         "src/main/java/com/esri/samples/service_area_task/ServiceAreaTaskController.java",
+        "src/main/java/com/esri/samples/service_area_task/ServiceAreaTaskSample.java",
         "src/main/resources/service_area_task/main.fxml"
     ],
-    "title": "Service Area Task"
+    "title": "Service area task"
 }

--- a/ogc/browse-wfs-layers/README.metadata.json
+++ b/ogc/browse-wfs-layers/README.metadata.json
@@ -8,19 +8,21 @@
     "keywords": [
         "OGC",
         "WFS",
-        "feature",
-        "web",
-        "service",
-        "layers",
         "browse",
         "catalog",
+        "feature",
+        "layers",
+        "service",
+        "web",
         "FeatureLayer",
         "WfsFeatureTable",
         "WfsLayerInfo",
         "WfsService",
         "WfsServiceInfo"
     ],
-    "redirect_from": "/java/latest/sample-code/browse-wfs-layers.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/browse-wfs-layers.htm"
+    ],
     "relevant_apis": [
         "FeatureLayer",
         "WfsFeatureTable",

--- a/ogc/display-wfs-layer/README.metadata.json
+++ b/ogc/display-wfs-layer/README.metadata.json
@@ -8,18 +8,21 @@
     "keywords": [
         "OGC",
         "WFS",
-        "layers. feature",
-        "web",
-        "service",
         "browse",
         "catalog",
+        "feature",
         "interaction cache",
+        "layers",
+        "service",
+        "web",
         "FeatureLayer",
         "NavigationChangedEvent",
         "QueryParameters",
         "WfsFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/display-wfs-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/display-wfs-layer.htm"
+    ],
     "relevant_apis": [
         "FeatureLayer",
         "NavigationChangedEvent",
@@ -29,5 +32,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/display_wfs_layer/DisplayWFSLayerSample.java"
     ],
-    "title": "Display WFS Layer"
+    "title": "Display WFS layer"
 }

--- a/ogc/open-street-map-layer/README.md
+++ b/ogc/open-street-map-layer/README.md
@@ -19,7 +19,7 @@ When the sample opens, it will automatically display the map with the OpenStreet
 
 ## Relevant API
 
-* Map
+* ArcGISMap
 * MapView
 
 ## Additional information

--- a/ogc/open-street-map-layer/README.metadata.json
+++ b/ogc/open-street-map-layer/README.metadata.json
@@ -13,14 +13,14 @@
         "map",
         "open",
         "street",
-        "Map",
+        "ArcGISMap",
         "MapView"
     ],
     "redirect_from": [
         "/java/latest/sample-code/openstreetmap-layer.htm"
     ],
     "relevant_apis": [
-        "Map",
+        "ArcGISMap",
         "MapView"
     ],
     "snippets": [

--- a/ogc/open-street-map-layer/README.metadata.json
+++ b/ogc/open-street-map-layer/README.metadata.json
@@ -1,27 +1,30 @@
 {
     "category": "OGC",
-    "description": "Display tiles from OpenStreetMap.",
+    "description": "Add OpenStreetMap as a basemap layer.",
     "ignore": false,
     "images": [
         "OpenStreetMapLayer.png"
     ],
     "keywords": [
-        "Layers",
+        "OSM",
         "OpenStreetMap",
-        "ArcGISMap",
-        "Basemap",
-        "Basemap.Type",
+        "basemap",
+        "layers",
+        "map",
+        "open",
+        "street",
+        "Map",
         "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/openstreetmap-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/openstreetmap-layer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
-        "Basemap.Type",
+        "Map",
         "MapView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/open_street_map_layer/OpenStreetMapLayerSample.java"
     ],
-    "title": "OpenStreetMap Layer"
+    "title": "OpenStreetMap layer"
 }

--- a/ogc/style-wms-layer/README.metadata.json
+++ b/ogc/style-wms-layer/README.metadata.json
@@ -1,19 +1,29 @@
 {
     "category": "OGC",
-    "description": "Change the style of a WMS layer.",
+    "description": "Change the style of a Web Map Service (WMS) layer.",
     "ignore": false,
     "images": [
         "StyleWmsLayer.png"
     ],
     "keywords": [
-        "WmsLayer"
+        "WMS",
+        "imagery",
+        "styles",
+        "visualization",
+        "WmsLayer",
+        "WmsSublayer",
+        "WmsSublayerInfo"
     ],
-    "redirect_from": "/java/latest/sample-code/style-wms-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/style-wms-layer.htm"
+    ],
     "relevant_apis": [
-        "WmsLayer"
+        "WmsLayer",
+        "WmsSublayer",
+        "WmsSublayerInfo"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/style_wms_layer/StyleWmsLayerSample.java"
     ],
-    "title": "Style WMS Layer"
+    "title": "Style WMS layer"
 }

--- a/ogc/wfs-xml-query/README.metadata.json
+++ b/ogc/wfs-xml-query/README.metadata.json
@@ -8,15 +8,17 @@
     "keywords": [
         "OGC",
         "WFS",
-        "feature",
-        "web",
-        "service",
         "XML",
+        "feature",
         "query",
+        "service",
+        "web",
         "FeatureLayer",
         "WfsFeatureTable"
     ],
-    "redirect_from": "/java/latest/sample-code/load-wfs-with-xml-query.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/load-wfs-with-xml-query.htm"
+    ],
     "relevant_apis": [
         "FeatureLayer",
         "WfsFeatureTable"

--- a/ogc/wms-layer-url/README.metadata.json
+++ b/ogc/wms-layer-url/README.metadata.json
@@ -1,16 +1,21 @@
 {
     "category": "OGC",
-    "description": "Display a WMS layer.",
+    "description": "Display a WMS layer using a WMS service URL.",
     "ignore": false,
     "images": [
         "WmsLayerUrl.png"
     ],
     "keywords": [
+        "OGC",
+        "WMS",
+        "web map service",
         "ArcGISMap",
         "MapView",
         "WmsLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/wms-layer-url.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/wms-layer-url.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "MapView",
@@ -19,5 +24,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/wms_layer_url/WmsLayerUrlSample.java"
     ],
-    "title": "WMS Layer URL"
+    "title": "WMS layer (URL)"
 }

--- a/ogc/wmts-layer/README.metadata.json
+++ b/ogc/wmts-layer/README.metadata.json
@@ -1,27 +1,32 @@
 {
     "category": "OGC",
-    "description": "Dsiplay tiles from a Web Map Tile Service.",
+    "description": "Display a layer from a Web Map Tile Service.",
     "ignore": false,
     "images": [
         "WmtsLayer.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
-        "MapView",
+        "OGC",
+        "layer",
+        "raster",
+        "tiled",
+        "web map tile service",
         "WmtsLayer",
-        "WmtsService"
+        "WmtsLayerInfo",
+        "WmtsService",
+        "WmtsServiceInfo"
     ],
-    "redirect_from": "/java/latest/sample-code/wmts-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/wmts-layer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
-        "MapView",
         "WmtsLayer",
-        "WmtsService"
+        "WmtsLayerInfo",
+        "WmtsService",
+        "WmtsServiceInfo"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/wmts_layer/WmtsLayerSample.java"
     ],
-    "title": "WMTS Layer"
+    "title": "WMTS layer"
 }

--- a/portal/integrated-windows-authentication/README.metadata.json
+++ b/portal/integrated-windows-authentication/README.metadata.json
@@ -1,19 +1,24 @@
 {
     "category": "Portal",
-    "description": "Use Windows credentials to access services hosted on a portal secured with Integrated Windows Authentication (IWA).",
+    "description": "Connect to an IWA secured portal and search for maps.",
     "ignore": false,
     "images": [
         "IntegratedWindowsAuthentication.png"
     ],
     "keywords": [
+        "Windows",
         "authentication",
-        "IWA",
-        "login",
-        "portal",
         "security",
-        "sign-in"
+        "AuthenticationChallenge",
+        "AuthenticationChallengeHandler",
+        "AuthenticationChallengeResponse",
+        "AuthenticationManager",
+        "Portal",
+        "UserCredential"
     ],
-    "redirect_from": "/java/latest/sample-code/integrated-windows-authentication.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/integrated-windows-authentication.htm"
+    ],
     "relevant_apis": [
         "AuthenticationChallenge",
         "AuthenticationChallengeHandler",
@@ -31,5 +36,5 @@
         "src/main/resources/integrated_windows_authentication/iwa_auth_dialog.fxml",
         "src/main/resources/integrated_windows_authentication/main.fxml"
     ],
-    "title": "Integrated windows authentication"
+    "title": "Integrated Windows Authentication"
 }

--- a/portal/oauth/README.metadata.json
+++ b/portal/oauth/README.metadata.json
@@ -1,21 +1,28 @@
 {
     "category": "Portal",
-    "description": "Use OAuth2 to authenticate with a secure portal",
+    "description": "Authenticate with ArcGIS Online (or your own portal) using OAuth2 to access secured resources (such as private web maps or layers).",
     "ignore": false,
     "images": [
         "OAuth.png"
     ],
     "keywords": [
+        "OAuth",
         "authentication",
         "cloud",
         "credential",
         "portal",
-        "security"
-    ],
-    "redirect_from": "/java/latest/sample-code/oauth.htm",
-    "relevant_apis": [
-        "AuthenticationManager",
+        "security",
         "AuthenticationChallengeHandler",
+        "AuthenticationManager",
+        "OAuthConfiguration",
+        "PortalItem"
+    ],
+    "redirect_from": [
+        "/java/latest/sample-code/oauth.htm"
+    ],
+    "relevant_apis": [
+        "AuthenticationChallengeHandler",
+        "AuthenticationManager",
         "OAuthConfiguration",
         "PortalItem"
     ],

--- a/portal/token-authentication/README.md
+++ b/portal/token-authentication/README.md
@@ -27,7 +27,7 @@ Once you launch the sample, you will be challenged for an ArcGIS Online login to
 * AuthenticationChallengeHandler
 * AuthenticationManager
 * DefaultAuthenticationChallengeHandler
-* Map
+* ArcGISMap
 * MapView
 * Portal
 * PortalItem

--- a/portal/token-authentication/README.md
+++ b/portal/token-authentication/README.md
@@ -24,10 +24,10 @@ Once you launch the sample, you will be challenged for an ArcGIS Online login to
 
 ## Relevant API
 
+* ArcGISMap
 * AuthenticationChallengeHandler
 * AuthenticationManager
 * DefaultAuthenticationChallengeHandler
-* ArcGISMap
 * MapView
 * Portal
 * PortalItem

--- a/portal/token-authentication/README.metadata.json
+++ b/portal/token-authentication/README.metadata.json
@@ -11,10 +11,10 @@
         "portal",
         "remember",
         "security",
+        "ArcGISMap",
         "AuthenticationChallengeHandler",
         "AuthenticationManager",
         "DefaultAuthenticationChallengeHandler",
-        "Map",
         "MapView",
         "Portal",
         "PortalItem"
@@ -23,10 +23,10 @@
         "/java/latest/sample-code/token-authentication.htm"
     ],
     "relevant_apis": [
+        "ArcGISMap",
         "AuthenticationChallengeHandler",
         "AuthenticationManager",
         "DefaultAuthenticationChallengeHandler",
-        "Map",
         "MapView",
         "Portal",
         "PortalItem"

--- a/portal/token-authentication/README.metadata.json
+++ b/portal/token-authentication/README.metadata.json
@@ -1,15 +1,16 @@
 {
     "category": "Portal",
-    "description": "Access a map service that is secured with an ArcGIS token-based authentication.",
+    "description": "Access a web map service that is secured with ArcGIS token-based authentication.",
     "ignore": false,
     "images": [
         "TokenAuthentication.png"
     ],
     "keywords": [
         "authentication",
-        "map service",
+        "cloud",
+        "portal",
+        "remember",
         "security",
-        "token",
         "AuthenticationChallengeHandler",
         "AuthenticationManager",
         "DefaultAuthenticationChallengeHandler",
@@ -18,7 +19,9 @@
         "Portal",
         "PortalItem"
     ],
-    "redirect_from": "/java/latest/sample-code/token-authentication.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/token-authentication.htm"
+    ],
     "relevant_apis": [
         "AuthenticationChallengeHandler",
         "AuthenticationManager",

--- a/portal/webmap-keyword-search/README.metadata.json
+++ b/portal/webmap-keyword-search/README.metadata.json
@@ -1,31 +1,33 @@
 {
     "category": "Portal",
-    "description": "Find webmaps within a portal using a keyword.",
+    "description": "Find webmap portal items by using a search term.",
     "ignore": false,
     "images": [
         "WebmapKeywordSearch.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "MapView",
+        "keyword",
+        "query",
+        "search",
+        "webmap",
         "Portal",
         "PortalItem",
         "PortalQueryParameters",
         "PortalQueryResultSet"
     ],
-    "redirect_from": "/java/latest/sample-code/webmap-keyword-search.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/webmap-keyword-search.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "MapView",
         "Portal",
         "PortalItem",
         "PortalQueryParameters",
         "PortalQueryResultSet"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/webmap_keyword_search/WebmapKeywordSearchSample.java",
         "src/main/java/com/esri/samples/webmap_keyword_search/WebmapKeywordSearchController.java",
+        "src/main/java/com/esri/samples/webmap_keyword_search/WebmapKeywordSearchSample.java",
         "src/main/resources/webmap_keyword_search/main.fxml"
     ],
-    "title": "Webmap Keyword Search"
+    "title": "Webmap keyword search"
 }

--- a/raster/blend-renderer/README.metadata.json
+++ b/raster/blend-renderer/README.metadata.json
@@ -1,26 +1,29 @@
 {
     "category": "Raster",
-    "description": "Apply a blend renderer to a raster.",
+    "description": "Blend a hillshade with a raster by specifying the elevation data. The resulting raster looks similar to the original raster, but with some terrain shading, giving it a textured look.",
     "ignore": false,
     "images": [
         "BlendRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "color ramp",
+        "elevation",
+        "hillshade",
+        "image",
+        "raster",
+        "raster layer",
+        "visualization",
         "BlendRenderer",
         "ColorRamp",
-        "MapView",
         "Raster",
         "RasterLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/blend-renderer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/blend-renderer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "BlendRenderer",
         "ColorRamp",
-        "MapView",
         "Raster",
         "RasterLayer"
     ],
@@ -29,5 +32,5 @@
         "src/main/java/com/esri/samples/blend_renderer/BlendRendererSample.java",
         "src/main/resources/blend_renderer/main.fxml"
     ],
-    "title": "Blend Renderer"
+    "title": "Blend renderer"
 }

--- a/raster/colormap-renderer/README.metadata.json
+++ b/raster/colormap-renderer/README.metadata.json
@@ -6,24 +6,25 @@
         "ColormapRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "colormap",
+        "data",
+        "raster",
+        "renderer",
+        "visualization",
         "ColormapRenderer",
-        "MapView",
         "Raster",
         "RasterLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/colormap-renderer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/colormap-renderer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "ColormapRenderer",
-        "MapView",
         "Raster",
         "RasterLayer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/colormap_renderer/ColormapRendererSample.java"
     ],
-    "title": "Colormap Renderer"
+    "title": "Colormap renderer"
 }

--- a/raster/hillshade-renderer/README.metadata.json
+++ b/raster/hillshade-renderer/README.metadata.json
@@ -6,26 +6,30 @@
         "HillshadeRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "altitude",
+        "angle",
+        "azimuth",
+        "raster",
+        "slope",
+        "visualization",
         "Basemap",
         "HillshadeRenderer",
-        "MapView",
         "Raster",
         "RasterLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/hillshade-renderer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/hillshade-renderer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Basemap",
         "HillshadeRenderer",
-        "MapView",
         "Raster",
         "RasterLayer"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/hillshade_renderer/HillshadeRendererSample.java",
         "src/main/java/com/esri/samples/hillshade_renderer/HillshadeRendererController.java",
+        "src/main/java/com/esri/samples/hillshade_renderer/HillshadeRendererSample.java",
         "src/main/resources/hillshade_renderer/main.fxml"
     ],
-    "title": "Hillshade Renderer"
+    "title": "Hillshade renderer"
 }

--- a/raster/raster-function/README.metadata.json
+++ b/raster/raster-function/README.metadata.json
@@ -1,25 +1,28 @@
 {
     "category": "Raster",
-    "description": "Apply a raster function to a raster.",
+    "description": "Load a raster from a service, then apply a function to it.",
     "ignore": false,
     "images": [
         "RasterFunction.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "function",
+        "layer",
+        "raster",
+        "raster function",
+        "service",
         "ImageServiceRaster",
-        "MapView",
+        "Raster",
         "RasterFunction",
         "RasterFunctionArguments",
         "RasterLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/raster-function.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/raster-function.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "ImageServiceRaster",
-        "MapView",
+        "Raster",
         "RasterFunction",
         "RasterFunctionArguments",
         "RasterLayer"
@@ -27,5 +30,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java"
     ],
-    "title": "Raster Function"
+    "title": "Raster function"
 }

--- a/raster/raster-layer-file/README.metadata.json
+++ b/raster/raster-layer-file/README.metadata.json
@@ -1,27 +1,29 @@
 {
     "category": "Raster",
-    "description": "Display raster data from a local file.",
+    "description": "Create and use a raster layer made from a local raster file.",
     "ignore": false,
     "images": [
         "RasterLayerFile.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
-        "MapView",
+        "data",
+        "image",
+        "import",
+        "layer",
+        "raster",
+        "visualization",
         "Raster",
         "RasterLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/raster-layer-file.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/raster-layer-file.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
-        "MapView",
         "Raster",
         "RasterLayer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/raster_layer_file/RasterLayerFileSample.java"
     ],
-    "title": "Raster Layer File"
+    "title": "Raster layer (file)"
 }

--- a/raster/raster-layer-geopackage/README.metadata.json
+++ b/raster/raster-layer-geopackage/README.metadata.json
@@ -1,29 +1,34 @@
 {
     "category": "Raster",
-    "description": "Display raster data from a geopackage.",
+    "description": "Display a raster contained in a GeoPackage.",
     "ignore": false,
     "images": [
         "RasterLayerGeopackage.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "OGC",
+        "container",
+        "data",
+        "image",
+        "import",
+        "layer",
+        "package",
+        "raster",
+        "visualization",
         "GeoPackage",
         "GeoPackageRaster",
-        "MapView",
         "RasterLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/raster-layer-geopackage.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/raster-layer-geopackage.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "GeoPackage",
         "GeoPackageRaster",
-        "MapView",
         "RasterLayer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/raster_layer_geopackage/RasterLayerGeopackageSample.java"
     ],
-    "title": "Raster Layer GeoPackage"
+    "title": "Raster layer (GeoPackage)"
 }

--- a/raster/raster-layer-url/README.metadata.json
+++ b/raster/raster-layer-url/README.metadata.json
@@ -1,27 +1,25 @@
 {
     "category": "Raster",
-    "description": "Show raster data from an online raster image service.",
+    "description": "Create a raster layer from a raster image service.",
     "ignore": false,
     "images": [
         "RasterLayerURL.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
+        "image service",
+        "raster",
         "ImageServiceRaster",
-        "MapView",
         "RasterLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/raster-layer-url.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/raster-layer-url.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
         "ImageServiceRaster",
-        "MapView",
         "RasterLayer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/raster_layer_url/RasterLayerURLSample.java"
     ],
-    "title": "Raster Layer URL"
+    "title": "Raster layer (URL)"
 }

--- a/raster/raster-rendering-rule/README.metadata.json
+++ b/raster/raster-rendering-rule/README.metadata.json
@@ -13,7 +13,9 @@
         "RasterLayer",
         "RenderingRule"
     ],
-    "redirect_from": "/java/latest/sample-code/raster-rendering-rule.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/raster-rendering-rule.htm"
+    ],
     "relevant_apis": [
         "ImageServiceRaster",
         "RasterLayer",

--- a/raster/rgb-renderer/README.metadata.json
+++ b/raster/rgb-renderer/README.metadata.json
@@ -1,33 +1,43 @@
 {
     "category": "Raster",
-    "description": "Apply an RGB renderer to a raster.",
+    "description": "Apply an RGB renderer to a raster layer to enhance feature visibility.",
     "ignore": false,
     "images": [
         "RgbRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "analysis",
+        "color",
+        "composite",
+        "imagery",
+        "multiband",
+        "multispectral",
+        "pan-sharpen",
+        "photograph",
+        "raster",
+        "spectrum",
+        "stretch",
+        "visualization",
         "Basemap",
-        "MapView",
         "Raster",
         "RasterLayer",
-        "RgbRenderer",
+        "RGBRenderer",
         "StretchParameters"
     ],
-    "redirect_from": "/java/latest/sample-code/rgb-renderer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/rgb-renderer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Basemap",
-        "MapView",
         "Raster",
         "RasterLayer",
-        "RgbRenderer",
+        "RGBRenderer",
         "StretchParameters"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/rgb_renderer/RgbRendererSample.java",
         "src/main/java/com/esri/samples/rgb_renderer/RgbRendererController.java",
+        "src/main/java/com/esri/samples/rgb_renderer/RgbRendererSample.java",
         "src/main/resources/rgb_renderer/main.fxml"
     ],
-    "title": "Rgb Renderer"
+    "title": "RGB renderer"
 }

--- a/raster/stretch-renderer/README.metadata.json
+++ b/raster/stretch-renderer/README.metadata.json
@@ -1,33 +1,47 @@
 {
     "category": "Raster",
-    "description": "Apply a stretch renderer to a raster.",
+    "description": "Use a stretch renderer to enhance the visual contrast of raster data for analysis.",
     "ignore": false,
     "images": [
         "StretchRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Basemap",
-        "MapView",
+        "analysis",
+        "deviation",
+        "histogram",
+        "imagery",
+        "interpretation",
+        "min-max",
+        "percent clip",
+        "pixel",
+        "raster",
+        "stretch",
+        "symbology",
+        "visualization",
+        "MinMaxStretchParameters",
+        "PercentClipStretchParameters",
         "Raster",
         "RasterLayer",
+        "StandardDeviationStretchParameters",
         "StretchParameters",
         "StretchRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/stretch-renderer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/stretch-renderer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Basemap",
-        "MapView",
+        "MinMaxStretchParameters",
+        "PercentClipStretchParameters",
         "Raster",
         "RasterLayer",
+        "StandardDeviationStretchParameters",
         "StretchParameters",
         "StretchRenderer"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/stretch_renderer/StretchRendererSample.java",
         "src/main/java/com/esri/samples/stretch_renderer/StretchRendererController.java",
+        "src/main/java/com/esri/samples/stretch_renderer/StretchRendererSample.java",
         "src/main/resources/stretch_renderer/main.fxml"
     ],
-    "title": "Stretch Renderer"
+    "title": "Stretch renderer"
 }

--- a/scene/add-a-point-scene-layer/README.metadata.json
+++ b/scene/add-a-point-scene-layer/README.metadata.json
@@ -7,16 +7,18 @@
     ],
     "keywords": [
         "3D",
-        "point scene layer",
         "layers",
+        "point scene layer",
         "ArcGISSceneLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/add-a-point-scene-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/add-a-point-scene-layer.htm"
+    ],
     "relevant_apis": [
         "ArcGISSceneLayer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/add_a_point_scene_layer/AddAPointSceneLayerSample.java"
     ],
-    "title": "Add a point scene layer"
+    "title": "Add point scene layer"
 }

--- a/scene/add-an-integrated-mesh-layer/README.metadata.json
+++ b/scene/add-an-integrated-mesh-layer/README.metadata.json
@@ -11,7 +11,9 @@
         "layers",
         "IntegratedMeshLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/add-an-integrated-mesh-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/add-an-integrated-mesh-layer.htm"
+    ],
     "relevant_apis": [
         "IntegratedMeshLayer"
     ],

--- a/scene/animate-3d-graphic/README.metadata.json
+++ b/scene/animate-3d-graphic/README.metadata.json
@@ -1,54 +1,51 @@
 {
     "category": "Scene",
-    "description": "Animate a graphic's position and orientation and follow it with the camera.",
+    "description": "A camera follows a graphic while the graphic's position and rotation are animated.",
     "ignore": false,
     "images": [
         "Animate3dGraphic.png"
     ],
     "keywords": [
-        "3D",
-        "ArcGISMap",
+        "animation",
+        "camera",
+        "heading",
+        "pitch",
+        "roll",
+        "rotation",
+        "visualize",
         "ArcGISScene",
         "Camera",
         "GlobeCameraController",
         "Graphic",
         "GraphicsOverlay",
-        "LayerSceneProperties.SurfacePlacement",
-        "MapView",
         "ModelSceneSymbol",
         "OrbitGeoElementCameraController",
-        "Point",
-        "Polyline",
         "Renderer",
-        "Renderer.SceneProperties",
+        "SceneProperties",
         "SceneView",
-        "Viewpoint"
+        "SurfacePlacement"
     ],
-    "redirect_from": "/java/latest/sample-code/animate-3d-graphic.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/animate-3d-graphic.htm"
+    ],
     "relevant_apis": [
-        "3D",
-        "ArcGISMap",
         "ArcGISScene",
         "Camera",
         "GlobeCameraController",
         "Graphic",
         "GraphicsOverlay",
-        "LayerSceneProperties.SurfacePlacement",
-        "MapView",
         "ModelSceneSymbol",
         "OrbitGeoElementCameraController",
-        "Point",
-        "Polyline",
         "Renderer",
-        "Renderer.SceneProperties",
+        "SceneProperties",
         "SceneView",
-        "Viewpoint"
+        "SurfacePlacement"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/animate_3d_graphic/Animate3dGraphicSample.java",
         "src/main/java/com/esri/samples/animate_3d_graphic/Animate3dGraphicController.java",
+        "src/main/java/com/esri/samples/animate_3d_graphic/Animate3dGraphicSample.java",
         "src/main/java/com/esri/samples/animate_3d_graphic/AnimationModel.java",
         "src/main/resources/animate_3d_graphic/main.fxml"
     ],
-    "title": "Animate 3D Graphic"
+    "title": "Animate 3D graphic"
 }

--- a/scene/change-atmosphere-effect/README.metadata.json
+++ b/scene/change-atmosphere-effect/README.metadata.json
@@ -1,19 +1,21 @@
 {
     "category": "Scene",
-    "description": "Change the appearance of the atmosphere in a scene.",
+    "description": "Changes the appearance of the atmosphere in a scene.",
     "ignore": false,
     "images": [
         "ChangeAtmosphereEffect.gif"
     ],
     "keywords": [
-        "3D",
-        "AtmosphereEffect",
-        "Scene",
+        "atmosphere",
+        "horizon",
+        "sky",
         "ArcGISScene",
         "AtmosphereEffect",
         "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/change-atmosphere-effect.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/change-atmosphere-effect.htm"
+    ],
     "relevant_apis": [
         "ArcGISScene",
         "AtmosphereEffect",
@@ -22,5 +24,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/change_atmosphere_effect/ChangeAtmosphereEffectSample.java"
     ],
-    "title": "Change Atmosphere Effect"
+    "title": "Change atmosphere effect"
 }

--- a/scene/choose-camera-controller/README.metadata.json
+++ b/scene/choose-camera-controller/README.metadata.json
@@ -6,10 +6,9 @@
         "ChooseCameraController.png"
     ],
     "keywords": [
-        "camera controller",
-        "Camera",
-        "SceneView",
         "3D",
+        "camera",
+        "camera controller",
         "ArcGISScene",
         "Camera",
         "GlobeCameraController",
@@ -17,7 +16,9 @@
         "OrbitLocationCameraController",
         "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/choose-camera-controller.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/choose-camera-controller.htm"
+    ],
     "relevant_apis": [
         "ArcGISScene",
         "Camera",

--- a/scene/create-terrain-surface-from-local-raster/README.metadata.json
+++ b/scene/create-terrain-surface-from-local-raster/README.metadata.json
@@ -7,13 +7,16 @@
     ],
     "keywords": [
         "3D",
-        "Raster",
-        "Elevation",
-        "Surface",
+        "elevation",
+        "raster",
+        "surface",
+        "terrain",
         "RasterElevationSource",
         "Surface"
     ],
-    "redirect_from": "/java/latest/sample-code/create-terrain-surface-from-a-local-raster.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/create-terrain-surface-from-a-local-raster.htm"
+    ],
     "relevant_apis": [
         "RasterElevationSource",
         "Surface"
@@ -21,5 +24,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/create_terrain_surface_from_local_raster/CreateTerrainSurfaceFromLocalRasterSample.java"
     ],
-    "title": "Create Terrain Surface from a Local Raster"
+    "title": "Create terrain from a local raster"
 }

--- a/scene/create-terrain-surface-from-local-tile-package/README.metadata.json
+++ b/scene/create-terrain-surface-from-local-tile-package/README.metadata.json
@@ -7,13 +7,17 @@
     ],
     "keywords": [
         "3D",
-        "Tile Cache",
-        "Elevation",
-        "Surface",
+        "LERC",
+        "elevation",
+        "surface",
+        "terrain",
+        "tile cache",
         "ArcGISTiledElevationSource",
         "Surface"
     ],
-    "redirect_from": "/java/latest/sample-code/create-terrain-from-a-local-tile-package.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/create-terrain-from-a-local-tile-package.htm"
+    ],
     "relevant_apis": [
         "ArcGISTiledElevationSource",
         "Surface"
@@ -21,5 +25,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/create_terrain_surface_from_local_tile_package/CreateTerrainSurfaceFromLocalTilePackageSample.java"
     ],
-    "title": "Create Terrain from a Local Tile Package"
+    "title": "Create terrain from a local tile package"
 }

--- a/scene/display-scene/README.metadata.json
+++ b/scene/display-scene/README.metadata.json
@@ -1,27 +1,30 @@
 {
     "category": "Scene",
-    "description": "Display a 3. scene with terrain and imagery.",
+    "description": "Display a scene with a terrain surface and some imagery.",
     "ignore": false,
     "images": [
         "DisplayScene.png"
     ],
     "keywords": [
+        "3D",
+        "basemap",
+        "elevation",
+        "scene",
+        "surface",
         "ArcGISScene",
         "ArcGISTiledElevationSource",
-        "Camera",
-        "SceneView",
-        "Surface"
+        "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/display-scene.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/display-scene.htm"
+    ],
     "relevant_apis": [
         "ArcGISScene",
         "ArcGISTiledElevationSource",
-        "Camera",
-        "SceneView",
-        "Surface"
+        "SceneView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/display_scene/DisplaySceneSample.java"
     ],
-    "title": "Display Scene"
+    "title": "Display scene"
 }

--- a/scene/distance-composite-symbol/README.metadata.json
+++ b/scene/distance-composite-symbol/README.metadata.json
@@ -1,41 +1,26 @@
 {
     "category": "Scene",
-    "description": "Change a graphic's symbol based on camera proximity.",
+    "description": "Change a graphic's symbol based on the camera's proximity to it.",
     "ignore": false,
     "images": [
         "DistanceCompositeSymbol.gif"
     ],
     "keywords": [
-        "ArcGISScene",
-        "ArcGISTiledElevationSource",
-        "Camera",
+        "3D",
+        "data",
+        "graphic",
         "DistanceCompositeSceneSymbol",
-        "DistanceCompositeSceneSymbol.Range",
-        "Graphic",
-        "GraphicsOverlay",
-        "ModelSceneSymbol",
-        "Range",
-        "RangeCollection",
-        "SceneView",
-        "SimpleMarkerSceneSymbol"
+        "DistanceCompositeSceneSymbol.Range"
     ],
-    "redirect_from": "/java/latest/sample-code/distance-composite-symbol.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/distance-composite-symbol.htm"
+    ],
     "relevant_apis": [
-        "ArcGISScene",
-        "ArcGISTiledElevationSource",
-        "Camera",
         "DistanceCompositeSceneSymbol",
-        "DistanceCompositeSceneSymbol.Range",
-        "Graphic",
-        "GraphicsOverlay",
-        "ModelSceneSymbol",
-        "Range",
-        "RangeCollection",
-        "SceneView",
-        "SimpleMarkerSceneSymbol"
+        "DistanceCompositeSceneSymbol.Range"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/distance_composite_symbol/DistanceCompositeSymbolSample.java"
     ],
-    "title": "Distance Composite Symbol"
+    "title": "Distance composite symbol"
 }

--- a/scene/extrude-graphics/README.metadata.json
+++ b/scene/extrude-graphics/README.metadata.json
@@ -1,27 +1,33 @@
 {
     "category": "Scene",
-    "description": "Extrude graphics based on attributes.",
+    "description": "Extrude graphics based on an attribute value.",
     "ignore": false,
     "images": [
         "ExtrudeGraphics.png"
     ],
     "keywords": [
-        "ArcGISScene",
-        "Graphic",
-        "GraphicsOverlay",
+        "3D",
+        "extrude",
+        "extrusion",
+        "height",
+        "scene",
+        "visualization",
         "Renderer",
-        "Renderer.SceneProperties"
+        "SceneProperties",
+        "SceneProperties.ExtrusionMode",
+        "SimpleRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/extrude-graphics.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/extrude-graphics.htm"
+    ],
     "relevant_apis": [
-        "ArcGISScene",
-        "Graphic",
-        "GraphicsOverlay",
         "Renderer",
-        "Renderer.SceneProperties"
+        "SceneProperties",
+        "SceneProperties.ExtrusionMode",
+        "SimpleRenderer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/extrude_graphics/ExtrudeGraphicsSample.java"
     ],
-    "title": "Extrude Graphics"
+    "title": "Extrude graphics"
 }

--- a/scene/feature-layer-rendering-mode-scene/README.metadata.json
+++ b/scene/feature-layer-rendering-mode-scene/README.metadata.json
@@ -1,35 +1,35 @@
 {
     "category": "Scene",
-    "description": "Render features statically or dynamically in 3D.",
+    "description": "Render features in a scene statically or dynamically by setting the feature layer rendering mode.",
     "ignore": false,
     "images": [
         "FeatureLayerRenderingModeScene.gif"
     ],
     "keywords": [
+        "3D",
+        "dynamic",
+        "feature layer",
+        "features",
+        "rendering",
+        "static",
         "ArcGISScene",
-        "Camera",
         "FeatureLayer",
         "FeatureLayer.RenderingMode",
         "LoadSettings",
-        "Point",
-        "Polyline",
-        "Polygon",
-        "ServiceFeatureTable"
+        "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/feature-layer-rendering-mode-scene-.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/feature-layer-rendering-mode-scene-.htm"
+    ],
     "relevant_apis": [
         "ArcGISScene",
-        "Camera",
         "FeatureLayer",
         "FeatureLayer.RenderingMode",
         "LoadSettings",
-        "Point",
-        "Polyline",
-        "Polygon",
-        "ServiceFeatureTable"
+        "SceneView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/feature_layer_rendering_mode_scene/FeatureLayerRenderingModeSceneSample.java"
     ],
-    "title": "Feature Layer Rendering Mode (Scene)"
+    "title": "Feature layer rendering mode (Scene)"
 }

--- a/scene/feature-layer-rendering-mode-scene/README.metadata.json
+++ b/scene/feature-layer-rendering-mode-scene/README.metadata.json
@@ -19,7 +19,7 @@
         "SceneView"
     ],
     "redirect_from": [
-        "/java/latest/sample-code/feature-layer-rendering-mode-scene-.htm"
+        "/java/latest/sample-code/feature-layer-rendering-mode-scene.htm"
     ],
     "relevant_apis": [
         "ArcGISScene",

--- a/scene/get-elevation-at-a-point/README.metadata.json
+++ b/scene/get-elevation-at-a-point/README.metadata.json
@@ -7,14 +7,15 @@
     ],
     "keywords": [
         "elevation",
-        "point",
         "surface",
         "ArcGISTiledElevationSource",
         "BaseSurface",
         "ElevationSourcesList",
         "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/get-elevation-at-a-point.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/get-elevation-at-a-point.htm"
+    ],
     "relevant_apis": [
         "ArcGISTiledElevationSource",
         "BaseSurface",

--- a/scene/open-mobile-scene-package/README.metadata.json
+++ b/scene/open-mobile-scene-package/README.metadata.json
@@ -1,19 +1,22 @@
 {
     "category": "Scene",
-    "description": "Open and display a scene from an offline Mobile Scene Package (.mspk).",
+    "description": "Opens and displays a scene from a mobile scene package (.mspk).",
     "ignore": false,
     "images": [
         "OpenMobileScenePackage.png"
     ],
     "keywords": [
-        "Offline",
-        "Scene",
+        "offline",
+        "scene",
         "MobileScenePackage",
-        "MobileScenePackage"
+        "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/open-mobile-scene-package.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/open-mobile-scene-package.htm"
+    ],
     "relevant_apis": [
-        "MobileScenePackage"
+        "MobileScenePackage",
+        "SceneView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/open_mobile_scene_package/OpenMobileScenePackageSample.java"

--- a/scene/open-scene-portal-item/README.metadata.json
+++ b/scene/open-scene-portal-item/README.metadata.json
@@ -1,23 +1,28 @@
 {
     "category": "Scene",
-    "description": "Display a web scene.",
+    "description": "Open a web scene from a portal item.",
     "ignore": false,
     "images": [
         "OpenScenePortalItem.png"
     ],
     "keywords": [
+        "portal",
+        "scene",
+        "web scene",
         "ArcGISScene",
-        "Portal",
-        "PortalItem"
+        "PortalItem",
+        "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/open-scene-portal-item-.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/open-scene-portal-item-.htm"
+    ],
     "relevant_apis": [
         "ArcGISScene",
-        "Portal",
-        "PortalItem"
+        "PortalItem",
+        "SceneView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/open_scene_portal_item/OpenScenePortalItemSample.java"
     ],
-    "title": "Open Scene (Portal Item)"
+    "title": "Open scene (portal item)"
 }

--- a/scene/orbit-the-camera-around-an-object/README.metadata.json
+++ b/scene/orbit-the-camera-around-an-object/README.metadata.json
@@ -6,20 +6,24 @@
         "OrbitTheCameraAroundAnObject.png"
     ],
     "keywords": [
-        "OrbitGeoElementCameraController",
-        "Camera",
-        "SceneView",
         "3D",
+        "camera",
+        "object",
+        "orbit",
+        "rotate",
+        "scene",
         "OrbitGeoElementCameraController"
     ],
-    "redirect_from": "/java/latest/sample-code/orbit-the-camera-around-an-object.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/orbit-the-camera-around-an-object.htm"
+    ],
     "relevant_apis": [
         "OrbitGeoElementCameraController"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/orbit_the_camera_around_an_object/OrbitTheCameraAroundAnObjectSample.java",
         "src/main/java/com/esri/samples/orbit_the_camera_around_an_object/OrbitTheCameraAroundAnObjectController.java",
+        "src/main/java/com/esri/samples/orbit_the_camera_around_an_object/OrbitTheCameraAroundAnObjectSample.java",
         "src/main/resources/orbit_the_camera_around_an_object/main.fxml"
     ],
-    "title": "Orbit the camera around an object"
+    "title": "Orbit camera around object"
 }

--- a/scene/scene-layer-selection/README.metadata.json
+++ b/scene/scene-layer-selection/README.metadata.json
@@ -1,23 +1,33 @@
 {
     "category": "Scene",
-    "description": "Select clicked features in a scene.",
+    "description": "Identify features in a scene to select.",
     "ignore": false,
     "images": [
         "SceneLayerSelection.png"
     ],
     "keywords": [
+        "3D",
+        "Berlin",
+        "buildings",
+        "identify",
+        "model",
+        "query",
+        "search",
+        "select",
         "ArcGISSceneLayer",
-        "GeoElement",
-        "IdentifyLayerResult"
+        "Scene",
+        "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/scene-layer-selection.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/scene-layer-selection.htm"
+    ],
     "relevant_apis": [
         "ArcGISSceneLayer",
-        "GeoElement",
-        "IdentifyLayerResult"
+        "Scene",
+        "SceneView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/scene_layer_selection/SceneLayerSelectionSample.java"
     ],
-    "title": "Scene Layer Selection"
+    "title": "Scene layer selection"
 }

--- a/scene/scene-layer/README.metadata.json
+++ b/scene/scene-layer/README.metadata.json
@@ -1,31 +1,28 @@
 {
     "category": "Scene",
-    "description": "Display a scene layer with 3. buildings.",
+    "description": "Add a scene layer to a scene.",
     "ignore": false,
     "images": [
         "SceneLayer.png"
     ],
     "keywords": [
         "3D",
+        "layer",
+        "scene",
         "ArcGISScene",
         "ArcGISSceneLayer",
-        "ArcGISTiledElevationSource",
-        "Camera",
-        "SceneView",
-        "Surface"
+        "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/scene-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/scene-layer.htm"
+    ],
     "relevant_apis": [
-        "3D",
         "ArcGISScene",
         "ArcGISSceneLayer",
-        "ArcGISTiledElevationSource",
-        "Camera",
-        "SceneView",
-        "Surface"
+        "SceneView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/scene_layer/SceneLayerSample.java"
     ],
-    "title": "Scene Layer"
+    "title": "Scene layer"
 }

--- a/scene/scene-properties-expressions/README.metadata.json
+++ b/scene/scene-properties-expressions/README.metadata.json
@@ -1,33 +1,41 @@
 {
     "category": "Scene",
-    "description": "Update the orientation of a graphic using scene property rotation expressions.",
+    "description": "Update the orientation of a graphic using expressions based on its attributes.",
     "ignore": false,
     "images": [
         "ScenePropertiesExpressions.gif"
     ],
     "keywords": [
-        "ArcGISScene",
+        "3D",
+        "expression",
+        "graphics",
+        "heading",
+        "pitch",
+        "rotation",
+        "scene",
+        "symbology",
         "Graphic",
         "GraphicsOverlay",
-        "Renderer",
-        "Renderer.SceneProperties",
-        "SceneView",
-        "Viewpoint"
+        "SceneProperties",
+        "SceneProperties.setHeadingExpression",
+        "SceneProperties.setPitchExpression",
+        "SimpleRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/scene-properties-expressions.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/scene-properties-expressions.htm"
+    ],
     "relevant_apis": [
-        "ArcGISScene",
         "Graphic",
         "GraphicsOverlay",
-        "Renderer",
-        "Renderer.SceneProperties",
-        "SceneView",
-        "Viewpoint"
+        "SceneProperties",
+        "SceneProperties.setHeadingExpression",
+        "SceneProperties.setPitchExpression",
+        "SimpleRenderer"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/scene_properties_expressions/ScenePropertiesExpressionsSample.java",
         "src/main/java/com/esri/samples/scene_properties_expressions/ScenePropertiesExpressionsController.java",
+        "src/main/java/com/esri/samples/scene_properties_expressions/ScenePropertiesExpressionsSample.java",
         "src/main/resources/scene_properties_expressions/main.fxml"
     ],
-    "title": "Scene Properties Expressions"
+    "title": "Scene property expressions"
 }

--- a/scene/surface-placement/README.metadata.json
+++ b/scene/surface-placement/README.metadata.json
@@ -1,23 +1,30 @@
 {
     "category": "Scene",
-    "description": "Position graphics relative to terrain.",
+    "description": "Position graphics relative to a surface using different surface placement modes.",
     "ignore": false,
     "images": [
         "SurfacePlacement.png"
     ],
     "keywords": [
         "3D",
-        "Absolute",
-        "Altitude",
-        "Draped",
-        "Elevation",
-        "Floating",
-        "Relative",
-        "Scene",
-        "Sea level",
-        "Surface placement"
+        "absolute",
+        "altitude",
+        "draped",
+        "elevation",
+        "floating",
+        "relative",
+        "scenes",
+        "sea level",
+        "surface placement",
+        "Graphic",
+        "GraphicsOverlay",
+        "LayerSceneProperties.SurfacePlacement",
+        "SceneProperties",
+        "Surface"
     ],
-    "redirect_from": "/java/latest/sample-code/elevation-mode.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/elevation-mode.htm"
+    ],
     "relevant_apis": [
         "Graphic",
         "GraphicsOverlay",
@@ -26,8 +33,7 @@
         "Surface"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/surface_placement/SurfacePlacementSample.java",
-        "src/main/java/com/esri/samples/surface_placement/SurfacePlacementLauncher.java"
+        "src/main/java/com/esri/samples/surface_placement/SurfacePlacementSample.java"
     ],
-    "title": "Surface Placement"
+    "title": "Surface placement"
 }

--- a/scene/symbols/README.metadata.json
+++ b/scene/symbols/README.metadata.json
@@ -1,26 +1,40 @@
 {
     "category": "Scene",
-    "description": "Create graphics with simple 3D shapes.",
+    "description": "Show various kinds of 3D symbols in a scene.",
     "ignore": false,
     "images": [
         "Symbols.png"
     ],
     "keywords": [
-        "ArcGISScene",
+        "3D",
+        "cone",
+        "cube",
+        "cylinder",
+        "diamond",
+        "geometry",
+        "pyramid",
+        "scene",
+        "shape",
+        "sphere",
+        "symbol",
+        "tetrahedron",
+        "tube",
+        "visualization",
         "Graphic",
         "GraphicsOverlay",
+        "SceneSymbol.AnchorPosition",
         "SimpleMarkerSceneSymbol",
-        "SimpleMarkerSceneSymbol.STYLE",
-        "SceneSymbol.AnchorPosition"
+        "SimpleMarkerSceneSymbol.Style"
     ],
-    "redirect_from": "/java/latest/sample-code/symbols.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/symbols.htm"
+    ],
     "relevant_apis": [
-        "ArcGISScene",
         "Graphic",
         "GraphicsOverlay",
+        "SceneSymbol.AnchorPosition",
         "SimpleMarkerSceneSymbol",
-        "SimpleMarkerSceneSymbol.STYLE",
-        "SceneSymbol.AnchorPosition"
+        "SimpleMarkerSceneSymbol.Style"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/symbols/SymbolsSample.java"

--- a/scene/sync-map-and-scene-viewpoints/README.metadata.json
+++ b/scene/sync-map-and-scene-viewpoints/README.metadata.json
@@ -1,29 +1,37 @@
 {
     "category": "Scene",
-    "description": "Synchronize the viewpoints between a MapView and a SceneView.",
+    "description": "Keep the view points of two views (e.g. MapView and SceneView) synchronized with each other.",
     "ignore": false,
     "images": [
         "SyncMapAndSceneViewpoints.png"
     ],
     "keywords": [
-        "2D",
         "3D",
-        "view synchronisation",
-        "Viewpoint",
-        "Scene",
-        "Map",
+        "automatic refresh",
+        "event",
+        "event handler",
+        "events",
+        "extent",
+        "interaction",
+        "interactions",
+        "pan",
+        "sync",
+        "synchronize",
+        "zoom",
         "GeoView",
-        "Viewpoint",
-        "ViewpointChangedEvent"
+        "MapView",
+        "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/sync-map-and-scene-viewpoints.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/sync-map-and-scene-viewpoints.htm"
+    ],
     "relevant_apis": [
         "GeoView",
-        "Viewpoint",
-        "ViewpointChangedEvent"
+        "MapView",
+        "SceneView"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/sync_map_and_scene_viewpoints/SyncMapAndSceneViewpointsSample.java"
     ],
-    "title": "Sync Map and Scene Viewpoints"
+    "title": "Sync map and scene viewpoints"
 }

--- a/scene/terrain-exaggeration/README.metadata.json
+++ b/scene/terrain-exaggeration/README.metadata.json
@@ -1,25 +1,32 @@
 {
     "category": "Scene",
-    "description": "Vertically exaggerate terrain.",
+    "description": "Vertically exaggerate terrain in a scene.",
     "ignore": false,
     "images": [
         "TerrainExaggeration.gif"
     ],
     "keywords": [
+        "3D",
+        "DEM",
+        "DTM",
+        "elevation",
+        "scene",
+        "surface",
+        "terrain",
         "ArcGISScene",
-        "Surface",
-        "ArcGISTiledElevationSource"
+        "Surface"
     ],
-    "redirect_from": "/java/latest/sample-code/terrain-exaggeration.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/terrain-exaggeration.htm"
+    ],
     "relevant_apis": [
         "ArcGISScene",
-        "Surface",
-        "ArcGISTiledElevationSource"
+        "Surface"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/terrain_exaggeration/TerrainExaggerationSample.java",
         "src/main/java/com/esri/samples/terrain_exaggeration/TerrainExaggerationController.java",
+        "src/main/java/com/esri/samples/terrain_exaggeration/TerrainExaggerationSample.java",
         "src/main/resources/terrain_exaggeration/main.fxml"
     ],
-    "title": "Terrain Exaggeration"
+    "title": "Terrain exaggeration"
 }

--- a/scene/view-content-beneath-terrain-surface/README.metadata.json
+++ b/scene/view-content-beneath-terrain-surface/README.metadata.json
@@ -10,16 +10,18 @@
         "subsurface",
         "underground",
         "utilities",
-        "Surface",
-        "Surface.NavigationConstraint"
+        "NavigationConstraint",
+        "Surface"
     ],
-    "redirect_from": "/java/latest/sample-code/view-content-beneath-terrain-surface.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/view-content-beneath-terrain-surface.htm"
+    ],
     "relevant_apis": [
-        "Surface",
-        "Surface.NavigationConstraint"
+        "NavigationConstraint",
+        "Surface"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/view_content_beneath_terrain_surface/ViewContentBeneathTerrainSurfaceSample.java"
     ],
-    "title": "View content beneath terrain surface"
+    "title": "View content beneath the terrain surface"
 }

--- a/scene/view-point-cloud-data-offline/README.metadata.json
+++ b/scene/view-point-cloud-data-offline/README.metadata.json
@@ -1,17 +1,19 @@
 {
     "category": "Scene",
-    "description": "Display local 3. point cloud data.",
+    "description": "Display local 3D point cloud data.",
     "ignore": false,
     "images": [
         "ViewPointCloudDataOffline.png"
     ],
     "keywords": [
         "3D",
-        "point cloud",
         "lidar",
+        "point cloud",
         "PointCloudLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/view-point-cloud-data-offline.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/view-point-cloud-data-offline.htm"
+    ],
     "relevant_apis": [
         "PointCloudLayer"
     ],

--- a/search/find-address/README.metadata.json
+++ b/search/find-address/README.metadata.json
@@ -6,24 +6,24 @@
         "FindAddress.gif"
     ],
     "keywords": [
-        "ArcGISMap",
+        "address",
+        "geocode",
+        "locator",
+        "search",
         "GeocodeParameters",
         "GeocodeResult",
-        "GraphicsOverlay",
-        "LocatorTask",
-        "MapView"
+        "LocatorTask"
     ],
-    "redirect_from": "/java/latest/sample-code/find-address.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/find-address.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "GeocodeParameters",
         "GeocodeResult",
-        "GraphicsOverlay",
-        "LocatorTask",
-        "MapView"
+        "LocatorTask"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/find_address/FindAddressSample.java"
     ],
-    "title": "Find Address"
+    "title": "Find address"
 }

--- a/search/find-place/README.metadata.json
+++ b/search/find-place/README.metadata.json
@@ -1,39 +1,40 @@
 {
     "category": "Search",
-    "description": "Find places of interest near a location or within an specific area.",
+    "description": "Find places of interest near a location or within a specific area.",
     "ignore": false,
     "images": [
         "FindPlace.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "POI",
+        "businesses",
+        "geocode",
+        "locations",
+        "locator",
+        "places of interest",
+        "point of interest",
+        "search",
+        "suggestions",
         "GeocodeParameters",
         "GeocodeResult",
-        "Graphic",
-        "GraphicsOverlay",
         "LocatorTask",
-        "MapView",
-        "PictureMarkerSymbol",
-        "ReverseGeocodeParameters",
-        "TileCache"
+        "SuggestParameters",
+        "SuggestResult"
     ],
-    "redirect_from": "/java/latest/sample-code/find-place.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/find-place.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "GeocodeParameters",
         "GeocodeResult",
-        "Graphic",
-        "GraphicsOverlay",
         "LocatorTask",
-        "MapView",
-        "PictureMarkerSymbol",
-        "ReverseGeocodeParameters",
-        "TileCache"
+        "SuggestParameters",
+        "SuggestResult"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/find_place/FindPlaceSample.java",
         "src/main/java/com/esri/samples/find_place/FindPlaceController.java",
+        "src/main/java/com/esri/samples/find_place/FindPlaceSample.java",
         "src/main/resources/find_place/main.fxml"
     ],
-    "title": "Find Place"
+    "title": "Find place"
 }

--- a/search/offline-geocode/README.metadata.json
+++ b/search/offline-geocode/README.metadata.json
@@ -1,43 +1,34 @@
 {
     "category": "Search",
-    "description": "Geocode with offline data.",
+    "description": "Geocode addresses to locations and reverse geocode locations to addresses offline.",
     "ignore": false,
     "images": [
         "OfflineGeocode.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "ArcGISTiledLayer",
-        "Callout",
-        "MapView",
-        "LocatorTask",
+        "geocode",
+        "geocoder",
+        "locator",
+        "offline",
+        "package",
+        "query",
+        "search",
         "GeocodeParameters",
         "GeocodeResult",
-        "Graphic",
-        "GraphicsOverlay",
-        "Point",
-        "PictureMarkerSymbol",
-        "ReverseGeocodeParameters",
-        "TileCache"
+        "LocatorTask",
+        "ReverseGeocodeParameters"
     ],
-    "redirect_from": "/java/latest/sample-code/offline-geocode.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/offline-geocode.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "ArcGISTiledLayer",
-        "Callout",
-        "MapView",
-        "LocatorTask",
         "GeocodeParameters",
         "GeocodeResult",
-        "Graphic",
-        "GraphicsOverlay",
-        "Point",
-        "PictureMarkerSymbol",
-        "ReverseGeocodeParameters",
-        "TileCache"
+        "LocatorTask",
+        "ReverseGeocodeParameters"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/offline_geocode/OfflineGeocodeSample.java"
     ],
-    "title": "Offline Geocode"
+    "title": "Offline geocode"
 }

--- a/search/reverse-geocode-online/README.metadata.json
+++ b/search/reverse-geocode-online/README.metadata.json
@@ -1,33 +1,30 @@
 {
     "category": "Search",
-    "description": "Find the address of a location.",
+    "description": "Use an online service to find the address for a point on the map.",
     "ignore": false,
     "images": [
         "ReverseGeocodeOnline.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "address",
+        "geocode",
+        "locate",
+        "reverse geocode",
+        "search",
         "GeocodeParameters",
-        "GraphicsOverlay",
         "LocatorTask",
-        "MapView",
-        "PictureMarkerSymbol",
-        "ReverseGeocodeParameters",
-        "TileCache"
+        "ReverseGeocodeParameters"
     ],
-    "redirect_from": "/java/latest/sample-code/reverse-geocode-online.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/reverse-geocode-online.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "GeocodeParameters",
-        "GraphicsOverlay",
         "LocatorTask",
-        "MapView",
-        "PictureMarkerSymbol",
-        "ReverseGeocodeParameters",
-        "TileCache"
+        "ReverseGeocodeParameters"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/reverse_geocode_online/ReverseGeocodeOnlineSample.java"
     ],
-    "title": "Reverse Geocode Online"
+    "title": "Reverse geocode online"
 }

--- a/symbology/custom-dictionary-style/README.metadata.json
+++ b/symbology/custom-dictionary-style/README.metadata.json
@@ -1,26 +1,28 @@
 {
-  "category": "Symbology",
-  "description": "Use a custom dictionary style (.stylx) to symbolize features using a variety of attribute values.",
-  "ignore": false,
-  "images": [
-    "CustomDictionaryStyle.png"
-  ],
-  "keywords": [
-    "dictionary",
-    "military",
-    "renderer",
-    "style",
-    "stylx",
-    "unique value",
-    "visualization"
-  ],
-  "relevant_apis": [
-    "DictionaryRenderer",
-    "DictionarySymbolStyle",
-    "DictionarySymbolStyleConfiguration"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/custom_dictionary_style/CustomDictionaryStyleSample.java"
-  ],
-  "title": "Custom dictionary style"
+    "category": "Symbology",
+    "description": "Use a custom dictionary style (.stylx) to symbolize features using a variety of attribute values.",
+    "ignore": false,
+    "images": [
+        "CustomDictionaryStyle.png"
+    ],
+    "keywords": [
+        "dictionary",
+        "military",
+        "renderer",
+        "style",
+        "stylx",
+        "unique value",
+        "visualization",
+        "DictionaryRenderer",
+        "DictionarySymbolStyle"
+    ],
+    "redirect_from": [],
+    "relevant_apis": [
+        "DictionaryRenderer",
+        "DictionarySymbolStyle"
+    ],
+    "snippets": [
+        "src/main/java/com/esri/samples/custom_dictionary_style/CustomDictionaryStyleSample.java"
+    ],
+    "title": "Custom dictionary style"
 }

--- a/symbology/custom-dictionary-style/README.metadata.json
+++ b/symbology/custom-dictionary-style/README.metadata.json
@@ -16,7 +16,7 @@
         "DictionaryRenderer",
         "DictionarySymbolStyle"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "DictionaryRenderer",
         "DictionarySymbolStyle"

--- a/symbology/graphics-overlay-dictionary-renderer-3D/README.metadata.json
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/README.metadata.json
@@ -1,23 +1,27 @@
 {
     "category": "Symbology",
-    "description": "Display MIL-STD-2525d military symbology in 3D.",
+    "description": "Display MIL-STD-2525. military symbology in 3D.",
     "ignore": false,
     "images": [
         "GraphicsOverlayDictionaryRenderer3D.png"
     ],
     "keywords": [
-        "Graphics",
-        "Symbology",
-        "3D",
-        "GraphicsOverlay",
+        "defense",
+        "military",
+        "situational awareness",
+        "tactical",
+        "visualization",
         "DictionaryRenderer",
-        "DictionarySymbolStyle"
+        "DictionarySymbolStyle",
+        "GraphicsOverlay"
     ],
-    "redirect_from": "/java/latest/sample-code/graphics-overlay-dictionary-renderer-3d.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/graphics-overlay-dictionary-renderer-3d.htm"
+    ],
     "relevant_apis": [
-        "GraphicsOverlay",
         "DictionaryRenderer",
-        "DictionarySymbolStyle"
+        "DictionarySymbolStyle",
+        "GraphicsOverlay"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/graphics_overlay_dictionary_renderer_3D/GraphicsOverlayDictionaryRenderer3DSample.java"

--- a/symbology/picture-marker-symbol/README.metadata.json
+++ b/symbology/picture-marker-symbol/README.metadata.json
@@ -6,24 +6,21 @@
         "PictureMarkerSymbol.png"
     ],
     "keywords": [
-        "ArcGISMap",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
-        "PictureMarkerSymbol",
-        "Point"
+        "graphics",
+        "marker",
+        "picture",
+        "symbol",
+        "visualization",
+        "PictureMarkerSymbol"
     ],
-    "redirect_from": "/java/latest/sample-code/picture-marker-symbol.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/picture-marker-symbol.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
-        "Graphic",
-        "GraphicsOverlay",
-        "MapView",
-        "PictureMarkerSymbol",
-        "Point"
+        "PictureMarkerSymbol"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/picture_marker_symbol/PictureMarkerSymbolSample.java"
     ],
-    "title": "Picture Marker Symbol"
+    "title": "Picture marker symbol"
 }

--- a/symbology/read-symbols-from-mobile-style-file/README.metadata.json
+++ b/symbology/read-symbols-from-mobile-style-file/README.metadata.json
@@ -1,28 +1,34 @@
 {
-  "category": "Symbology",
-  "description": "Combine multiple symbols from a mobile style file into a single symbol.",
-  "ignore": false,
-  "images": [
-    "ReadSymbolsFromMobileStyleFile.png"
-  ],
-  "keywords": [
-    "advanced symbology",
-    "mobile style",
-    "multilayer",
-    "stylx"
-  ],
-  "relevant_apis": [
-    "MultilayerPointSymbol",
-    "MultilayerSymbol",
-    "SymbolLayer",
-    "SymbolStyle",
-    "SymbolStyleSearchParameters"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/read_symbols_from_mobile_style_file/ReadSymbolsFromMobileStyleFileSample.java",
-    "src/main/java/com/esri/samples/read_symbols_from_mobile_style_file/ReadSymbolsFromMobileStyleFileController.java",
-    "src/main/java/com/esri/samples/read_symbols_from_mobile_style_file/SymbolLayerInfoListCell.java",
-    "src/main/resources/read_symbols_from_mobile_style_file/main.fxml"
-  ],
-  "title": "Read Symbols from Mobile Style File"
+    "category": "Symbology",
+    "description": "Combine multiple symbols from a mobile style file into a single symbol.",
+    "ignore": false,
+    "images": [
+        "ReadSymbolsFromMobileStyleFile.png"
+    ],
+    "keywords": [
+        "advanced symbology",
+        "mobile style",
+        "multilayer",
+        "stylx",
+        "MultilayerPointSymbol",
+        "MultilayerSymbol",
+        "SymbolLayer",
+        "SymbolStyle",
+        "SymbolStyleSearchParameters"
+    ],
+    "redirect_from": [],
+    "relevant_apis": [
+        "MultilayerPointSymbol",
+        "MultilayerSymbol",
+        "SymbolLayer",
+        "SymbolStyle",
+        "SymbolStyleSearchParameters"
+    ],
+    "snippets": [
+        "src/main/java/com/esri/samples/read_symbols_from_mobile_style_file/ReadSymbolsFromMobileStyleFileController.java",
+        "src/main/java/com/esri/samples/read_symbols_from_mobile_style_file/ReadSymbolsFromMobileStyleFileSample.java",
+        "src/main/java/com/esri/samples/read_symbols_from_mobile_style_file/SymbolLayerInfoListCell.java",
+        "src/main/resources/read_symbols_from_mobile_style_file/main.fxml"
+    ],
+    "title": "Read symbols from a mobile style file"
 }

--- a/symbology/read-symbols-from-mobile-style-file/README.metadata.json
+++ b/symbology/read-symbols-from-mobile-style-file/README.metadata.json
@@ -16,7 +16,7 @@
         "SymbolStyle",
         "SymbolStyleSearchParameters"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "MultilayerPointSymbol",
         "MultilayerSymbol",

--- a/symbology/simple-fill-symbol/README.metadata.json
+++ b/symbology/simple-fill-symbol/README.metadata.json
@@ -1,35 +1,35 @@
 {
     "category": "Symbology",
-    "description": "Change a graphic's fill color, outline, and style properties.",
+    "description": "Change a graphic's fill color, outline color, and fill style properties.",
     "ignore": false,
     "images": [
         "SimpleFillSymbol.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "fill",
+        "graphic",
+        "line",
+        "symbol",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
-        "Polygon",
         "PointCollection",
+        "Polygon",
         "SimpleFillSymbol",
-        "SimpleFillSymbol.Style",
         "SimpleLineSymbol"
     ],
-    "redirect_from": "/java/latest/sample-code/simple-fill-symbol.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/simple-fill-symbol.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
-        "Polygon",
         "PointCollection",
+        "Polygon",
         "SimpleFillSymbol",
-        "SimpleFillSymbol.Style",
         "SimpleLineSymbol"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java"
     ],
-    "title": "Simple Fill Symbol"
+    "title": "Simple fill symbol"
 }

--- a/symbology/simple-line-symbol/README.metadata.json
+++ b/symbology/simple-line-symbol/README.metadata.json
@@ -1,33 +1,32 @@
 {
     "category": "Symbology",
-    "description": "Change a line graphic's color and style.",
+    "description": "Change a line graphic's color, width and style.",
     "ignore": false,
     "images": [
         "SimpleLineSymbol.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "graphic",
+        "line",
+        "symbol",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
-        "Polyline",
         "PointCollection",
-        "SimpleLineSymbol",
-        "SimpleLineSymbol.Style"
+        "Polyline",
+        "SimpleLineSymbol"
     ],
-    "redirect_from": "/java/latest/sample-code/simple-line-symbol.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/simple-line-symbol.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
-        "Polyline",
         "PointCollection",
-        "SimpleLineSymbol",
-        "SimpleLineSymbol.Style"
+        "Polyline",
+        "SimpleLineSymbol"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/simple_line_symbol/SimpleLineSymbolSample.java"
     ],
-    "title": "Simple Line Symbol"
+    "title": "Simple line symbol"
 }

--- a/symbology/simple-marker-symbol/README.metadata.json
+++ b/symbology/simple-marker-symbol/README.metadata.json
@@ -1,31 +1,29 @@
 {
     "category": "Symbology",
-    "description": "Show simple markers.",
+    "description": "Show a simple marker symbol on a map.",
     "ignore": false,
     "images": [
         "SimpleMarkerSymbol.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "symbol",
+        "visualization",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
         "Point",
-        "SimpleMarkerSymbol",
-        "SimpleMarkerSymbol.Style"
+        "SimpleMarkerSymbol"
     ],
-    "redirect_from": "/java/latest/sample-code/simple-marker-symbol.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/simple-marker-symbol.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
         "Point",
-        "SimpleMarkerSymbol",
-        "SimpleMarkerSymbol.Style"
+        "SimpleMarkerSymbol"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/simple_marker_symbol/SimpleMarkerSymbolSample.java"
     ],
-    "title": "Simple Marker Symbol"
+    "title": "Simple marker symbol"
 }

--- a/symbology/simple-renderer/README.metadata.json
+++ b/symbology/simple-renderer/README.metadata.json
@@ -1,33 +1,35 @@
 {
     "category": "Symbology",
-    "description": "Set default symbols for all graphics in an overlay.",
+    "description": "Display common symbols for all graphics in a graphics overlay with a renderer.",
     "ignore": false,
     "images": [
         "SimpleRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "graphics",
+        "marker",
+        "renderer",
+        "symbol",
+        "symbolize",
+        "symbology",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
         "Point",
         "SimpleMarkerSymbol",
-        "SimpleMarkerSymbol.Style",
         "SimpleRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/simple-renderer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/simple-renderer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Graphic",
         "GraphicsOverlay",
-        "MapView",
         "Point",
         "SimpleMarkerSymbol",
-        "SimpleMarkerSymbol.Style",
         "SimpleRenderer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/simple_renderer/SimpleRendererSample.java"
     ],
-    "title": "Simple Renderer"
+    "title": "Simple renderer"
 }

--- a/symbology/symbol-dictionary/README.metadata.json
+++ b/symbology/symbol-dictionary/README.metadata.json
@@ -17,13 +17,16 @@
         "mil2525d",
         "military",
         "military symbology",
+        "search",
         "symbology",
         "StyleSymbolSearchParameters",
         "StyleSymbolSearchResult",
         "Symbol",
         "SymbolDictionary"
     ],
-    "redirect_from": "/java/latest/sample-code/symbol-dictionary.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/symbol-dictionary.htm"
+    ],
     "relevant_apis": [
         "StyleSymbolSearchParameters",
         "StyleSymbolSearchResult",
@@ -31,11 +34,11 @@
         "SymbolDictionary"
     ],
     "snippets": [
-        "src/main/java/com/esri/samples/symbol_dictionary/SymbolDictionarySample.java",
         "src/main/java/com/esri/samples/symbol_dictionary/SymbolDictionaryController.java",
+        "src/main/java/com/esri/samples/symbol_dictionary/SymbolDictionarySample.java",
         "src/main/java/com/esri/samples/symbol_dictionary/SymbolView.java",
         "src/main/resources/symbol_dictionary/main.fxml",
         "src/main/resources/symbol_dictionary/symbol_view.fxml"
     ],
-    "title": "Symbol Dictionary"
+    "title": "Search symbol dictionary"
 }

--- a/symbology/symbolize-shapefile/README.metadata.json
+++ b/symbology/symbolize-shapefile/README.metadata.json
@@ -1,18 +1,25 @@
 {
     "category": "Symbology",
-    "description": "Override the default rendering of a shapefile.",
+    "description": "Display a shapefile with custom symbology.",
     "ignore": false,
     "images": [
         "SymbolizeShapefile.png"
     ],
     "keywords": [
+        "package",
+        "shape file",
+        "shapefile",
+        "symbology",
+        "visualization",
         "FeatureLayer",
         "ShapefileFeatureTable",
         "SimpleFillSymbol",
         "SimpleLineSymbol",
         "SimpleRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/symbolize-shapefile.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/symbolize-shapefile.htm"
+    ],
     "relevant_apis": [
         "FeatureLayer",
         "ShapefileFeatureTable",
@@ -23,5 +30,5 @@
     "snippets": [
         "src/main/java/com/esri/samples/symbolize_shapefile/SymbolizeShapefileSample.java"
     ],
-    "title": "Symbolize Shapefile"
+    "title": "Symbolize shapefile"
 }

--- a/symbology/unique-value-renderer/README.metadata.json
+++ b/symbology/unique-value-renderer/README.metadata.json
@@ -1,33 +1,36 @@
 {
     "category": "Symbology",
-    "description": "Symbolize features based on their unique attribute value.",
+    "description": "Render features in a layer using a distinct symbol for each unique attribute value.",
     "ignore": false,
     "images": [
         "UniqueValueRenderer.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "draw",
+        "renderer",
+        "symbol",
+        "symbology",
+        "values",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable",
         "SimpleFillSymbol",
         "SimpleLineSymbol",
-        "UniqueValues",
+        "UniqueValue",
         "UniqueValueRenderer"
     ],
-    "redirect_from": "/java/latest/sample-code/unique-value-renderer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/unique-value-renderer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "FeatureLayer",
-        "MapView",
         "ServiceFeatureTable",
         "SimpleFillSymbol",
         "SimpleLineSymbol",
-        "UniqueValues",
+        "UniqueValue",
         "UniqueValueRenderer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java"
     ],
-    "title": "Unique Value Renderer"
+    "title": "Unique value renderer"
 }

--- a/tiled_layers/export-tiles/README.metadata.json
+++ b/tiled_layers/export-tiles/README.metadata.json
@@ -1,33 +1,32 @@
 {
     "category": "Tiled layers",
-    "description": "Export tiles from an online tile service.",
+    "description": "Download tiles to a local tile cache file stored on the device.",
     "ignore": false,
     "images": [
         "ExportTiles.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "cache",
+        "download",
+        "offline",
         "ArcGISTiledLayer",
-        "Basemap",
         "ExportTileCacheJob",
-        "ExportTileCacheParamters",
+        "ExportTileCacheParameters",
         "ExportTileCacheTask",
-        "MapView",
         "TileCache"
     ],
-    "redirect_from": "/java/latest/sample-code/export-tiles.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/export-tiles.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "ArcGISTiledLayer",
-        "Basemap",
         "ExportTileCacheJob",
-        "ExportTileCacheParamters",
+        "ExportTileCacheParameters",
         "ExportTileCacheTask",
-        "MapView",
         "TileCache"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/export_tiles/ExportTilesSample.java"
     ],
-    "title": "Export Tiles"
+    "title": "Export tiles"
 }

--- a/tiled_layers/export-vector-tiles/README.metadata.json
+++ b/tiled_layers/export-vector-tiles/README.metadata.json
@@ -6,32 +6,32 @@
         "ExportVectorTiles.png"
     ],
     "keywords": [
+        "cache",
+        "download",
+        "offline",
+        "vector",
         "ArcGISVectorTiledLayer",
         "ExportVectorTilesJob",
-        "ExportVectorTilesParamters",
+        "ExportVectorTilesParameters",
         "ExportVectorTilesResult",
         "ExportVectorTilesTask",
         "ItemResourceCache",
-        "Portal",
-        "PortalItem",
-        "UserCredential",
         "VectorTileCache"
     ],
-    "redirect_from": "/java/latest/sample-code/export-vector-tiles.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/export-vector-tiles.htm"
+    ],
     "relevant_apis": [
         "ArcGISVectorTiledLayer",
         "ExportVectorTilesJob",
-        "ExportVectorTilesParamters",
+        "ExportVectorTilesParameters",
         "ExportVectorTilesResult",
         "ExportVectorTilesTask",
         "ItemResourceCache",
-        "Portal",
-        "PortalItem",
-        "UserCredential",
         "VectorTileCache"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/export_vector_tiles/ExportVectorTilesSample.java"
     ],
-    "title": "Export Vector Tiles"
+    "title": "Export vector tiles"
 }

--- a/tiled_layers/tile-cache/README.metadata.json
+++ b/tiled_layers/tile-cache/README.metadata.json
@@ -1,23 +1,27 @@
 {
     "category": "Tiled layers",
-    "description": "Create a basemap from a local tile cache.",
+    "description": "Load an offline copy of a tiled map service as a basemap.",
     "ignore": false,
     "images": [
         "TileCache.png"
     ],
     "keywords": [
+        "cache",
         "layers",
+        "offline",
         "tile",
-        "TileCache",
-        "ArcGISTiledLayer",
         "ArcGISMap",
         "ArcGISTiledLayer",
+        "Basemap",
         "TileCache"
     ],
-    "redirect_from": "/java/latest/sample-code/tile-cache.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/tile-cache.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "ArcGISTiledLayer",
+        "Basemap",
         "TileCache"
     ],
     "snippets": [

--- a/tiled_layers/tiled-layer/README.metadata.json
+++ b/tiled_layers/tiled-layer/README.metadata.json
@@ -1,22 +1,28 @@
 {
     "category": "Tiled layers",
-    "description": "Display tiles from an ArcGIS tile service.",
+    "description": "Load an ArcGIS tiled layer from a URL.",
     "ignore": false,
     "images": [
         "TiledLayer.png"
     ],
     "keywords": [
+        "basemap",
         "layers",
-        "tile",
-        "ArcGISTiledLayer",
+        "raster tiles",
+        "tiled layer",
+        "visualization",
         "ArcGISMap",
         "ArcGISTiledLayer",
+        "Basemap",
         "MapView"
     ],
-    "redirect_from": "/java/latest/sample-code/tiled-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/tiled-layer.htm"
+    ],
     "relevant_apis": [
         "ArcGISMap",
         "ArcGISTiledLayer",
+        "Basemap",
         "MapView"
     ],
     "snippets": [

--- a/tiled_layers/vector-tiled-layer-url/README.metadata.json
+++ b/tiled_layers/vector-tiled-layer-url/README.metadata.json
@@ -1,25 +1,28 @@
 {
     "category": "Tiled layers",
-    "description": "Display tiles from an ArcGIS vector tile service.",
+    "description": "Load an ArcGIS vector tiled layer from a URL.",
     "ignore": false,
     "images": [
         "VectorTiledLayerURL.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "tiles",
+        "vector",
+        "vector basemap",
+        "vector tiled layer",
+        "vector tiles",
         "ArcGISVectorTiledLayer",
-        "Basemap",
-        "MapView"
+        "Basemap"
     ],
-    "redirect_from": "/java/latest/sample-code/vector-tiled-layer-url.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/vector-tiled-layer-url.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "ArcGISVectorTiledLayer",
-        "Basemap",
-        "MapView"
+        "Basemap"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/vector_tiled_layer_url/VectorTiledLayerURLSample.java"
     ],
-    "title": "Vector Tiled Layer URL"
+    "title": "Vector tiled layer URL"
 }

--- a/tiled_layers/web-tiled-layer/README.metadata.json
+++ b/tiled_layers/web-tiled-layer/README.metadata.json
@@ -1,25 +1,30 @@
 {
     "category": "Tiled layers",
-    "description": "Display map tiles from any custom (non-ArcGIS) service.",
+    "description": "Display a tiled web layer.",
     "ignore": false,
     "images": [
         "WebTiledLayer.png"
     ],
     "keywords": [
-        "ArcGISMap",
+        "OGC",
+        "Open Street Map",
+        "OpenStreetMap",
+        "layer",
+        "stamen.com",
+        "tiled",
+        "tiles",
         "Basemap",
-        "MapView",
         "WebTiledLayer"
     ],
-    "redirect_from": "/java/latest/sample-code/web-tiled-layer.htm",
+    "redirect_from": [
+        "/java/latest/sample-code/web-tiled-layer.htm"
+    ],
     "relevant_apis": [
-        "ArcGISMap",
         "Basemap",
-        "MapView",
         "WebTiledLayer"
     ],
     "snippets": [
         "src/main/java/com/esri/samples/web_tiled_layer/WebTiledLayerSample.java"
     ],
-    "title": "Web Tiled Layer"
+    "title": "Web tiled layer"
 }

--- a/utility_network/trace-a-utility-network/README.metadata.json
+++ b/utility_network/trace-a-utility-network/README.metadata.json
@@ -29,7 +29,7 @@
         "UtilityTraceResult",
         "UtilityTraceType"
     ],
-    "redirect_from": [],
+    "redirect_from": [""],
     "relevant_apis": [
         "UtilityAssetType",
         "UtilityDomainNetwork",

--- a/utility_network/trace-a-utility-network/README.metadata.json
+++ b/utility_network/trace-a-utility-network/README.metadata.json
@@ -1,41 +1,55 @@
 {
-  "category": "Utility network",
-  "description": "Discover connected features in a utility network using connected, subnetwork, upstream, and downstream traces.",
-  "ignore": false,
-  "images": [
-    "TraceUtilityNetwork.png"
-  ],
-  "keywords": [
-    "condition barriers",
-    "downstream trace",
-    "network analysis",
-    "subnetwork trace",
-    "trace configuration",
-    "upstream trace",
-    "utility network",
-    "validate consistency"
-  ],
-  "relevant_apis": [
-    "FractionAlongEdge",
-    "UtilityAssetType",
-    "UtilityDomainNetwork",
-    "UtilityElement",
-    "UtilityElementTraceResult",
-    "UtilityNetwork",
-    "UtilityNetworkDefinition",
-    "UtilityNetworkSource",
-    "UtilityTerminal",
-    "UtilityTier",
-    "UtilityTraceParameters",
-    "UtilityTraceResult",
-    "UtilityTraceType"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/trace_a_utility_network/TraceAUtilityNetworkController.java",
-    "src/main/java/com/esri/samples/trace_a_utility_network/TraceAUtilityNetworkLauncher.java",
-    "src/main/java/com/esri/samples/trace_a_utility_network/TraceAUtilityNetworkSample.java",
-    "src/main/java/com/esri/samples/trace_a_utility_network/UtilityTerminalListCell.java",
-    "src/main/resources/trace_a_utility_network/main.fxml"
-  ],
-  "title": "Trace a utility network"
+    "category": "Utility network",
+    "description": "Discover connected features in a utility network using connected, subnetwork, upstream, and downstream traces.",
+    "ignore": false,
+    "images": [
+        "TraceUtilityNetwork.png"
+    ],
+    "keywords": [
+        "condition barriers",
+        "downstream trace",
+        "network analysis",
+        "subnetwork trace",
+        "trace configuration",
+        "traversability",
+        "upstream trace",
+        "utility network",
+        "validate consistency",
+        "UtilityAssetType",
+        "UtilityDomainNetwork",
+        "UtilityElement",
+        "UtilityElementTraceResult",
+        "UtilityNetwork",
+        "UtilityNetworkDefinition",
+        "UtilityNetworkSource",
+        "UtilityTerminal",
+        "UtilityTier",
+        "UtilityTraceConfiguration",
+        "UtilityTraceParameters",
+        "UtilityTraceResult",
+        "UtilityTraceType"
+    ],
+    "redirect_from": [],
+    "relevant_apis": [
+        "UtilityAssetType",
+        "UtilityDomainNetwork",
+        "UtilityElement",
+        "UtilityElementTraceResult",
+        "UtilityNetwork",
+        "UtilityNetworkDefinition",
+        "UtilityNetworkSource",
+        "UtilityTerminal",
+        "UtilityTier",
+        "UtilityTraceConfiguration",
+        "UtilityTraceParameters",
+        "UtilityTraceResult",
+        "UtilityTraceType"
+    ],
+    "snippets": [
+        "src/main/java/com/esri/samples/trace_a_utility_network/TraceAUtilityNetworkController.java",
+        "src/main/java/com/esri/samples/trace_a_utility_network/TraceAUtilityNetworkSample.java",
+        "src/main/java/com/esri/samples/trace_a_utility_network/UtilityTerminalListCell.java",
+        "src/main/resources/trace_a_utility_network/main.fxml"
+    ],
+    "title": "Trace a utility network"
 }


### PR DESCRIPTION
Hi both,
as discussed here is a big PR to update all available README.metadata.json files, using a script to get the information from the file structure and from the README.md itself.
Unfortunately these changes end up in the git diff as the whole file being changed. Don't worry, not actually that much has changed (see below). I believe this is because of a change in encoding?

I think a good solution would be to probably only review 1 file from each category, and trust the script to do the rest properly. The main thing to look out for is probably mistakes in data scraping/ unusual characters or formatting, etc. The content is all straight from the README.md so I wouldn't worry about reviewing it here.

As mentioned below, `integrated_windows_authentication` is a good candidate for checking the script has done it's job properly, as it has many .java/.fxml files.
Probably also good to look at some files with .gif in the readme (e.g. `offline routing`)

Also noticed an unusual entry in:
analysis/viewshed-geoelement/README.metadata.json

The 'RelevantAPI' section has: `GeometryEngine.distanceGeodetic (used to animate the vehicle)`. @Rachael-E I'm going to guess this has no place in the README.metadata.json. I'll try and add a regex to search for any text in brackets and get rid of it. (see appropriate commit)

A quick overview:
- `category`: should be unchanged
- `description`: is scraped straight from the second line of the README.md, might change in some instances where we didn't have the two files in sync
- `ignore`: is always false
- `images`: Should essentially be unchanged. It is scraped from the README.md, meaning if the readme shows a gif, the metadata shows a gif (unless the files were out of sync). 
- `keywords`: a combination of the 'tags' in the REAMDE.md and the 'RELEVANT API' in the README.md. We've previously missed out on adding the API into this section, but it's definitely required. The tags are alphabetised, followed by the API, also alphabetised.
- `redirect_from`: should be unchanged
- `relevant_apis`: from the 'Relevant API' in the README.md
- `snippets`: all .java and .fxml files from the file structure, with the exception of *Launcher.java files.
	An interesting case to look at here is `integrated_windows_authentication` (several .java and .fxml files)
- `title`: scraped from the README.md


