### PR TITLE
feature layer feature service - fix screenshot path

### DIFF
--- a/feature_layers/feature-layer-feature-service/README.md
+++ b/feature_layers/feature-layer-feature-service/README.md
@@ -2,7 +2,7 @@
 
 Show features from an online feature service.
 
-![Image of feature layer feature service](screenshot.png)
+![Image of feature layer feature service](FeatureLayerFeatureService.png)
 
 ## Use case
 

--- a/feature_layers/feature-layer-feature-service/README.metadata.json
+++ b/feature_layers/feature-layer-feature-service/README.metadata.json
@@ -3,7 +3,7 @@
     "description": "Show features from an online feature service.",
     "ignore": false,
     "images": [
-        "screenshot.png"
+        "FeatureLayerFeatureService.png"
     ],
     "keywords": [
         "feature table",


### PR DESCRIPTION
Not sure how this snuck through, but it was breaking my local sample viewer builds. 
The screenshot file name was wrong. Small update to fix that.