### PR TITLE
Display Utility Associations - move styling from CSS into main java class

### DIFF
--- a/utility_network/display-utility-associations/src/main/java/com/esri/samples/display_utility_associations/DisplayUtilityAssociationsSample.java
+++ b/utility_network/display-utility-associations/src/main/java/com/esri/samples/display_utility_associations/DisplayUtilityAssociationsSample.java
@@ -62,8 +62,7 @@ public class DisplayUtilityAssociationsSample extends Application {
       // create stack pane and application scene
       StackPane stackPane = new StackPane();
       Scene scene = new Scene(stackPane);
-      scene.getStylesheets().add(getClass().getResource("/display_utility_associations/style.css").toExternalForm());
-      
+
       // set title, size, and add scene to stage
       stage.setTitle("Display Utility Associations Sample");
       stage.setWidth(800);
@@ -137,7 +136,6 @@ public class DisplayUtilityAssociationsSample extends Application {
       
       // create a legend
       GridPane gridPane = new GridPane();
-      gridPane.getStyleClass().add("grid-pane");
       gridPane.getColumnConstraints().addAll(Arrays.asList(new ColumnConstraints(25), new ColumnConstraints(100)));
       gridPane.add(attachmentImageView, 0, 0);
       gridPane.add(attachmentLabel, 1, 0);
@@ -147,7 +145,10 @@ public class DisplayUtilityAssociationsSample extends Application {
       gridPane.setMaxHeight(80);
       gridPane.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(255,255,255,0.3)"), CornerRadii.EMPTY,
               Insets.EMPTY)));
-      
+      gridPane.setPadding(new Insets(10));
+      gridPane.setVgap(20);
+      gridPane.setAlignment(Pos.CENTER);
+
       // add the map view and legend to the stack pane
       stackPane.getChildren().addAll(mapView, gridPane);
       StackPane.setAlignment(gridPane, Pos.TOP_LEFT);

--- a/utility_network/display-utility-associations/src/main/java/com/esri/samples/display_utility_associations/DisplayUtilityAssociationsSample.java
+++ b/utility_network/display-utility-associations/src/main/java/com/esri/samples/display_utility_associations/DisplayUtilityAssociationsSample.java
@@ -30,6 +30,7 @@ import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.*;
+import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
@@ -142,6 +143,10 @@ public class DisplayUtilityAssociationsSample extends Application {
       gridPane.add(attachmentLabel, 1, 0);
       gridPane.add(connectivityImageView, 0, 1);
       gridPane.add(connectivityLabel, 1, 1);
+      gridPane.setMaxWidth(80);
+      gridPane.setMaxHeight(100);
+      gridPane.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(0,0,0,0.3)"), CornerRadii.EMPTY,
+              Insets.EMPTY)));
       
       // add the map view and legend to the stack pane
       stackPane.getChildren().addAll(mapView, gridPane);

--- a/utility_network/display-utility-associations/src/main/java/com/esri/samples/display_utility_associations/DisplayUtilityAssociationsSample.java
+++ b/utility_network/display-utility-associations/src/main/java/com/esri/samples/display_utility_associations/DisplayUtilityAssociationsSample.java
@@ -143,9 +143,9 @@ public class DisplayUtilityAssociationsSample extends Application {
       gridPane.add(attachmentLabel, 1, 0);
       gridPane.add(connectivityImageView, 0, 1);
       gridPane.add(connectivityLabel, 1, 1);
-      gridPane.setMaxWidth(80);
-      gridPane.setMaxHeight(100);
-      gridPane.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(0,0,0,0.3)"), CornerRadii.EMPTY,
+      gridPane.setMaxWidth(100);
+      gridPane.setMaxHeight(80);
+      gridPane.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(255,255,255,0.3)"), CornerRadii.EMPTY,
               Insets.EMPTY)));
       
       // add the map view and legend to the stack pane

--- a/utility_network/display-utility-associations/src/main/resources/display_utility_associations/style.css
+++ b/utility_network/display-utility-associations/src/main/resources/display_utility_associations/style.css
@@ -1,8 +1,5 @@
 .grid-pane {
   -fx-padding: 10;
-  -fx-background-color: rgba(255,255,255,0.5);
-  -fx-max-height: 80;
-  -fx-max-width: 100;
   -fx-vgap: 20;
   -fx-alignment: center;
 }

--- a/utility_network/display-utility-associations/src/main/resources/display_utility_associations/style.css
+++ b/utility_network/display-utility-associations/src/main/resources/display_utility_associations/style.css
@@ -1,5 +1,0 @@
-.grid-pane {
-  -fx-padding: 10;
-  -fx-vgap: 20;
-  -fx-alignment: center;
-}


### PR DESCRIPTION
Hi @Rachael-E, another update for this sample, as the CSS rules break the sample within the SampleViewer.
All I've done is move the offending rules from the CSS file into the `.java` file