### PR TITLE
Fix cancel button in Edit features with feature-linked annotation

### DIFF
--- a/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditAttributesDialog.java
+++ b/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditAttributesDialog.java
@@ -28,7 +28,7 @@ import com.esri.arcgisruntime.data.Feature;
 /**
  * Custom dialog for editing feature attributes.
  */
-public class EditAttributesDialog extends Dialog<Feature>{
+public class EditAttributesDialog extends Dialog<Boolean>{
 
   @FXML private TextField addressTextField;
   @FXML private TextField streetNameTextField;
@@ -51,7 +51,7 @@ public class EditAttributesDialog extends Dialog<Feature>{
     addressTextField.setText(selectedFeature.getAttributes().get("AD_ADDRESS").toString());
     streetNameTextField.setText(selectedFeature.getAttributes().get("ST_STR_NAM").toString());
 
-    // convert the result to an address and street name when the ok button is clicked
+    // convert the result to an address and street name when the update button is clicked
     setResultConverter(dialogButton -> {
       if (dialogButton == updateButton) {
         try {
@@ -67,6 +67,7 @@ public class EditAttributesDialog extends Dialog<Feature>{
         } catch (Exception e) {
           e.printStackTrace();
         }
+        return true;
       }
       return null;
     });

--- a/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
+++ b/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
@@ -233,7 +233,7 @@ public class EditFeaturesWithFeatureLinkedAnnotationSample extends Application {
         // update the selected feature's feature table
         updateAttributes(selectedFeature);
       }
-      else{
+      else {
         // if the user chose to cancel, clear selection of the feature
         clearSelection();
       }

--- a/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
+++ b/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
@@ -19,6 +19,7 @@ package com.esri.samples.edit_features_with_feature_linked_annotation;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import javafx.application.Application;
@@ -225,10 +226,17 @@ public class EditFeaturesWithFeatureLinkedAnnotationSample extends Application {
       EditAttributesDialog editAttributesDialog = new EditAttributesDialog(selectedFeature);
 
       // show the dialog and wait for the user response
-      editAttributesDialog.showAndWait();
+      Optional<Boolean> updatingFeature = editAttributesDialog.showAndWait();
 
-      // update the selected feature's feature table
-      updateAttributes(selectedFeature);
+      // if the user chose to update the feature's attributes
+      if (updatingFeature.isPresent()) {
+        // update the selected feature's feature table
+        updateAttributes(selectedFeature);
+      }
+      else{
+        // if the user chose to cancel, clear selection of the feature
+        clearSelection();
+      }
     } else {
       new Alert(Alert.AlertType.WARNING, "Feature of unexpected geometry type selected.").show();
     }


### PR DESCRIPTION
This PR fixes a bug noticed by @hardikc07 during verification. Previously, when the dialog box 's cancel button was clicked, the feature was still selected.

Now when when the update button is clicked, `editAttributesDialog.showAndWait()` returns true, otherwise it returns null, which is stored in an Optional. When the dialog is created, the features are updated based on the value in the Optional.