### PR TITLE
Update http to https for world geocoding service

### DIFF
--- a/search/find-address/src/main/java/com/esri/samples/find_address/FindAddressSample.java
+++ b/search/find-address/src/main/java/com/esri/samples/find_address/FindAddressSample.java
@@ -98,7 +98,7 @@ public class FindAddressSample extends Application {
       callout.setLeaderPosition(LeaderPosition.BOTTOM);
 
       // create a locatorTask
-      locatorTask = new LocatorTask("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
+      locatorTask = new LocatorTask("https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
 
       // create geocode task parameters
       GeocodeParameters geocodeParameters = new GeocodeParameters();

--- a/search/find-place/src/main/java/com/esri/samples/find_place/FindPlaceController.java
+++ b/search/find-place/src/main/java/com/esri/samples/find_place/FindPlaceController.java
@@ -82,7 +82,7 @@ public class FindPlaceController {
     callout.setLeaderPosition(Callout.LeaderPosition.BOTTOM);
 
     // create a locatorTask task
-    locatorTask = new LocatorTask("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
+    locatorTask = new LocatorTask("https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
 
     // create a pin graphic
     Image img = new Image(getClass().getResourceAsStream("/find_place/pin.png"), 0, 80, true, true);

--- a/search/reverse-geocode-online/src/main/java/com/esri/samples/reverse_geocode_online/ReverseGeocodeOnlineSample.java
+++ b/search/reverse-geocode-online/src/main/java/com/esri/samples/reverse_geocode_online/ReverseGeocodeOnlineSample.java
@@ -91,7 +91,7 @@ public class ReverseGeocodeOnlineSample extends Application {
       callout.setLeaderPosition(LeaderPosition.BOTTOM);
 
       // create a locator task
-      locatorTask = new LocatorTask("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
+      locatorTask = new LocatorTask("https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
 
       // create geocode task parameters
       ReverseGeocodeParameters reverseGeocodeParameters = new ReverseGeocodeParameters();


### PR DESCRIPTION
Update references to world geocoding service URLs from http to https. Identified in 'Find Place', 'Find Address' and 'Reverse Geocode Online' via a find in path search.

As per https://support.esri.com/en/technical-article/000023241
And further details in CS 2252.

@JonLavi 

Checklist:
- [x] Set target branch to master (current release) or dev (next release)
- [x] Request a reviewer
- [x] Assign a reviewer
- [x] Tag reviewer in comment
