### PR TITLE
Edit with Branch Versioning: remove authentication handler

### DIFF
--- a/editing/edit-with-branch-versioning/README.md
+++ b/editing/edit-with-branch-versioning/README.md
@@ -10,7 +10,7 @@ Workflows often progress in discrete stages, with each stage requiring the alloc
 
 ## How to use the sample
 
-Upon opening the sample, you will be prompted to enter credentials for the service (un: editor01 / pwd: editor01.password). Once loaded, the map will zoom to the extent of the feature layer. The current version is indicated in the top left corner of the map. You can create a new version by specifying the version information (name, access, and description) in the form in the top right corner, and then clicking "Create version". See the *Additional Information* section for restrictions on the version name.
+Once loaded, the map will zoom to the extent of the feature layer. The current version is indicated in the top left corner of the map. You can create a new version by specifying the version information (name, access, and description) in the form in the top right corner, and then clicking "Create version". See the *Additional Information* section for restrictions on the version name.
 
 Select a feature using the primary mouse button to edit an attribute and/or click again with the secondary mouse button to relocate the point.
 
@@ -43,10 +43,6 @@ Click the "Switch version" button in the top left corner to switch back and fort
 The feature layer used in this sample is [Damage to commercial buildings](https://sampleserver7.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0) located in Naperville, Illinois.
 
 ## Additional information
-
-Credentials:
-- Username: editor01
-- Password: editor01.password
 
 The name of the version must meet the following criteria:
 

--- a/editing/edit-with-branch-versioning/src/main/java/com/esri/samples/edit_with_branch_versioning/EditWithBranchVersioningController.java
+++ b/editing/edit-with-branch-versioning/src/main/java/com/esri/samples/edit_with_branch_versioning/EditWithBranchVersioningController.java
@@ -90,14 +90,15 @@ public class EditWithBranchVersioningController {
         }
       });
 
-      // set the user credentials required to authenticate with the service geodatabase
-      // alternatively authentication could be handled with an AuthenticationChallengeHandler
-      UserCredential userCredential = new UserCredential("editor01", "editor01.password");
-
-      // create and load a service geodatabase
+      // create a service geodatabase
       serviceGeodatabase = new ServiceGeodatabase("https://sampleserver7.arcgisonline" +
         ".com/arcgis/rest/services/DamageAssessment/FeatureServer");
+
+      // set the user credentials required to authenticate with the service geodatabase
+      UserCredential userCredential = new UserCredential("editor01", "editor01.password");
       serviceGeodatabase.setCredential(userCredential);
+
+      // load the service geodatabase
       serviceGeodatabase.loadAsync();
 
       serviceGeodatabase.addDoneLoadingListener(() -> {

--- a/editing/edit-with-branch-versioning/src/main/java/com/esri/samples/edit_with_branch_versioning/EditWithBranchVersioningController.java
+++ b/editing/edit-with-branch-versioning/src/main/java/com/esri/samples/edit_with_branch_versioning/EditWithBranchVersioningController.java
@@ -47,8 +47,7 @@ import com.esri.arcgisruntime.mapping.GeoElement;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
 import com.esri.arcgisruntime.mapping.view.MapView;
-import com.esri.arcgisruntime.security.AuthenticationManager;
-import com.esri.arcgisruntime.security.DefaultAuthenticationChallengeHandler;
+import com.esri.arcgisruntime.security.UserCredential;
 
 public class EditWithBranchVersioningController {
 
@@ -91,13 +90,16 @@ public class EditWithBranchVersioningController {
         }
       });
 
-      // handle authentication for the service geodatabase
-      AuthenticationManager.setAuthenticationChallengeHandler(new DefaultAuthenticationChallengeHandler());
+      // set the user credentials required to authenticate with the service geodatabase
+      // alternatively authentication could be handled with an AuthenticationChallengeHandler
+      UserCredential userCredential = new UserCredential("editor01", "editor01.password");
 
       // create and load a service geodatabase
       serviceGeodatabase = new ServiceGeodatabase("https://sampleserver7.arcgisonline" +
         ".com/arcgis/rest/services/DamageAssessment/FeatureServer");
+      serviceGeodatabase.setCredential(userCredential);
       serviceGeodatabase.loadAsync();
+
       serviceGeodatabase.addDoneLoadingListener(() -> {
         if (serviceGeodatabase.getLoadStatus() == LoadStatus.LOADED) {
 


### PR DESCRIPTION
### Description

After some verification on the different platforms it was agreed at the review meeting to remove the authentication handler from the Edit with Branch Versioning samples, as it was proving tricky for users to enter credentials that were in the readme when they needed to complete authentication before they could access the readme. Other samples demonstrate how you can implement authentication.

So I have amended the readme, and removed the `AuthenticationChallengeHandler` in the Controller. Instead the user credentials are hard coded and set directly to the `ServiceGeodatabase`. 

I added a comment that the `AuthenticationChallengeHandler` could be used as an alternative. Any thoughts on this wording, and whether I could/should direct the user to a sample to look at, like 'oauth'? Wasn't sure if that was too much to put in the comments.

<!-- Give a brief summary description (one or two sentences) of the work done within the PR, and also write any particular points on which you'd like specific feedback/advice on. Ensure to both request a review and also assign that reviewee, as well as tag them in this PR description. -->

Checklist:
- [x] Set target branch to master (current release) or dev (next release)
- [x] Request a reviewer
- [x] Assign a reviewer
- [x] Tag reviewer in comment
