### PR TITLE
Update style WMS layers to use correct spatial reference

### DIFF
--- a/ogc/style-wms-layer/src/main/java/com/esri/samples/style_wms_layer/StyleWmsLayerSample.java
+++ b/ogc/style-wms-layer/src/main/java/com/esri/samples/style_wms_layer/StyleWmsLayerSample.java
@@ -55,9 +55,9 @@ public class StyleWmsLayerSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with spatial reference appropriate for the service
+      // create a map with spatial reference appropriate for the service (North American Datum 83)
       ArcGISMap map = new ArcGISMap(SpatialReference.create(26915));
-      map.setMinScale(7000000.0);
+      map.setMinScale(7000000);
       // set the map to the map view
       mapView = new MapView();
       mapView.setMap(map);

--- a/ogc/style-wms-layer/src/main/java/com/esri/samples/style_wms_layer/StyleWmsLayerSample.java
+++ b/ogc/style-wms-layer/src/main/java/com/esri/samples/style_wms_layer/StyleWmsLayerSample.java
@@ -31,8 +31,8 @@ import javafx.stage.Stage;
 import com.esri.arcgisruntime.layers.WmsLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
 import com.esri.arcgisruntime.mapping.Viewpoint;
+import com.esri.arcgisruntime.geometry.SpatialReference;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class StyleWmsLayerSample extends Application {
@@ -55,8 +55,10 @@ public class StyleWmsLayerSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map and add it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.createImagery());
+      // create a map with spatial reference appropriate for the service
+      ArcGISMap map = new ArcGISMap(SpatialReference.create(26915));
+      map.setMinScale(7000000.0);
+      // set the map to the map view
       mapView = new MapView();
       mapView.setMap(map);
 


### PR DESCRIPTION
This PR resolves issue #997:

- The service doesn't support the spatial reference of the map. They layer should have failed to load
- The service is generating incorrect images when the view includes polar regions; this is a service issue.

**Resolution:**

- Update sample to set a MinScale of 7,000,000 - avoids zooming to polar regions
- Update sample to use SR 26915
- Update sample to use no basemap (layer draws white over basemap anyway)