### PR TITLE
fix metadata file path, title, redirect

### DIFF
--- a/utility_network/display-utility-associations/README.metadata.json
+++ b/utility_network/display-utility-associations/README.metadata.json
@@ -1,30 +1,31 @@
 {
-  "category": "Utility network",
-  "description": "Create graphics for utility associations in a utility network.",
-  "ignore": false,
-  "images": [
-    "DisplayUtilityAssociations.png"
-  ],
-  "keywords": [
-    "associating",
-    "association",
-    "attachment",
-    "connectivity",
-    "containment",
-    "relationships",
-    "GraphicsOverlay",
-    "UtilityAssociation",
-    "UtilityAssociationType",
-    "UtilityNetwork"
-  ],
-  "relevant_apis": [
-    "GraphicsOverlay",
-    "UtilityAssociation",
-    "UtilityAssociationType",
-    "UtilityNetwork"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/display-utility-associations/DisplayUtilityAssociationsSample.java"
-  ],
-  "title": "Display utility association"
+    "category": "Utility network",
+    "description": "Create graphics for utility associations in a utility network.",
+    "ignore": false,
+    "images": [
+        "DisplayUtilityAssociations.png"
+    ],
+    "keywords": [
+        "associating",
+        "association",
+        "attachment",
+        "connectivity",
+        "containment",
+        "relationships",
+        "GraphicsOverlay",
+        "UtilityAssociation",
+        "UtilityAssociationType",
+        "UtilityNetwork"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "GraphicsOverlay",
+        "UtilityAssociation",
+        "UtilityAssociationType",
+        "UtilityNetwork"
+    ],
+    "snippets": [
+        "src/main/java/com/esri/samples/display_utility_associations/DisplayUtilityAssociationsSample.java"
+    ],
+    "title": "Display utility associations"
 }


### PR DESCRIPTION
Hi @Rachael-E ,

The file `utility_network/display-utility-associations/README.metadata.json` had a few typos in it, causing the SampleViewer to fail loading it up.
I've run this file through the generator script (which is why every line looks 'new'), but the actual changes are in the path in `snippets`, `title`, and adding the empty `redirect from`.
