### PR TITLE
Fix `display utility associations` metadata file

### DIFF
--- a/utility_network/display-utility-associations/README.metadata.json
+++ b/utility_network/display-utility-associations/README.metadata.json
@@ -1,30 +1,31 @@
 {
-  "category": "Utility network",
-  "description": "Create graphics for utility associations in a utility network.",
-  "ignore": false,
-  "images": [
-    "DisplayUtilityAssociations.png"
-  ],
-  "keywords": [
-    "associating",
-    "association",
-    "attachment",
-    "connectivity",
-    "containment",
-    "relationships",
-    "GraphicsOverlay",
-    "UtilityAssociation",
-    "UtilityAssociationType",
-    "UtilityNetwork"
-  ],
-  "relevant_apis": [
-    "GraphicsOverlay",
-    "UtilityAssociation",
-    "UtilityAssociationType",
-    "UtilityNetwork"
-  ],
-  "snippets": [
-    "src/main/java/com/esri/samples/display-utility-associations/DisplayUtilityAssociationsSample.java"
-  ],
-  "title": "Display utility association"
+    "category": "Utility network",
+    "description": "Create graphics for utility associations in a utility network.",
+    "ignore": false,
+    "images": [
+        "DisplayUtilityAssociations.png"
+    ],
+    "keywords": [
+        "associating",
+        "association",
+        "attachment",
+        "connectivity",
+        "containment",
+        "relationships",
+        "GraphicsOverlay",
+        "UtilityAssociation",
+        "UtilityAssociationType",
+        "UtilityNetwork"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "GraphicsOverlay",
+        "UtilityAssociation",
+        "UtilityAssociationType",
+        "UtilityNetwork"
+    ],
+    "snippets": [
+        "src/main/java/com/esri/samples/display_utility_associations/DisplayUtilityAssociationsSample.java"
+    ],
+    "title": "Display utility associations"
 }

--- a/utility_network/display-utility-associations/README.metadata.json
+++ b/utility_network/display-utility-associations/README.metadata.json
@@ -11,7 +11,7 @@
     "attachment",
     "connectivity",
     "containment",
-    "relationships"
+    "relationships",
     "GraphicsOverlay",
     "UtilityAssociation",
     "UtilityAssociationType",


### PR DESCRIPTION
Hi @Rachael-E,
I've cherry picked the commits we merged into `dev` yesterday to fix this metadata file.
This PR is to apply these changes to `master` as well, to make sure that the SampleViewer and dev page get a correct metadata file if they happen to be build from Master.
Again the diff shows everything is new, but this has to do with the way the script works. Some issue with encoding, I believe.
The changes are:
- fixes `"keywords"` by adding a previously missing comma
- fixes the path in `"snippets":`
- fixes the title, changing it to plural `associations`
- adds the missing `redirect_from` key