### PR TITLE
Fix BufferList sample bug

### DIFF
--- a/geometry/buffer-list/src/main/java/com/esri/samples/buffer_list/BufferListSample.java
+++ b/geometry/buffer-list/src/main/java/com/esri/samples/buffer_list/BufferListSample.java
@@ -91,12 +91,11 @@ public class BufferListSample extends Application {
       // create a map view
       mapView = new MapView();
 
-      // create a map with a basemap and add it to the map view
+      // create a blank map with a spatial reference
       ArcGISMap map = new ArcGISMap(statePlaneNorthCentralTexas);
-      mapView.setMap(map);
-
-      // set an initial viewpoint
+      // set an initial viewpoint and add the map to the map view
       map.setInitialViewpoint(new Viewpoint(boundaryPolygon.getExtent()));
+      mapView.setMap(map);
 
       // create an image layer from a service URL (counties, cities, and highways)
       ArcGISMapImageLayer mapImageLayer = new ArcGISMapImageLayer("https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer");

--- a/geometry/buffer-list/src/main/java/com/esri/samples/buffer_list/BufferListSample.java
+++ b/geometry/buffer-list/src/main/java/com/esri/samples/buffer_list/BufferListSample.java
@@ -88,7 +88,7 @@ public class BufferListSample extends Application {
       );
       Polygon boundaryPolygon = (Polygon) GeometryEngine.project(new Polygon(new PointCollection(boundaryPoints)), statePlaneNorthCentralTexas);
 
-      // create a map with a basemap and set an initial viewpoint
+      // create a blank map with a spatial reference and set an initial viewpoint
       ArcGISMap map = new ArcGISMap(statePlaneNorthCentralTexas);
       map.setInitialViewpoint(new Viewpoint(boundaryPolygon.getExtent()));
 

--- a/geometry/buffer-list/src/main/java/com/esri/samples/buffer_list/BufferListSample.java
+++ b/geometry/buffer-list/src/main/java/com/esri/samples/buffer_list/BufferListSample.java
@@ -88,19 +88,18 @@ public class BufferListSample extends Application {
       );
       Polygon boundaryPolygon = (Polygon) GeometryEngine.project(new Polygon(new PointCollection(boundaryPoints)), statePlaneNorthCentralTexas);
 
-      // create a map view
-      mapView = new MapView();
-
-      // create a blank map with a spatial reference
+      // create a map with a basemap and set an initial viewpoint
       ArcGISMap map = new ArcGISMap(statePlaneNorthCentralTexas);
-      // set an initial viewpoint and add the map to the map view
       map.setInitialViewpoint(new Viewpoint(boundaryPolygon.getExtent()));
-      mapView.setMap(map);
 
       // create an image layer from a service URL (counties, cities, and highways)
       ArcGISMapImageLayer mapImageLayer = new ArcGISMapImageLayer("https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer");
       // add the image layer to the map's base layers
       map.getBasemap().getBaseLayers().add(mapImageLayer);
+
+      // create a map view and set the map to it
+      mapView = new MapView();
+      mapView.setMap(map);
 
       // show alert if layer fails to load
       mapImageLayer.addDoneLoadingListener(() -> {


### PR DESCRIPTION
Moves the `setInitialViewpoint` logic before setting the `mapView` to the `ArcGISMap`: if the map initial viewpoint logic is ordered after setting the map view to the map, it won't execute. Also updated the comments to be clearer. @JonLavi please could you take a look and test to make sure this works ok? Thanks! 