### PR TITLE
change empty array to empty string

### DIFF
--- a/scene/animate-images-with-image-overlay/README.metadata.json
+++ b/scene/animate-images-with-image-overlay/README.metadata.json
@@ -18,7 +18,7 @@
         "ImageOverlay",
         "SceneView"
     ],
-    "redirect_from": [""],
+    "redirect_from": "",
     "relevant_apis": [
         "ImageFrame",
         "ImageOverlay",


### PR DESCRIPTION
Our developer site is currently failing to build, because it doesn't properly evaluate empty arrays in the `redirect_from` property. This is a temporary fix to change the format until the code can be made more robust.