### PR TITLE
Remove deprecated surface placement enum from ExtrudeGraphics sample

### DIFF
--- a/scene/extrude-graphics/src/main/java/com/esri/samples/extrude_graphics/ExtrudeGraphicsSample.java
+++ b/scene/extrude-graphics/src/main/java/com/esri/samples/extrude_graphics/ExtrudeGraphicsSample.java
@@ -85,7 +85,7 @@ public class ExtrudeGraphicsSample extends Application {
 
       // add a graphics overlay
       GraphicsOverlay graphicsOverlay = new GraphicsOverlay();
-      graphicsOverlay.getSceneProperties().setSurfacePlacement(LayerSceneProperties.SurfacePlacement.DRAPED);
+      graphicsOverlay.getSceneProperties().setSurfacePlacement(LayerSceneProperties.SurfacePlacement.DRAPED_BILLBOARDED);
 
       // set renderer with extrusion property
       SimpleRenderer renderer = new SimpleRenderer();


### PR DESCRIPTION
### Description 

As spotted by @Rachael-E : 

As of 100.7.0, LayerSceneProperties.SurfacePlacement.DRAPED was deprecated and replaced with either DRAPED_BILLBOARDED or DRAPED_FLAT. We updated this in our SurfacePlacement samples, but at least for Java, I have just noticed we are still using DRAPED in the Extrude Graphics sample.

We should make sure this deprecated call is removed for Java.

Checklist:
- [x] Set target branch to master (current release) or dev (next release)
- [x] Request a reviewer
- [x] Assign a reviewer
- [x] Tag reviewer in comment
