### PR TITLE
Fix missing redirect URL

### DIFF
--- a/scene/animate-images-with-image-overlay/README.metadata.json
+++ b/scene/animate-images-with-image-overlay/README.metadata.json
@@ -18,7 +18,7 @@
         "ImageOverlay",
         "SceneView"
     ],
-    "redirect_from": "/java/latest/sample-code/animate-images-with-image-overlay.htm",
+    "redirect_from": "",
     "relevant_apis": [
         "ImageFrame",
         "ImageOverlay",

--- a/scene/animate-images-with-image-overlay/README.metadata.json
+++ b/scene/animate-images-with-image-overlay/README.metadata.json
@@ -18,7 +18,7 @@
         "ImageOverlay",
         "SceneView"
     ],
-    "redirect_from": [""],
+    "redirect_from": "/java/latest/sample-code/animate-images-with-image-overlay.htm",
     "relevant_apis": [
         "ImageFrame",
         "ImageOverlay",


### PR DESCRIPTION
`redirect_from` should not be an array of empty strings. if using array, all strings must be valid URLs.