### PR TITLE
Remove deprecated Gradle features from samples 

### DIFF
--- a/analysis/analyze-hotspots/build.gradle
+++ b/analysis/analyze-hotspots/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/analysis/analyze-hotspots/build.gradle
+++ b/analysis/analyze-hotspots/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/analysis/analyze-hotspots/build.gradle
+++ b/analysis/analyze-hotspots/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/analysis/analyze-hotspots/build.gradle
+++ b/analysis/analyze-hotspots/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/analysis/analyze-hotspots/build.gradle
+++ b/analysis/analyze-hotspots/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/analysis/distance-measurement-analysis/build.gradle
+++ b/analysis/distance-measurement-analysis/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/analysis/distance-measurement-analysis/build.gradle
+++ b/analysis/distance-measurement-analysis/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/analysis/distance-measurement-analysis/build.gradle
+++ b/analysis/distance-measurement-analysis/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/analysis/distance-measurement-analysis/build.gradle
+++ b/analysis/distance-measurement-analysis/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/analysis/distance-measurement-analysis/build.gradle
+++ b/analysis/distance-measurement-analysis/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/analysis/line-of-sight-geoelement/build.gradle
+++ b/analysis/line-of-sight-geoelement/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/analysis/line-of-sight-geoelement/build.gradle
+++ b/analysis/line-of-sight-geoelement/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/analysis/line-of-sight-geoelement/build.gradle
+++ b/analysis/line-of-sight-geoelement/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/analysis/line-of-sight-geoelement/build.gradle
+++ b/analysis/line-of-sight-geoelement/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/analysis/line-of-sight-geoelement/build.gradle
+++ b/analysis/line-of-sight-geoelement/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/analysis/line-of-sight-location/build.gradle
+++ b/analysis/line-of-sight-location/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/analysis/line-of-sight-location/build.gradle
+++ b/analysis/line-of-sight-location/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/analysis/line-of-sight-location/build.gradle
+++ b/analysis/line-of-sight-location/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/analysis/line-of-sight-location/build.gradle
+++ b/analysis/line-of-sight-location/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/analysis/line-of-sight-location/build.gradle
+++ b/analysis/line-of-sight-location/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/analysis/viewshed-camera/build.gradle
+++ b/analysis/viewshed-camera/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/analysis/viewshed-camera/build.gradle
+++ b/analysis/viewshed-camera/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/analysis/viewshed-camera/build.gradle
+++ b/analysis/viewshed-camera/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/analysis/viewshed-camera/build.gradle
+++ b/analysis/viewshed-camera/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/analysis/viewshed-camera/build.gradle
+++ b/analysis/viewshed-camera/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/analysis/viewshed-geoelement/build.gradle
+++ b/analysis/viewshed-geoelement/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/analysis/viewshed-geoelement/build.gradle
+++ b/analysis/viewshed-geoelement/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/analysis/viewshed-geoelement/build.gradle
+++ b/analysis/viewshed-geoelement/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/analysis/viewshed-geoelement/build.gradle
+++ b/analysis/viewshed-geoelement/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/analysis/viewshed-geoelement/build.gradle
+++ b/analysis/viewshed-geoelement/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/analysis/viewshed-geoprocessing/build.gradle
+++ b/analysis/viewshed-geoprocessing/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/analysis/viewshed-geoprocessing/build.gradle
+++ b/analysis/viewshed-geoprocessing/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/analysis/viewshed-geoprocessing/build.gradle
+++ b/analysis/viewshed-geoprocessing/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/analysis/viewshed-geoprocessing/build.gradle
+++ b/analysis/viewshed-geoprocessing/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/analysis/viewshed-geoprocessing/build.gradle
+++ b/analysis/viewshed-geoprocessing/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/analysis/viewshed-location/build.gradle
+++ b/analysis/viewshed-location/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/analysis/viewshed-location/build.gradle
+++ b/analysis/viewshed-location/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/analysis/viewshed-location/build.gradle
+++ b/analysis/viewshed-location/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/analysis/viewshed-location/build.gradle
+++ b/analysis/viewshed-location/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/analysis/viewshed-location/build.gradle
+++ b/analysis/viewshed-location/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/add-graphics-with-renderer/build.gradle
+++ b/display_information/add-graphics-with-renderer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/add-graphics-with-renderer/build.gradle
+++ b/display_information/add-graphics-with-renderer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/add-graphics-with-renderer/build.gradle
+++ b/display_information/add-graphics-with-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/add-graphics-with-renderer/build.gradle
+++ b/display_information/add-graphics-with-renderer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/display_information/add-graphics-with-renderer/build.gradle
+++ b/display_information/add-graphics-with-renderer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/add-graphics-with-symbols/build.gradle
+++ b/display_information/add-graphics-with-symbols/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/add-graphics-with-symbols/build.gradle
+++ b/display_information/add-graphics-with-symbols/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/add-graphics-with-symbols/build.gradle
+++ b/display_information/add-graphics-with-symbols/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/add-graphics-with-symbols/build.gradle
+++ b/display_information/add-graphics-with-symbols/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/display_information/add-graphics-with-symbols/build.gradle
+++ b/display_information/add-graphics-with-symbols/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/control-annotation-sublayer-visibility/build.gradle
+++ b/display_information/control-annotation-sublayer-visibility/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/control-annotation-sublayer-visibility/build.gradle
+++ b/display_information/control-annotation-sublayer-visibility/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
     }
 
 wrapper {

--- a/display_information/control-annotation-sublayer-visibility/build.gradle
+++ b/display_information/control-annotation-sublayer-visibility/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
     }

--- a/display_information/control-annotation-sublayer-visibility/build.gradle
+++ b/display_information/control-annotation-sublayer-visibility/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/display_information/control-annotation-sublayer-visibility/build.gradle
+++ b/display_information/control-annotation-sublayer-visibility/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/dictionary-renderer-graphics-overlay/build.gradle
+++ b/display_information/dictionary-renderer-graphics-overlay/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'org.jooq:joox:1.4.0'

--- a/display_information/dictionary-renderer-graphics-overlay/build.gradle
+++ b/display_information/dictionary-renderer-graphics-overlay/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/dictionary-renderer-graphics-overlay/build.gradle
+++ b/display_information/dictionary-renderer-graphics-overlay/build.gradle
@@ -70,7 +70,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/dictionary-renderer-graphics-overlay/build.gradle
+++ b/display_information/dictionary-renderer-graphics-overlay/build.gradle
@@ -68,7 +68,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/dictionary-renderer-graphics-overlay/build.gradle
+++ b/display_information/dictionary-renderer-graphics-overlay/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile 'org.jooq:joox:1.4.0'
+    implementation 'org.jooq:joox:1.4.0'
 }
 
 task copyNatives(type: Copy) {

--- a/display_information/dictionary-renderer-graphics-overlay/build.gradle
+++ b/display_information/dictionary-renderer-graphics-overlay/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/display-annotation/build.gradle
+++ b/display_information/display-annotation/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'org.jooq:joox:1.4.0'

--- a/display_information/display-annotation/build.gradle
+++ b/display_information/display-annotation/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/display-annotation/build.gradle
+++ b/display_information/display-annotation/build.gradle
@@ -70,7 +70,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/display-annotation/build.gradle
+++ b/display_information/display-annotation/build.gradle
@@ -68,7 +68,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/display-annotation/build.gradle
+++ b/display_information/display-annotation/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile 'org.jooq:joox:1.4.0'
+    implementation 'org.jooq:joox:1.4.0'
 }
 
 task copyNatives(type: Copy) {

--- a/display_information/display-annotation/build.gradle
+++ b/display_information/display-annotation/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/display-grid/build.gradle
+++ b/display_information/display-grid/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/display-grid/build.gradle
+++ b/display_information/display-grid/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/display-grid/build.gradle
+++ b/display_information/display-grid/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/display-grid/build.gradle
+++ b/display_information/display-grid/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/display_information/display-grid/build.gradle
+++ b/display_information/display-grid/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/format-coordinates/build.gradle
+++ b/display_information/format-coordinates/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/format-coordinates/build.gradle
+++ b/display_information/format-coordinates/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/format-coordinates/build.gradle
+++ b/display_information/format-coordinates/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/format-coordinates/build.gradle
+++ b/display_information/format-coordinates/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/display_information/format-coordinates/build.gradle
+++ b/display_information/format-coordinates/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/identify-graphics/build.gradle
+++ b/display_information/identify-graphics/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/display_information/identify-graphics/build.gradle
+++ b/display_information/identify-graphics/build.gradle
@@ -65,7 +65,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/identify-graphics/build.gradle
+++ b/display_information/identify-graphics/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/identify-graphics/build.gradle
+++ b/display_information/identify-graphics/build.gradle
@@ -63,7 +63,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/identify-graphics/build.gradle
+++ b/display_information/identify-graphics/build.gradle
@@ -21,7 +21,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/show-callout/build.gradle
+++ b/display_information/show-callout/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/show-callout/build.gradle
+++ b/display_information/show-callout/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/show-callout/build.gradle
+++ b/display_information/show-callout/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/show-callout/build.gradle
+++ b/display_information/show-callout/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/display_information/show-callout/build.gradle
+++ b/display_information/show-callout/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/show-labels-on-layer/build.gradle
+++ b/display_information/show-labels-on-layer/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/show-labels-on-layer/build.gradle
+++ b/display_information/show-labels-on-layer/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile "com.google.code.gson:gson:2.8.5"
+    implementation "com.google.code.gson:gson:2.8.5"
 }
 
 task copyNatives(type: Copy) {

--- a/display_information/show-labels-on-layer/build.gradle
+++ b/display_information/show-labels-on-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/show-labels-on-layer/build.gradle
+++ b/display_information/show-labels-on-layer/build.gradle
@@ -65,7 +65,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/show-labels-on-layer/build.gradle
+++ b/display_information/show-labels-on-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile "com.google.code.gson:gson:2.8.5"

--- a/display_information/show-labels-on-layer/build.gradle
+++ b/display_information/show-labels-on-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/sketch-on-map/build.gradle
+++ b/display_information/sketch-on-map/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/sketch-on-map/build.gradle
+++ b/display_information/sketch-on-map/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/sketch-on-map/build.gradle
+++ b/display_information/sketch-on-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/sketch-on-map/build.gradle
+++ b/display_information/sketch-on-map/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/display_information/sketch-on-map/build.gradle
+++ b/display_information/sketch-on-map/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/display_information/update-graphics/build.gradle
+++ b/display_information/update-graphics/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/display_information/update-graphics/build.gradle
+++ b/display_information/update-graphics/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/display_information/update-graphics/build.gradle
+++ b/display_information/update-graphics/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/display_information/update-graphics/build.gradle
+++ b/display_information/update-graphics/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/display_information/update-graphics/build.gradle
+++ b/display_information/update-graphics/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/editing/add-features/build.gradle
+++ b/editing/add-features/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/editing/add-features/build.gradle
+++ b/editing/add-features/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/editing/add-features/build.gradle
+++ b/editing/add-features/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/editing/add-features/build.gradle
+++ b/editing/add-features/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/editing/add-features/build.gradle
+++ b/editing/add-features/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/editing/delete-features/build.gradle
+++ b/editing/delete-features/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/editing/delete-features/build.gradle
+++ b/editing/delete-features/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/editing/delete-features/build.gradle
+++ b/editing/delete-features/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/editing/delete-features/build.gradle
+++ b/editing/delete-features/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/editing/delete-features/build.gradle
+++ b/editing/delete-features/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/editing/edit-and-sync-features/build.gradle
+++ b/editing/edit-and-sync-features/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/editing/edit-and-sync-features/build.gradle
+++ b/editing/edit-and-sync-features/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/editing/edit-and-sync-features/build.gradle
+++ b/editing/edit-and-sync-features/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/editing/edit-and-sync-features/build.gradle
+++ b/editing/edit-and-sync-features/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/editing/edit-and-sync-features/build.gradle
+++ b/editing/edit-and-sync-features/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -65,7 +65,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'commons-io:commons-io:2.4'

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile 'commons-io:commons-io:2.4'
+    implementation 'commons-io:commons-io:2.4'
 }
 
 task copyNatives(type: Copy) {

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/editing/edit-features-with-feature-linked-annotation/build.gradle
+++ b/editing/edit-features-with-feature-linked-annotation/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/editing/edit-features-with-feature-linked-annotation/build.gradle
+++ b/editing/edit-features-with-feature-linked-annotation/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/editing/edit-features-with-feature-linked-annotation/build.gradle
+++ b/editing/edit-features-with-feature-linked-annotation/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/editing/edit-features-with-feature-linked-annotation/build.gradle
+++ b/editing/edit-features-with-feature-linked-annotation/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/editing/edit-features-with-feature-linked-annotation/build.gradle
+++ b/editing/edit-features-with-feature-linked-annotation/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/editing/edit-with-branch-versioning/build.gradle
+++ b/editing/edit-with-branch-versioning/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/editing/edit-with-branch-versioning/build.gradle
+++ b/editing/edit-with-branch-versioning/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/editing/edit-with-branch-versioning/build.gradle
+++ b/editing/edit-with-branch-versioning/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/editing/edit-with-branch-versioning/build.gradle
+++ b/editing/edit-with-branch-versioning/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/editing/edit-with-branch-versioning/build.gradle
+++ b/editing/edit-with-branch-versioning/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/editing/update-attributes/build.gradle
+++ b/editing/update-attributes/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/editing/update-attributes/build.gradle
+++ b/editing/update-attributes/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/editing/update-attributes/build.gradle
+++ b/editing/update-attributes/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/editing/update-attributes/build.gradle
+++ b/editing/update-attributes/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/editing/update-attributes/build.gradle
+++ b/editing/update-attributes/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/editing/update-geometries/build.gradle
+++ b/editing/update-geometries/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/editing/update-geometries/build.gradle
+++ b/editing/update-geometries/build.gradle
@@ -65,7 +65,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/editing/update-geometries/build.gradle
+++ b/editing/update-geometries/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/editing/update-geometries/build.gradle
+++ b/editing/update-geometries/build.gradle
@@ -63,7 +63,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/editing/update-geometries/build.gradle
+++ b/editing/update-geometries/build.gradle
@@ -21,7 +21,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/change-feature-layer-renderer/build.gradle
+++ b/feature_layers/change-feature-layer-renderer/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/change-feature-layer-renderer/build.gradle
+++ b/feature_layers/change-feature-layer-renderer/build.gradle
@@ -65,7 +65,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/change-feature-layer-renderer/build.gradle
+++ b/feature_layers/change-feature-layer-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/change-feature-layer-renderer/build.gradle
+++ b/feature_layers/change-feature-layer-renderer/build.gradle
@@ -63,7 +63,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/change-feature-layer-renderer/build.gradle
+++ b/feature_layers/change-feature-layer-renderer/build.gradle
@@ -21,7 +21,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -32,7 +32,7 @@ configurations {
 
 dependencies {
     compile 'commons-io:commons-io:2.4'
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile 'commons-io:commons-io:2.4'
+    implementation 'commons-io:commons-io:2.4'
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -65,7 +65,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-collection-layer-from-portal/build.gradle
+++ b/feature_layers/feature-collection-layer-from-portal/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-collection-layer-from-portal/build.gradle
+++ b/feature_layers/feature-collection-layer-from-portal/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-collection-layer-from-portal/build.gradle
+++ b/feature_layers/feature-collection-layer-from-portal/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-collection-layer-from-portal/build.gradle
+++ b/feature_layers/feature-collection-layer-from-portal/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-collection-layer-from-portal/build.gradle
+++ b/feature_layers/feature-collection-layer-from-portal/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-collection-layer-query/build.gradle
+++ b/feature_layers/feature-collection-layer-query/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-collection-layer-query/build.gradle
+++ b/feature_layers/feature-collection-layer-query/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-collection-layer-query/build.gradle
+++ b/feature_layers/feature-collection-layer-query/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-collection-layer-query/build.gradle
+++ b/feature_layers/feature-collection-layer-query/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-collection-layer-query/build.gradle
+++ b/feature_layers/feature-collection-layer-query/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-collection-layer/build.gradle
+++ b/feature_layers/feature-collection-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-collection-layer/build.gradle
+++ b/feature_layers/feature-collection-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-collection-layer/build.gradle
+++ b/feature_layers/feature-collection-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-collection-layer/build.gradle
+++ b/feature_layers/feature-collection-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-collection-layer/build.gradle
+++ b/feature_layers/feature-collection-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-layer-definition-expression/build.gradle
+++ b/feature_layers/feature-layer-definition-expression/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-layer-definition-expression/build.gradle
+++ b/feature_layers/feature-layer-definition-expression/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-layer-definition-expression/build.gradle
+++ b/feature_layers/feature-layer-definition-expression/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-layer-definition-expression/build.gradle
+++ b/feature_layers/feature-layer-definition-expression/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-layer-definition-expression/build.gradle
+++ b/feature_layers/feature-layer-definition-expression/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-layer-dictionary-renderer/build.gradle
+++ b/feature_layers/feature-layer-dictionary-renderer/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-layer-dictionary-renderer/build.gradle
+++ b/feature_layers/feature-layer-dictionary-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-layer-dictionary-renderer/build.gradle
+++ b/feature_layers/feature-layer-dictionary-renderer/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-layer-dictionary-renderer/build.gradle
+++ b/feature_layers/feature-layer-dictionary-renderer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-layer-dictionary-renderer/build.gradle
+++ b/feature_layers/feature-layer-dictionary-renderer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-layer-extrusion/build.gradle
+++ b/feature_layers/feature-layer-extrusion/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-layer-extrusion/build.gradle
+++ b/feature_layers/feature-layer-extrusion/build.gradle
@@ -65,7 +65,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-layer-extrusion/build.gradle
+++ b/feature_layers/feature-layer-extrusion/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-layer-extrusion/build.gradle
+++ b/feature_layers/feature-layer-extrusion/build.gradle
@@ -63,7 +63,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-layer-extrusion/build.gradle
+++ b/feature_layers/feature-layer-extrusion/build.gradle
@@ -21,7 +21,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-layer-feature-service/build.gradle
+++ b/feature_layers/feature-layer-feature-service/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-layer-feature-service/build.gradle
+++ b/feature_layers/feature-layer-feature-service/build.gradle
@@ -65,7 +65,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-layer-feature-service/build.gradle
+++ b/feature_layers/feature-layer-feature-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-layer-feature-service/build.gradle
+++ b/feature_layers/feature-layer-feature-service/build.gradle
@@ -63,7 +63,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-layer-feature-service/build.gradle
+++ b/feature_layers/feature-layer-feature-service/build.gradle
@@ -21,7 +21,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-layer-geodatabase/build.gradle
+++ b/feature_layers/feature-layer-geodatabase/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-layer-geodatabase/build.gradle
+++ b/feature_layers/feature-layer-geodatabase/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-layer-geodatabase/build.gradle
+++ b/feature_layers/feature-layer-geodatabase/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-layer-geodatabase/build.gradle
+++ b/feature_layers/feature-layer-geodatabase/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-layer-geodatabase/build.gradle
+++ b/feature_layers/feature-layer-geodatabase/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-layer-geopackage/build.gradle
+++ b/feature_layers/feature-layer-geopackage/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-layer-geopackage/build.gradle
+++ b/feature_layers/feature-layer-geopackage/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-layer-geopackage/build.gradle
+++ b/feature_layers/feature-layer-geopackage/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-layer-geopackage/build.gradle
+++ b/feature_layers/feature-layer-geopackage/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-layer-geopackage/build.gradle
+++ b/feature_layers/feature-layer-geopackage/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-layer-query/build.gradle
+++ b/feature_layers/feature-layer-query/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-layer-query/build.gradle
+++ b/feature_layers/feature-layer-query/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-layer-query/build.gradle
+++ b/feature_layers/feature-layer-query/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-layer-query/build.gradle
+++ b/feature_layers/feature-layer-query/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-layer-query/build.gradle
+++ b/feature_layers/feature-layer-query/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-layer-rendering-mode-map/build.gradle
+++ b/feature_layers/feature-layer-rendering-mode-map/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-layer-rendering-mode-map/build.gradle
+++ b/feature_layers/feature-layer-rendering-mode-map/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-layer-rendering-mode-map/build.gradle
+++ b/feature_layers/feature-layer-rendering-mode-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-layer-rendering-mode-map/build.gradle
+++ b/feature_layers/feature-layer-rendering-mode-map/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-layer-rendering-mode-map/build.gradle
+++ b/feature_layers/feature-layer-rendering-mode-map/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-layer-selection/build.gradle
+++ b/feature_layers/feature-layer-selection/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-layer-selection/build.gradle
+++ b/feature_layers/feature-layer-selection/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-layer-selection/build.gradle
+++ b/feature_layers/feature-layer-selection/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-layer-selection/build.gradle
+++ b/feature_layers/feature-layer-selection/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-layer-selection/build.gradle
+++ b/feature_layers/feature-layer-selection/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/feature-layer-shapefile/build.gradle
+++ b/feature_layers/feature-layer-shapefile/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/feature-layer-shapefile/build.gradle
+++ b/feature_layers/feature-layer-shapefile/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/feature-layer-shapefile/build.gradle
+++ b/feature_layers/feature-layer-shapefile/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/feature-layer-shapefile/build.gradle
+++ b/feature_layers/feature-layer-shapefile/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/feature-layer-shapefile/build.gradle
+++ b/feature_layers/feature-layer-shapefile/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/generate-geodatabase/build.gradle
+++ b/feature_layers/generate-geodatabase/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/generate-geodatabase/build.gradle
+++ b/feature_layers/generate-geodatabase/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/generate-geodatabase/build.gradle
+++ b/feature_layers/generate-geodatabase/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/generate-geodatabase/build.gradle
+++ b/feature_layers/generate-geodatabase/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/generate-geodatabase/build.gradle
+++ b/feature_layers/generate-geodatabase/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/list-related-features/build.gradle
+++ b/feature_layers/list-related-features/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/list-related-features/build.gradle
+++ b/feature_layers/list-related-features/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/list-related-features/build.gradle
+++ b/feature_layers/list-related-features/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/list-related-features/build.gradle
+++ b/feature_layers/list-related-features/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/list-related-features/build.gradle
+++ b/feature_layers/list-related-features/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/service-feature-table-cache/build.gradle
+++ b/feature_layers/service-feature-table-cache/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/service-feature-table-cache/build.gradle
+++ b/feature_layers/service-feature-table-cache/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/service-feature-table-cache/build.gradle
+++ b/feature_layers/service-feature-table-cache/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/service-feature-table-cache/build.gradle
+++ b/feature_layers/service-feature-table-cache/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/service-feature-table-cache/build.gradle
+++ b/feature_layers/service-feature-table-cache/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/service-feature-table-manual-cache/build.gradle
+++ b/feature_layers/service-feature-table-manual-cache/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/service-feature-table-manual-cache/build.gradle
+++ b/feature_layers/service-feature-table-manual-cache/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/service-feature-table-manual-cache/build.gradle
+++ b/feature_layers/service-feature-table-manual-cache/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/service-feature-table-manual-cache/build.gradle
+++ b/feature_layers/service-feature-table-manual-cache/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/service-feature-table-manual-cache/build.gradle
+++ b/feature_layers/service-feature-table-manual-cache/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/service-feature-table-no-cache/build.gradle
+++ b/feature_layers/service-feature-table-no-cache/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/service-feature-table-no-cache/build.gradle
+++ b/feature_layers/service-feature-table-no-cache/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/service-feature-table-no-cache/build.gradle
+++ b/feature_layers/service-feature-table-no-cache/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/service-feature-table-no-cache/build.gradle
+++ b/feature_layers/service-feature-table-no-cache/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/service-feature-table-no-cache/build.gradle
+++ b/feature_layers/service-feature-table-no-cache/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/statistical-query-group-and-sort/build.gradle
+++ b/feature_layers/statistical-query-group-and-sort/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/statistical-query-group-and-sort/build.gradle
+++ b/feature_layers/statistical-query-group-and-sort/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/statistical-query-group-and-sort/build.gradle
+++ b/feature_layers/statistical-query-group-and-sort/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/statistical-query-group-and-sort/build.gradle
+++ b/feature_layers/statistical-query-group-and-sort/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/statistical-query-group-and-sort/build.gradle
+++ b/feature_layers/statistical-query-group-and-sort/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/statistical-query/build.gradle
+++ b/feature_layers/statistical-query/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/statistical-query/build.gradle
+++ b/feature_layers/statistical-query/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/statistical-query/build.gradle
+++ b/feature_layers/statistical-query/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/statistical-query/build.gradle
+++ b/feature_layers/statistical-query/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/statistical-query/build.gradle
+++ b/feature_layers/statistical-query/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/feature_layers/time-based-query/build.gradle
+++ b/feature_layers/time-based-query/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/feature_layers/time-based-query/build.gradle
+++ b/feature_layers/time-based-query/build.gradle
@@ -65,7 +65,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/feature_layers/time-based-query/build.gradle
+++ b/feature_layers/time-based-query/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/feature_layers/time-based-query/build.gradle
+++ b/feature_layers/time-based-query/build.gradle
@@ -63,7 +63,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/feature_layers/time-based-query/build.gradle
+++ b/feature_layers/time-based-query/build.gradle
@@ -21,7 +21,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/buffer-list/build.gradle
+++ b/geometry/buffer-list/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/buffer-list/build.gradle
+++ b/geometry/buffer-list/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/buffer-list/build.gradle
+++ b/geometry/buffer-list/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/buffer-list/build.gradle
+++ b/geometry/buffer-list/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/buffer-list/build.gradle
+++ b/geometry/buffer-list/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/buffer/build.gradle
+++ b/geometry/buffer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/buffer/build.gradle
+++ b/geometry/buffer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/buffer/build.gradle
+++ b/geometry/buffer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/buffer/build.gradle
+++ b/geometry/buffer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/buffer/build.gradle
+++ b/geometry/buffer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/clip-geometry/build.gradle
+++ b/geometry/clip-geometry/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/clip-geometry/build.gradle
+++ b/geometry/clip-geometry/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/clip-geometry/build.gradle
+++ b/geometry/clip-geometry/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/clip-geometry/build.gradle
+++ b/geometry/clip-geometry/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/clip-geometry/build.gradle
+++ b/geometry/clip-geometry/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/convex-hull-list/build.gradle
+++ b/geometry/convex-hull-list/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/convex-hull-list/build.gradle
+++ b/geometry/convex-hull-list/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/convex-hull-list/build.gradle
+++ b/geometry/convex-hull-list/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/convex-hull-list/build.gradle
+++ b/geometry/convex-hull-list/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/convex-hull-list/build.gradle
+++ b/geometry/convex-hull-list/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/convex-hull/build.gradle
+++ b/geometry/convex-hull/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/convex-hull/build.gradle
+++ b/geometry/convex-hull/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/convex-hull/build.gradle
+++ b/geometry/convex-hull/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/convex-hull/build.gradle
+++ b/geometry/convex-hull/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/convex-hull/build.gradle
+++ b/geometry/convex-hull/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/create-geometries/build.gradle
+++ b/geometry/create-geometries/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/create-geometries/build.gradle
+++ b/geometry/create-geometries/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/create-geometries/build.gradle
+++ b/geometry/create-geometries/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/create-geometries/build.gradle
+++ b/geometry/create-geometries/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/create-geometries/build.gradle
+++ b/geometry/create-geometries/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/cut-geometry/build.gradle
+++ b/geometry/cut-geometry/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/cut-geometry/build.gradle
+++ b/geometry/cut-geometry/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/cut-geometry/build.gradle
+++ b/geometry/cut-geometry/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/cut-geometry/build.gradle
+++ b/geometry/cut-geometry/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/cut-geometry/build.gradle
+++ b/geometry/cut-geometry/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/densify-and-generalize/build.gradle
+++ b/geometry/densify-and-generalize/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/densify-and-generalize/build.gradle
+++ b/geometry/densify-and-generalize/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/densify-and-generalize/build.gradle
+++ b/geometry/densify-and-generalize/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/densify-and-generalize/build.gradle
+++ b/geometry/densify-and-generalize/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/densify-and-generalize/build.gradle
+++ b/geometry/densify-and-generalize/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/geodesic-operations/build.gradle
+++ b/geometry/geodesic-operations/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/geodesic-operations/build.gradle
+++ b/geometry/geodesic-operations/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/geodesic-operations/build.gradle
+++ b/geometry/geodesic-operations/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/geodesic-operations/build.gradle
+++ b/geometry/geodesic-operations/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/geodesic-operations/build.gradle
+++ b/geometry/geodesic-operations/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/geodesic-sector-and-ellipse/build.gradle
+++ b/geometry/geodesic-sector-and-ellipse/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/geodesic-sector-and-ellipse/build.gradle
+++ b/geometry/geodesic-sector-and-ellipse/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/geodesic-sector-and-ellipse/build.gradle
+++ b/geometry/geodesic-sector-and-ellipse/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/geodesic-sector-and-ellipse/build.gradle
+++ b/geometry/geodesic-sector-and-ellipse/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/geodesic-sector-and-ellipse/build.gradle
+++ b/geometry/geodesic-sector-and-ellipse/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/geometry-engine-simplify/build.gradle
+++ b/geometry/geometry-engine-simplify/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/geometry-engine-simplify/build.gradle
+++ b/geometry/geometry-engine-simplify/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/geometry-engine-simplify/build.gradle
+++ b/geometry/geometry-engine-simplify/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/geometry-engine-simplify/build.gradle
+++ b/geometry/geometry-engine-simplify/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/geometry-engine-simplify/build.gradle
+++ b/geometry/geometry-engine-simplify/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/list-transformations-by-suitability/build.gradle
+++ b/geometry/list-transformations-by-suitability/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/list-transformations-by-suitability/build.gradle
+++ b/geometry/list-transformations-by-suitability/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/list-transformations-by-suitability/build.gradle
+++ b/geometry/list-transformations-by-suitability/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/list-transformations-by-suitability/build.gradle
+++ b/geometry/list-transformations-by-suitability/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/list-transformations-by-suitability/build.gradle
+++ b/geometry/list-transformations-by-suitability/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/nearest-vertex/build.gradle
+++ b/geometry/nearest-vertex/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/nearest-vertex/build.gradle
+++ b/geometry/nearest-vertex/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/nearest-vertex/build.gradle
+++ b/geometry/nearest-vertex/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/nearest-vertex/build.gradle
+++ b/geometry/nearest-vertex/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/nearest-vertex/build.gradle
+++ b/geometry/nearest-vertex/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/project/build.gradle
+++ b/geometry/project/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/project/build.gradle
+++ b/geometry/project/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/project/build.gradle
+++ b/geometry/project/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/project/build.gradle
+++ b/geometry/project/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/project/build.gradle
+++ b/geometry/project/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/spatial-operations/build.gradle
+++ b/geometry/spatial-operations/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/spatial-operations/build.gradle
+++ b/geometry/spatial-operations/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/spatial-operations/build.gradle
+++ b/geometry/spatial-operations/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/spatial-operations/build.gradle
+++ b/geometry/spatial-operations/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/spatial-operations/build.gradle
+++ b/geometry/spatial-operations/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/geometry/spatial-relationships/build.gradle
+++ b/geometry/spatial-relationships/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/geometry/spatial-relationships/build.gradle
+++ b/geometry/spatial-relationships/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/geometry/spatial-relationships/build.gradle
+++ b/geometry/spatial-relationships/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/geometry/spatial-relationships/build.gradle
+++ b/geometry/spatial-relationships/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/geometry/spatial-relationships/build.gradle
+++ b/geometry/spatial-relationships/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/group_layers/group-layers/build.gradle
+++ b/group_layers/group-layers/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/group_layers/group-layers/build.gradle
+++ b/group_layers/group-layers/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/group_layers/group-layers/build.gradle
+++ b/group_layers/group-layers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/group_layers/group-layers/build.gradle
+++ b/group_layers/group-layers/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/group_layers/group-layers/build.gradle
+++ b/group_layers/group-layers/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/hydrography/add-enc-exchange-set/build.gradle
+++ b/hydrography/add-enc-exchange-set/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/hydrography/add-enc-exchange-set/build.gradle
+++ b/hydrography/add-enc-exchange-set/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/hydrography/add-enc-exchange-set/build.gradle
+++ b/hydrography/add-enc-exchange-set/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/hydrography/add-enc-exchange-set/build.gradle
+++ b/hydrography/add-enc-exchange-set/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/hydrography/add-enc-exchange-set/build.gradle
+++ b/hydrography/add-enc-exchange-set/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/image_layers/change-sublayer-renderer/build.gradle
+++ b/image_layers/change-sublayer-renderer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/image_layers/change-sublayer-renderer/build.gradle
+++ b/image_layers/change-sublayer-renderer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/image_layers/change-sublayer-renderer/build.gradle
+++ b/image_layers/change-sublayer-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/image_layers/change-sublayer-renderer/build.gradle
+++ b/image_layers/change-sublayer-renderer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/image_layers/change-sublayer-renderer/build.gradle
+++ b/image_layers/change-sublayer-renderer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/image_layers/map-image-layer-sublayer-visibility/build.gradle
+++ b/image_layers/map-image-layer-sublayer-visibility/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/image_layers/map-image-layer-sublayer-visibility/build.gradle
+++ b/image_layers/map-image-layer-sublayer-visibility/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/image_layers/map-image-layer-sublayer-visibility/build.gradle
+++ b/image_layers/map-image-layer-sublayer-visibility/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/image_layers/map-image-layer-sublayer-visibility/build.gradle
+++ b/image_layers/map-image-layer-sublayer-visibility/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/image_layers/map-image-layer-sublayer-visibility/build.gradle
+++ b/image_layers/map-image-layer-sublayer-visibility/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/image_layers/map-image-layer-tables/build.gradle
+++ b/image_layers/map-image-layer-tables/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/image_layers/map-image-layer-tables/build.gradle
+++ b/image_layers/map-image-layer-tables/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/image_layers/map-image-layer-tables/build.gradle
+++ b/image_layers/map-image-layer-tables/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/image_layers/map-image-layer-tables/build.gradle
+++ b/image_layers/map-image-layer-tables/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/image_layers/map-image-layer-tables/build.gradle
+++ b/image_layers/map-image-layer-tables/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/image_layers/map-image-layer/build.gradle
+++ b/image_layers/map-image-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/image_layers/map-image-layer/build.gradle
+++ b/image_layers/map-image-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/image_layers/map-image-layer/build.gradle
+++ b/image_layers/map-image-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/image_layers/map-image-layer/build.gradle
+++ b/image_layers/map-image-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/image_layers/map-image-layer/build.gradle
+++ b/image_layers/map-image-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/image_layers/query-map-image-sublayer/build.gradle
+++ b/image_layers/query-map-image-sublayer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/image_layers/query-map-image-sublayer/build.gradle
+++ b/image_layers/query-map-image-sublayer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/image_layers/query-map-image-sublayer/build.gradle
+++ b/image_layers/query-map-image-sublayer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/image_layers/query-map-image-sublayer/build.gradle
+++ b/image_layers/query-map-image-sublayer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/image_layers/query-map-image-sublayer/build.gradle
+++ b/image_layers/query-map-image-sublayer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/kml/create-and-save-kml-file/build.gradle
+++ b/kml/create-and-save-kml-file/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/kml/create-and-save-kml-file/build.gradle
+++ b/kml/create-and-save-kml-file/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/kml/create-and-save-kml-file/build.gradle
+++ b/kml/create-and-save-kml-file/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/kml/create-and-save-kml-file/build.gradle
+++ b/kml/create-and-save-kml-file/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/kml/create-and-save-kml-file/build.gradle
+++ b/kml/create-and-save-kml-file/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/kml/display-kml-network-links/build.gradle
+++ b/kml/display-kml-network-links/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/kml/display-kml-network-links/build.gradle
+++ b/kml/display-kml-network-links/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/kml/display-kml-network-links/build.gradle
+++ b/kml/display-kml-network-links/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/kml/display-kml-network-links/build.gradle
+++ b/kml/display-kml-network-links/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/kml/display-kml-network-links/build.gradle
+++ b/kml/display-kml-network-links/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/kml/display-kml/build.gradle
+++ b/kml/display-kml/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/kml/display-kml/build.gradle
+++ b/kml/display-kml/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/kml/display-kml/build.gradle
+++ b/kml/display-kml/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/kml/display-kml/build.gradle
+++ b/kml/display-kml/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/kml/display-kml/build.gradle
+++ b/kml/display-kml/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/kml/edit-kml-ground-overlay/build.gradle
+++ b/kml/edit-kml-ground-overlay/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/kml/edit-kml-ground-overlay/build.gradle
+++ b/kml/edit-kml-ground-overlay/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/kml/edit-kml-ground-overlay/build.gradle
+++ b/kml/edit-kml-ground-overlay/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/kml/edit-kml-ground-overlay/build.gradle
+++ b/kml/edit-kml-ground-overlay/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/kml/edit-kml-ground-overlay/build.gradle
+++ b/kml/edit-kml-ground-overlay/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/kml/identify-kml-features/build.gradle
+++ b/kml/identify-kml-features/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/kml/identify-kml-features/build.gradle
+++ b/kml/identify-kml-features/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/kml/identify-kml-features/build.gradle
+++ b/kml/identify-kml-features/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/kml/identify-kml-features/build.gradle
+++ b/kml/identify-kml-features/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/kml/identify-kml-features/build.gradle
+++ b/kml/identify-kml-features/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/kml/list-kml-contents/build.gradle
+++ b/kml/list-kml-contents/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/kml/list-kml-contents/build.gradle
+++ b/kml/list-kml-contents/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/kml/list-kml-contents/build.gradle
+++ b/kml/list-kml-contents/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/kml/list-kml-contents/build.gradle
+++ b/kml/list-kml-contents/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/kml/list-kml-contents/build.gradle
+++ b/kml/list-kml-contents/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/kml/play-a-kml-tour/build.gradle
+++ b/kml/play-a-kml-tour/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/kml/play-a-kml-tour/build.gradle
+++ b/kml/play-a-kml-tour/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/kml/play-a-kml-tour/build.gradle
+++ b/kml/play-a-kml-tour/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/kml/play-a-kml-tour/build.gradle
+++ b/kml/play-a-kml-tour/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/kml/play-a-kml-tour/build.gradle
+++ b/kml/play-a-kml-tour/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/local_server/local-server-feature-layer/build.gradle
+++ b/local_server/local-server-feature-layer/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/local_server/local-server-feature-layer/build.gradle
+++ b/local_server/local-server-feature-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/local_server/local-server-feature-layer/build.gradle
+++ b/local_server/local-server-feature-layer/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/local_server/local-server-feature-layer/build.gradle
+++ b/local_server/local-server-feature-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/local_server/local-server-feature-layer/build.gradle
+++ b/local_server/local-server-feature-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/local_server/local-server-geoprocessing/build.gradle
+++ b/local_server/local-server-geoprocessing/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/local_server/local-server-geoprocessing/build.gradle
+++ b/local_server/local-server-geoprocessing/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/local_server/local-server-geoprocessing/build.gradle
+++ b/local_server/local-server-geoprocessing/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/local_server/local-server-geoprocessing/build.gradle
+++ b/local_server/local-server-geoprocessing/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/local_server/local-server-geoprocessing/build.gradle
+++ b/local_server/local-server-geoprocessing/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/local_server/local-server-map-image-layer/build.gradle
+++ b/local_server/local-server-map-image-layer/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/local_server/local-server-map-image-layer/build.gradle
+++ b/local_server/local-server-map-image-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/local_server/local-server-map-image-layer/build.gradle
+++ b/local_server/local-server-map-image-layer/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/local_server/local-server-map-image-layer/build.gradle
+++ b/local_server/local-server-map-image-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/local_server/local-server-map-image-layer/build.gradle
+++ b/local_server/local-server-map-image-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/local_server/local-server-services/build.gradle
+++ b/local_server/local-server-services/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/local_server/local-server-services/build.gradle
+++ b/local_server/local-server-services/build.gradle
@@ -70,7 +70,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/local_server/local-server-services/build.gradle
+++ b/local_server/local-server-services/build.gradle
@@ -68,7 +68,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/local_server/local-server-services/build.gradle
+++ b/local_server/local-server-services/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'commons-io:commons-io:2.4'

--- a/local_server/local-server-services/build.gradle
+++ b/local_server/local-server-services/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile 'commons-io:commons-io:2.4'
+    implementation 'commons-io:commons-io:2.4'
 }
 
 task copyNatives(type: Copy) {

--- a/local_server/local-server-services/build.gradle
+++ b/local_server/local-server-services/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
@@ -70,7 +70,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
@@ -68,7 +68,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'commons-io:commons-io:2.4'

--- a/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile 'commons-io:commons-io:2.4'
+    implementation 'commons-io:commons-io:2.4'
 }
 
 task copyNatives(type: Copy) {

--- a/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/download-preplanned-map/build.gradle
+++ b/map/download-preplanned-map/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/download-preplanned-map/build.gradle
+++ b/map/download-preplanned-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/download-preplanned-map/build.gradle
+++ b/map/download-preplanned-map/build.gradle
@@ -65,7 +65,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/download-preplanned-map/build.gradle
+++ b/map/download-preplanned-map/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'commons-io:commons-io:2.4'

--- a/map/download-preplanned-map/build.gradle
+++ b/map/download-preplanned-map/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile 'commons-io:commons-io:2.4'
+    implementation 'commons-io:commons-io:2.4'
 }
 
 task copyNatives(type: Copy) {

--- a/map/download-preplanned-map/build.gradle
+++ b/map/download-preplanned-map/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/generate-offline-map-overrides/build.gradle
+++ b/map/generate-offline-map-overrides/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/generate-offline-map-overrides/build.gradle
+++ b/map/generate-offline-map-overrides/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/generate-offline-map-overrides/build.gradle
+++ b/map/generate-offline-map-overrides/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/generate-offline-map-overrides/build.gradle
+++ b/map/generate-offline-map-overrides/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/generate-offline-map-overrides/build.gradle
+++ b/map/generate-offline-map-overrides/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/generate-offline-map-with-local-basemap/build.gradle
+++ b/map/generate-offline-map-with-local-basemap/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/generate-offline-map-with-local-basemap/build.gradle
+++ b/map/generate-offline-map-with-local-basemap/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/generate-offline-map-with-local-basemap/build.gradle
+++ b/map/generate-offline-map-with-local-basemap/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/generate-offline-map-with-local-basemap/build.gradle
+++ b/map/generate-offline-map-with-local-basemap/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/generate-offline-map-with-local-basemap/build.gradle
+++ b/map/generate-offline-map-with-local-basemap/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/generate-offline-map/build.gradle
+++ b/map/generate-offline-map/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/generate-offline-map/build.gradle
+++ b/map/generate-offline-map/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/generate-offline-map/build.gradle
+++ b/map/generate-offline-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/generate-offline-map/build.gradle
+++ b/map/generate-offline-map/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/generate-offline-map/build.gradle
+++ b/map/generate-offline-map/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/honor-mobile-map-package-expiration-date/build.gradle
+++ b/map/honor-mobile-map-package-expiration-date/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/honor-mobile-map-package-expiration-date/build.gradle
+++ b/map/honor-mobile-map-package-expiration-date/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
     }
 
 wrapper {

--- a/map/honor-mobile-map-package-expiration-date/build.gradle
+++ b/map/honor-mobile-map-package-expiration-date/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
     }

--- a/map/honor-mobile-map-package-expiration-date/build.gradle
+++ b/map/honor-mobile-map-package-expiration-date/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/honor-mobile-map-package-expiration-date/build.gradle
+++ b/map/honor-mobile-map-package-expiration-date/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/manage-bookmarks/build.gradle
+++ b/map/manage-bookmarks/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/manage-bookmarks/build.gradle
+++ b/map/manage-bookmarks/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/manage-bookmarks/build.gradle
+++ b/map/manage-bookmarks/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/manage-bookmarks/build.gradle
+++ b/map/manage-bookmarks/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/manage-bookmarks/build.gradle
+++ b/map/manage-bookmarks/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/manage-operational-layers/build.gradle
+++ b/map/manage-operational-layers/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/manage-operational-layers/build.gradle
+++ b/map/manage-operational-layers/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/manage-operational-layers/build.gradle
+++ b/map/manage-operational-layers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/manage-operational-layers/build.gradle
+++ b/map/manage-operational-layers/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/manage-operational-layers/build.gradle
+++ b/map/manage-operational-layers/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/map-initial-extent/build.gradle
+++ b/map/map-initial-extent/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/map-initial-extent/build.gradle
+++ b/map/map-initial-extent/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/map-initial-extent/build.gradle
+++ b/map/map-initial-extent/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/map-initial-extent/build.gradle
+++ b/map/map-initial-extent/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/map-initial-extent/build.gradle
+++ b/map/map-initial-extent/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/map-reference-scale/build.gradle
+++ b/map/map-reference-scale/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/map-reference-scale/build.gradle
+++ b/map/map-reference-scale/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/map-reference-scale/build.gradle
+++ b/map/map-reference-scale/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/map-reference-scale/build.gradle
+++ b/map/map-reference-scale/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/map-reference-scale/build.gradle
+++ b/map/map-reference-scale/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/map-spatial-reference/build.gradle
+++ b/map/map-spatial-reference/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/map-spatial-reference/build.gradle
+++ b/map/map-spatial-reference/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/map-spatial-reference/build.gradle
+++ b/map/map-spatial-reference/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/map-spatial-reference/build.gradle
+++ b/map/map-spatial-reference/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/map-spatial-reference/build.gradle
+++ b/map/map-spatial-reference/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/min-max-scale/build.gradle
+++ b/map/min-max-scale/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/min-max-scale/build.gradle
+++ b/map/min-max-scale/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/min-max-scale/build.gradle
+++ b/map/min-max-scale/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/min-max-scale/build.gradle
+++ b/map/min-max-scale/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/min-max-scale/build.gradle
+++ b/map/min-max-scale/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/mobile-map-search-and-route/build.gradle
+++ b/map/mobile-map-search-and-route/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/mobile-map-search-and-route/build.gradle
+++ b/map/mobile-map-search-and-route/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/mobile-map-search-and-route/build.gradle
+++ b/map/mobile-map-search-and-route/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/mobile-map-search-and-route/build.gradle
+++ b/map/mobile-map-search-and-route/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/mobile-map-search-and-route/build.gradle
+++ b/map/mobile-map-search-and-route/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/open-map-url/build.gradle
+++ b/map/open-map-url/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/open-map-url/build.gradle
+++ b/map/open-map-url/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/open-map-url/build.gradle
+++ b/map/open-map-url/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/open-map-url/build.gradle
+++ b/map/open-map-url/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/open-map-url/build.gradle
+++ b/map/open-map-url/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/open-mobile-map-package/build.gradle
+++ b/map/open-mobile-map-package/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/open-mobile-map-package/build.gradle
+++ b/map/open-mobile-map-package/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/open-mobile-map-package/build.gradle
+++ b/map/open-mobile-map-package/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/open-mobile-map-package/build.gradle
+++ b/map/open-mobile-map-package/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/open-mobile-map-package/build.gradle
+++ b/map/open-mobile-map-package/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/read-geopackage/build.gradle
+++ b/map/read-geopackage/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/read-geopackage/build.gradle
+++ b/map/read-geopackage/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/read-geopackage/build.gradle
+++ b/map/read-geopackage/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/read-geopackage/build.gradle
+++ b/map/read-geopackage/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/read-geopackage/build.gradle
+++ b/map/read-geopackage/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map/set-initial-map-location/build.gradle
+++ b/map/set-initial-map-location/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map/set-initial-map-location/build.gradle
+++ b/map/set-initial-map-location/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map/set-initial-map-location/build.gradle
+++ b/map/set-initial-map-location/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map/set-initial-map-location/build.gradle
+++ b/map/set-initial-map-location/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map/set-initial-map-location/build.gradle
+++ b/map/set-initial-map-location/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map_view/change-viewpoint/build.gradle
+++ b/map_view/change-viewpoint/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map_view/change-viewpoint/build.gradle
+++ b/map_view/change-viewpoint/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map_view/change-viewpoint/build.gradle
+++ b/map_view/change-viewpoint/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map_view/change-viewpoint/build.gradle
+++ b/map_view/change-viewpoint/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map_view/change-viewpoint/build.gradle
+++ b/map_view/change-viewpoint/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map_view/display-drawing-status/build.gradle
+++ b/map_view/display-drawing-status/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map_view/display-drawing-status/build.gradle
+++ b/map_view/display-drawing-status/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map_view/display-drawing-status/build.gradle
+++ b/map_view/display-drawing-status/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map_view/display-drawing-status/build.gradle
+++ b/map_view/display-drawing-status/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map_view/display-drawing-status/build.gradle
+++ b/map_view/display-drawing-status/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map_view/display-layer-view-state/build.gradle
+++ b/map_view/display-layer-view-state/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map_view/display-layer-view-state/build.gradle
+++ b/map_view/display-layer-view-state/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map_view/display-layer-view-state/build.gradle
+++ b/map_view/display-layer-view-state/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map_view/display-layer-view-state/build.gradle
+++ b/map_view/display-layer-view-state/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map_view/display-layer-view-state/build.gradle
+++ b/map_view/display-layer-view-state/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map_view/identify-layers/build.gradle
+++ b/map_view/identify-layers/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map_view/identify-layers/build.gradle
+++ b/map_view/identify-layers/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map_view/identify-layers/build.gradle
+++ b/map_view/identify-layers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map_view/identify-layers/build.gradle
+++ b/map_view/identify-layers/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map_view/identify-layers/build.gradle
+++ b/map_view/identify-layers/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'
+    implementation 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'
 }
 
 task copyNatives(type: Copy) {

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -65,7 +65,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'
+    implementation 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'
 }
 
 task copyNatives(type: Copy) {

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -65,7 +65,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/network_analysis/closest-facility-static/build.gradle
+++ b/network_analysis/closest-facility-static/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/network_analysis/closest-facility-static/build.gradle
+++ b/network_analysis/closest-facility-static/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/network_analysis/closest-facility-static/build.gradle
+++ b/network_analysis/closest-facility-static/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/network_analysis/closest-facility-static/build.gradle
+++ b/network_analysis/closest-facility-static/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/network_analysis/closest-facility-static/build.gradle
+++ b/network_analysis/closest-facility-static/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/network_analysis/closest-facility/build.gradle
+++ b/network_analysis/closest-facility/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/network_analysis/closest-facility/build.gradle
+++ b/network_analysis/closest-facility/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/network_analysis/closest-facility/build.gradle
+++ b/network_analysis/closest-facility/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/network_analysis/closest-facility/build.gradle
+++ b/network_analysis/closest-facility/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/network_analysis/closest-facility/build.gradle
+++ b/network_analysis/closest-facility/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/network_analysis/find-route/build.gradle
+++ b/network_analysis/find-route/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/network_analysis/find-route/build.gradle
+++ b/network_analysis/find-route/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/network_analysis/find-route/build.gradle
+++ b/network_analysis/find-route/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/network_analysis/find-route/build.gradle
+++ b/network_analysis/find-route/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/network_analysis/find-route/build.gradle
+++ b/network_analysis/find-route/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
+++ b/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
+++ b/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
+++ b/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
+++ b/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
+++ b/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/network_analysis/offline-routing/build.gradle
+++ b/network_analysis/offline-routing/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/network_analysis/offline-routing/build.gradle
+++ b/network_analysis/offline-routing/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/network_analysis/offline-routing/build.gradle
+++ b/network_analysis/offline-routing/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/network_analysis/offline-routing/build.gradle
+++ b/network_analysis/offline-routing/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/network_analysis/offline-routing/build.gradle
+++ b/network_analysis/offline-routing/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/network_analysis/routing-around-barriers/build.gradle
+++ b/network_analysis/routing-around-barriers/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/network_analysis/routing-around-barriers/build.gradle
+++ b/network_analysis/routing-around-barriers/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/network_analysis/routing-around-barriers/build.gradle
+++ b/network_analysis/routing-around-barriers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/network_analysis/routing-around-barriers/build.gradle
+++ b/network_analysis/routing-around-barriers/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/network_analysis/routing-around-barriers/build.gradle
+++ b/network_analysis/routing-around-barriers/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/network_analysis/service-area-task/build.gradle
+++ b/network_analysis/service-area-task/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/network_analysis/service-area-task/build.gradle
+++ b/network_analysis/service-area-task/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/network_analysis/service-area-task/build.gradle
+++ b/network_analysis/service-area-task/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/network_analysis/service-area-task/build.gradle
+++ b/network_analysis/service-area-task/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/network_analysis/service-area-task/build.gradle
+++ b/network_analysis/service-area-task/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/ogc/browse-wfs-layers/build.gradle
+++ b/ogc/browse-wfs-layers/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/ogc/browse-wfs-layers/build.gradle
+++ b/ogc/browse-wfs-layers/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/ogc/browse-wfs-layers/build.gradle
+++ b/ogc/browse-wfs-layers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/ogc/browse-wfs-layers/build.gradle
+++ b/ogc/browse-wfs-layers/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/ogc/browse-wfs-layers/build.gradle
+++ b/ogc/browse-wfs-layers/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/ogc/display-wfs-layer/build.gradle
+++ b/ogc/display-wfs-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/ogc/display-wfs-layer/build.gradle
+++ b/ogc/display-wfs-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/ogc/display-wfs-layer/build.gradle
+++ b/ogc/display-wfs-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/ogc/display-wfs-layer/build.gradle
+++ b/ogc/display-wfs-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/ogc/display-wfs-layer/build.gradle
+++ b/ogc/display-wfs-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/ogc/open-street-map-layer/build.gradle
+++ b/ogc/open-street-map-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/ogc/open-street-map-layer/build.gradle
+++ b/ogc/open-street-map-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/ogc/open-street-map-layer/build.gradle
+++ b/ogc/open-street-map-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/ogc/open-street-map-layer/build.gradle
+++ b/ogc/open-street-map-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/ogc/open-street-map-layer/build.gradle
+++ b/ogc/open-street-map-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/ogc/style-wms-layer/build.gradle
+++ b/ogc/style-wms-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/ogc/style-wms-layer/build.gradle
+++ b/ogc/style-wms-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/ogc/style-wms-layer/build.gradle
+++ b/ogc/style-wms-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/ogc/style-wms-layer/build.gradle
+++ b/ogc/style-wms-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/ogc/style-wms-layer/build.gradle
+++ b/ogc/style-wms-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/ogc/wfs-xml-query/build.gradle
+++ b/ogc/wfs-xml-query/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/ogc/wfs-xml-query/build.gradle
+++ b/ogc/wfs-xml-query/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/ogc/wfs-xml-query/build.gradle
+++ b/ogc/wfs-xml-query/build.gradle
@@ -65,7 +65,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/ogc/wfs-xml-query/build.gradle
+++ b/ogc/wfs-xml-query/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'commons-io:commons-io:2.4'

--- a/ogc/wfs-xml-query/build.gradle
+++ b/ogc/wfs-xml-query/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile 'commons-io:commons-io:2.4'
+    implementation 'commons-io:commons-io:2.4'
 }
 
 task copyNatives(type: Copy) {

--- a/ogc/wfs-xml-query/build.gradle
+++ b/ogc/wfs-xml-query/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/ogc/wms-layer-url/build.gradle
+++ b/ogc/wms-layer-url/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/ogc/wms-layer-url/build.gradle
+++ b/ogc/wms-layer-url/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/ogc/wms-layer-url/build.gradle
+++ b/ogc/wms-layer-url/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/ogc/wms-layer-url/build.gradle
+++ b/ogc/wms-layer-url/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/ogc/wms-layer-url/build.gradle
+++ b/ogc/wms-layer-url/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/ogc/wmts-layer/build.gradle
+++ b/ogc/wmts-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/ogc/wmts-layer/build.gradle
+++ b/ogc/wmts-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/ogc/wmts-layer/build.gradle
+++ b/ogc/wmts-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/ogc/wmts-layer/build.gradle
+++ b/ogc/wmts-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/ogc/wmts-layer/build.gradle
+++ b/ogc/wmts-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/portal/integrated-windows-authentication/build.gradle
+++ b/portal/integrated-windows-authentication/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/portal/integrated-windows-authentication/build.gradle
+++ b/portal/integrated-windows-authentication/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/portal/integrated-windows-authentication/build.gradle
+++ b/portal/integrated-windows-authentication/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/portal/integrated-windows-authentication/build.gradle
+++ b/portal/integrated-windows-authentication/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/portal/integrated-windows-authentication/build.gradle
+++ b/portal/integrated-windows-authentication/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/portal/oauth/build.gradle
+++ b/portal/oauth/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/portal/oauth/build.gradle
+++ b/portal/oauth/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/portal/oauth/build.gradle
+++ b/portal/oauth/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/portal/oauth/build.gradle
+++ b/portal/oauth/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/portal/oauth/build.gradle
+++ b/portal/oauth/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/portal/token-authentication/build.gradle
+++ b/portal/token-authentication/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/portal/token-authentication/build.gradle
+++ b/portal/token-authentication/build.gradle
@@ -65,7 +65,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/portal/token-authentication/build.gradle
+++ b/portal/token-authentication/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/portal/token-authentication/build.gradle
+++ b/portal/token-authentication/build.gradle
@@ -63,7 +63,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/portal/token-authentication/build.gradle
+++ b/portal/token-authentication/build.gradle
@@ -21,7 +21,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/portal/webmap-keyword-search/build.gradle
+++ b/portal/webmap-keyword-search/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/portal/webmap-keyword-search/build.gradle
+++ b/portal/webmap-keyword-search/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/portal/webmap-keyword-search/build.gradle
+++ b/portal/webmap-keyword-search/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/portal/webmap-keyword-search/build.gradle
+++ b/portal/webmap-keyword-search/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/portal/webmap-keyword-search/build.gradle
+++ b/portal/webmap-keyword-search/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/blend-renderer/build.gradle
+++ b/raster/blend-renderer/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/blend-renderer/build.gradle
+++ b/raster/blend-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/blend-renderer/build.gradle
+++ b/raster/blend-renderer/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/blend-renderer/build.gradle
+++ b/raster/blend-renderer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/blend-renderer/build.gradle
+++ b/raster/blend-renderer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/colormap-renderer/build.gradle
+++ b/raster/colormap-renderer/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/colormap-renderer/build.gradle
+++ b/raster/colormap-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/colormap-renderer/build.gradle
+++ b/raster/colormap-renderer/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/colormap-renderer/build.gradle
+++ b/raster/colormap-renderer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/colormap-renderer/build.gradle
+++ b/raster/colormap-renderer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/hillshade-renderer/build.gradle
+++ b/raster/hillshade-renderer/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/hillshade-renderer/build.gradle
+++ b/raster/hillshade-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/hillshade-renderer/build.gradle
+++ b/raster/hillshade-renderer/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/hillshade-renderer/build.gradle
+++ b/raster/hillshade-renderer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/hillshade-renderer/build.gradle
+++ b/raster/hillshade-renderer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/raster-function/build.gradle
+++ b/raster/raster-function/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/raster-function/build.gradle
+++ b/raster/raster-function/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/raster-function/build.gradle
+++ b/raster/raster-function/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/raster-function/build.gradle
+++ b/raster/raster-function/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/raster-function/build.gradle
+++ b/raster/raster-function/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/raster-layer-file/build.gradle
+++ b/raster/raster-layer-file/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/raster-layer-file/build.gradle
+++ b/raster/raster-layer-file/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/raster-layer-file/build.gradle
+++ b/raster/raster-layer-file/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/raster-layer-file/build.gradle
+++ b/raster/raster-layer-file/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/raster-layer-file/build.gradle
+++ b/raster/raster-layer-file/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/raster-layer-geopackage/build.gradle
+++ b/raster/raster-layer-geopackage/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/raster-layer-geopackage/build.gradle
+++ b/raster/raster-layer-geopackage/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/raster-layer-geopackage/build.gradle
+++ b/raster/raster-layer-geopackage/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/raster-layer-geopackage/build.gradle
+++ b/raster/raster-layer-geopackage/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/raster-layer-geopackage/build.gradle
+++ b/raster/raster-layer-geopackage/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/raster-layer-url/build.gradle
+++ b/raster/raster-layer-url/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/raster-layer-url/build.gradle
+++ b/raster/raster-layer-url/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/raster-layer-url/build.gradle
+++ b/raster/raster-layer-url/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/raster-layer-url/build.gradle
+++ b/raster/raster-layer-url/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/raster-layer-url/build.gradle
+++ b/raster/raster-layer-url/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/raster-rendering-rule/build.gradle
+++ b/raster/raster-rendering-rule/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/raster-rendering-rule/build.gradle
+++ b/raster/raster-rendering-rule/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/raster-rendering-rule/build.gradle
+++ b/raster/raster-rendering-rule/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/raster-rendering-rule/build.gradle
+++ b/raster/raster-rendering-rule/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/raster-rendering-rule/build.gradle
+++ b/raster/raster-rendering-rule/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/rgb-renderer/build.gradle
+++ b/raster/rgb-renderer/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/rgb-renderer/build.gradle
+++ b/raster/rgb-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/rgb-renderer/build.gradle
+++ b/raster/rgb-renderer/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/rgb-renderer/build.gradle
+++ b/raster/rgb-renderer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/rgb-renderer/build.gradle
+++ b/raster/rgb-renderer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/raster/stretch-renderer/build.gradle
+++ b/raster/stretch-renderer/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/raster/stretch-renderer/build.gradle
+++ b/raster/stretch-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/raster/stretch-renderer/build.gradle
+++ b/raster/stretch-renderer/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/raster/stretch-renderer/build.gradle
+++ b/raster/stretch-renderer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/raster/stretch-renderer/build.gradle
+++ b/raster/stretch-renderer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/add-a-point-scene-layer/build.gradle
+++ b/scene/add-a-point-scene-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/add-a-point-scene-layer/build.gradle
+++ b/scene/add-a-point-scene-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/add-a-point-scene-layer/build.gradle
+++ b/scene/add-a-point-scene-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/add-a-point-scene-layer/build.gradle
+++ b/scene/add-a-point-scene-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/add-a-point-scene-layer/build.gradle
+++ b/scene/add-a-point-scene-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/add-an-integrated-mesh-layer/build.gradle
+++ b/scene/add-an-integrated-mesh-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/add-an-integrated-mesh-layer/build.gradle
+++ b/scene/add-an-integrated-mesh-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/add-an-integrated-mesh-layer/build.gradle
+++ b/scene/add-an-integrated-mesh-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/add-an-integrated-mesh-layer/build.gradle
+++ b/scene/add-an-integrated-mesh-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/add-an-integrated-mesh-layer/build.gradle
+++ b/scene/add-an-integrated-mesh-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/animate-3d-graphic/build.gradle
+++ b/scene/animate-3d-graphic/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/animate-3d-graphic/build.gradle
+++ b/scene/animate-3d-graphic/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/animate-3d-graphic/build.gradle
+++ b/scene/animate-3d-graphic/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/animate-3d-graphic/build.gradle
+++ b/scene/animate-3d-graphic/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/animate-3d-graphic/build.gradle
+++ b/scene/animate-3d-graphic/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/animate-images-with-image-overlay/build.gradle
+++ b/scene/animate-images-with-image-overlay/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/animate-images-with-image-overlay/build.gradle
+++ b/scene/animate-images-with-image-overlay/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/animate-images-with-image-overlay/build.gradle
+++ b/scene/animate-images-with-image-overlay/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/animate-images-with-image-overlay/build.gradle
+++ b/scene/animate-images-with-image-overlay/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/animate-images-with-image-overlay/build.gradle
+++ b/scene/animate-images-with-image-overlay/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/change-atmosphere-effect/build.gradle
+++ b/scene/change-atmosphere-effect/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/change-atmosphere-effect/build.gradle
+++ b/scene/change-atmosphere-effect/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/change-atmosphere-effect/build.gradle
+++ b/scene/change-atmosphere-effect/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/change-atmosphere-effect/build.gradle
+++ b/scene/change-atmosphere-effect/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/change-atmosphere-effect/build.gradle
+++ b/scene/change-atmosphere-effect/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/choose-camera-controller/build.gradle
+++ b/scene/choose-camera-controller/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/choose-camera-controller/build.gradle
+++ b/scene/choose-camera-controller/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/choose-camera-controller/build.gradle
+++ b/scene/choose-camera-controller/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/choose-camera-controller/build.gradle
+++ b/scene/choose-camera-controller/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/choose-camera-controller/build.gradle
+++ b/scene/choose-camera-controller/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/create-terrain-surface-from-local-raster/build.gradle
+++ b/scene/create-terrain-surface-from-local-raster/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/create-terrain-surface-from-local-raster/build.gradle
+++ b/scene/create-terrain-surface-from-local-raster/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/create-terrain-surface-from-local-raster/build.gradle
+++ b/scene/create-terrain-surface-from-local-raster/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/create-terrain-surface-from-local-raster/build.gradle
+++ b/scene/create-terrain-surface-from-local-raster/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/create-terrain-surface-from-local-raster/build.gradle
+++ b/scene/create-terrain-surface-from-local-raster/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/create-terrain-surface-from-local-tile-package/build.gradle
+++ b/scene/create-terrain-surface-from-local-tile-package/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/create-terrain-surface-from-local-tile-package/build.gradle
+++ b/scene/create-terrain-surface-from-local-tile-package/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/create-terrain-surface-from-local-tile-package/build.gradle
+++ b/scene/create-terrain-surface-from-local-tile-package/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/create-terrain-surface-from-local-tile-package/build.gradle
+++ b/scene/create-terrain-surface-from-local-tile-package/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/create-terrain-surface-from-local-tile-package/build.gradle
+++ b/scene/create-terrain-surface-from-local-tile-package/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/display-scene/build.gradle
+++ b/scene/display-scene/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/display-scene/build.gradle
+++ b/scene/display-scene/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/display-scene/build.gradle
+++ b/scene/display-scene/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/display-scene/build.gradle
+++ b/scene/display-scene/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/display-scene/build.gradle
+++ b/scene/display-scene/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/distance-composite-symbol/build.gradle
+++ b/scene/distance-composite-symbol/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/distance-composite-symbol/build.gradle
+++ b/scene/distance-composite-symbol/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/distance-composite-symbol/build.gradle
+++ b/scene/distance-composite-symbol/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/distance-composite-symbol/build.gradle
+++ b/scene/distance-composite-symbol/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/distance-composite-symbol/build.gradle
+++ b/scene/distance-composite-symbol/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/extrude-graphics/build.gradle
+++ b/scene/extrude-graphics/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/extrude-graphics/build.gradle
+++ b/scene/extrude-graphics/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/extrude-graphics/build.gradle
+++ b/scene/extrude-graphics/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/extrude-graphics/build.gradle
+++ b/scene/extrude-graphics/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/extrude-graphics/build.gradle
+++ b/scene/extrude-graphics/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/feature-layer-rendering-mode-scene/build.gradle
+++ b/scene/feature-layer-rendering-mode-scene/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/feature-layer-rendering-mode-scene/build.gradle
+++ b/scene/feature-layer-rendering-mode-scene/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/feature-layer-rendering-mode-scene/build.gradle
+++ b/scene/feature-layer-rendering-mode-scene/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/feature-layer-rendering-mode-scene/build.gradle
+++ b/scene/feature-layer-rendering-mode-scene/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/feature-layer-rendering-mode-scene/build.gradle
+++ b/scene/feature-layer-rendering-mode-scene/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/get-elevation-at-a-point/build.gradle
+++ b/scene/get-elevation-at-a-point/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/get-elevation-at-a-point/build.gradle
+++ b/scene/get-elevation-at-a-point/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/get-elevation-at-a-point/build.gradle
+++ b/scene/get-elevation-at-a-point/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/get-elevation-at-a-point/build.gradle
+++ b/scene/get-elevation-at-a-point/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/get-elevation-at-a-point/build.gradle
+++ b/scene/get-elevation-at-a-point/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/open-mobile-scene-package/build.gradle
+++ b/scene/open-mobile-scene-package/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/open-mobile-scene-package/build.gradle
+++ b/scene/open-mobile-scene-package/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/open-mobile-scene-package/build.gradle
+++ b/scene/open-mobile-scene-package/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/open-mobile-scene-package/build.gradle
+++ b/scene/open-mobile-scene-package/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/open-mobile-scene-package/build.gradle
+++ b/scene/open-mobile-scene-package/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/open-scene-portal-item/build.gradle
+++ b/scene/open-scene-portal-item/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/open-scene-portal-item/build.gradle
+++ b/scene/open-scene-portal-item/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/open-scene-portal-item/build.gradle
+++ b/scene/open-scene-portal-item/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/open-scene-portal-item/build.gradle
+++ b/scene/open-scene-portal-item/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/open-scene-portal-item/build.gradle
+++ b/scene/open-scene-portal-item/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/orbit-the-camera-around-an-object/build.gradle
+++ b/scene/orbit-the-camera-around-an-object/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/orbit-the-camera-around-an-object/build.gradle
+++ b/scene/orbit-the-camera-around-an-object/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/orbit-the-camera-around-an-object/build.gradle
+++ b/scene/orbit-the-camera-around-an-object/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/orbit-the-camera-around-an-object/build.gradle
+++ b/scene/orbit-the-camera-around-an-object/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/orbit-the-camera-around-an-object/build.gradle
+++ b/scene/orbit-the-camera-around-an-object/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/realistic-lighting-and-shadows/build.gradle
+++ b/scene/realistic-lighting-and-shadows/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into(project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/realistic-lighting-and-shadows/build.gradle
+++ b/scene/realistic-lighting-and-shadows/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/realistic-lighting-and-shadows/build.gradle
+++ b/scene/realistic-lighting-and-shadows/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into(project.name)
     baseName = project.name
 }

--- a/scene/realistic-lighting-and-shadows/build.gradle
+++ b/scene/realistic-lighting-and-shadows/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/realistic-lighting-and-shadows/build.gradle
+++ b/scene/realistic-lighting-and-shadows/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/scene-layer-selection/build.gradle
+++ b/scene/scene-layer-selection/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/scene-layer-selection/build.gradle
+++ b/scene/scene-layer-selection/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/scene-layer-selection/build.gradle
+++ b/scene/scene-layer-selection/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/scene-layer-selection/build.gradle
+++ b/scene/scene-layer-selection/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/scene-layer-selection/build.gradle
+++ b/scene/scene-layer-selection/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/scene-layer/build.gradle
+++ b/scene/scene-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/scene-layer/build.gradle
+++ b/scene/scene-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/scene-layer/build.gradle
+++ b/scene/scene-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/scene-layer/build.gradle
+++ b/scene/scene-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/scene-layer/build.gradle
+++ b/scene/scene-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/scene-properties-expressions/build.gradle
+++ b/scene/scene-properties-expressions/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/scene-properties-expressions/build.gradle
+++ b/scene/scene-properties-expressions/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/scene-properties-expressions/build.gradle
+++ b/scene/scene-properties-expressions/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/scene-properties-expressions/build.gradle
+++ b/scene/scene-properties-expressions/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/scene-properties-expressions/build.gradle
+++ b/scene/scene-properties-expressions/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/surface-placement/build.gradle
+++ b/scene/surface-placement/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/surface-placement/build.gradle
+++ b/scene/surface-placement/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/surface-placement/build.gradle
+++ b/scene/surface-placement/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/surface-placement/build.gradle
+++ b/scene/surface-placement/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/surface-placement/build.gradle
+++ b/scene/surface-placement/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/symbols/build.gradle
+++ b/scene/symbols/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/symbols/build.gradle
+++ b/scene/symbols/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/symbols/build.gradle
+++ b/scene/symbols/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/symbols/build.gradle
+++ b/scene/symbols/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/symbols/build.gradle
+++ b/scene/symbols/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/sync-map-and-scene-viewpoints/build.gradle
+++ b/scene/sync-map-and-scene-viewpoints/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/sync-map-and-scene-viewpoints/build.gradle
+++ b/scene/sync-map-and-scene-viewpoints/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/sync-map-and-scene-viewpoints/build.gradle
+++ b/scene/sync-map-and-scene-viewpoints/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/sync-map-and-scene-viewpoints/build.gradle
+++ b/scene/sync-map-and-scene-viewpoints/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/sync-map-and-scene-viewpoints/build.gradle
+++ b/scene/sync-map-and-scene-viewpoints/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/terrain-exaggeration/build.gradle
+++ b/scene/terrain-exaggeration/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/terrain-exaggeration/build.gradle
+++ b/scene/terrain-exaggeration/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/terrain-exaggeration/build.gradle
+++ b/scene/terrain-exaggeration/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/terrain-exaggeration/build.gradle
+++ b/scene/terrain-exaggeration/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/terrain-exaggeration/build.gradle
+++ b/scene/terrain-exaggeration/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/view-content-beneath-terrain-surface/build.gradle
+++ b/scene/view-content-beneath-terrain-surface/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/view-content-beneath-terrain-surface/build.gradle
+++ b/scene/view-content-beneath-terrain-surface/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/view-content-beneath-terrain-surface/build.gradle
+++ b/scene/view-content-beneath-terrain-surface/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/view-content-beneath-terrain-surface/build.gradle
+++ b/scene/view-content-beneath-terrain-surface/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/view-content-beneath-terrain-surface/build.gradle
+++ b/scene/view-content-beneath-terrain-surface/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/scene/view-point-cloud-data-offline/build.gradle
+++ b/scene/view-point-cloud-data-offline/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/scene/view-point-cloud-data-offline/build.gradle
+++ b/scene/view-point-cloud-data-offline/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/scene/view-point-cloud-data-offline/build.gradle
+++ b/scene/view-point-cloud-data-offline/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/scene/view-point-cloud-data-offline/build.gradle
+++ b/scene/view-point-cloud-data-offline/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/scene/view-point-cloud-data-offline/build.gradle
+++ b/scene/view-point-cloud-data-offline/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/search/find-address/build.gradle
+++ b/search/find-address/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/search/find-address/build.gradle
+++ b/search/find-address/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/search/find-address/build.gradle
+++ b/search/find-address/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/search/find-address/build.gradle
+++ b/search/find-address/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/search/find-address/build.gradle
+++ b/search/find-address/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/search/find-place/build.gradle
+++ b/search/find-place/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/search/find-place/build.gradle
+++ b/search/find-place/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/search/find-place/build.gradle
+++ b/search/find-place/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/search/find-place/build.gradle
+++ b/search/find-place/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/search/find-place/build.gradle
+++ b/search/find-place/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/search/offline-geocode/build.gradle
+++ b/search/offline-geocode/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/search/offline-geocode/build.gradle
+++ b/search/offline-geocode/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/search/offline-geocode/build.gradle
+++ b/search/offline-geocode/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/search/offline-geocode/build.gradle
+++ b/search/offline-geocode/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/search/offline-geocode/build.gradle
+++ b/search/offline-geocode/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/search/reverse-geocode-online/build.gradle
+++ b/search/reverse-geocode-online/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/search/reverse-geocode-online/build.gradle
+++ b/search/reverse-geocode-online/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/search/reverse-geocode-online/build.gradle
+++ b/search/reverse-geocode-online/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/search/reverse-geocode-online/build.gradle
+++ b/search/reverse-geocode-online/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/search/reverse-geocode-online/build.gradle
+++ b/search/reverse-geocode-online/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/custom-dictionary-style/build.gradle
+++ b/symbology/custom-dictionary-style/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/custom-dictionary-style/build.gradle
+++ b/symbology/custom-dictionary-style/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/custom-dictionary-style/build.gradle
+++ b/symbology/custom-dictionary-style/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/custom-dictionary-style/build.gradle
+++ b/symbology/custom-dictionary-style/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/symbology/custom-dictionary-style/build.gradle
+++ b/symbology/custom-dictionary-style/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     compile 'org.jooq:joox:1.4.0'

--- a/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
@@ -70,7 +70,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
@@ -68,7 +68,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
-    compile 'org.jooq:joox:1.4.0'
+    implementation 'org.jooq:joox:1.4.0'
 }
 
 task copyNatives(type: Copy) {

--- a/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/picture-marker-symbol/build.gradle
+++ b/symbology/picture-marker-symbol/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/picture-marker-symbol/build.gradle
+++ b/symbology/picture-marker-symbol/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/picture-marker-symbol/build.gradle
+++ b/symbology/picture-marker-symbol/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/picture-marker-symbol/build.gradle
+++ b/symbology/picture-marker-symbol/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/symbology/picture-marker-symbol/build.gradle
+++ b/symbology/picture-marker-symbol/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/read-symbols-from-mobile-style-file/build.gradle
+++ b/symbology/read-symbols-from-mobile-style-file/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/read-symbols-from-mobile-style-file/build.gradle
+++ b/symbology/read-symbols-from-mobile-style-file/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/read-symbols-from-mobile-style-file/build.gradle
+++ b/symbology/read-symbols-from-mobile-style-file/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/read-symbols-from-mobile-style-file/build.gradle
+++ b/symbology/read-symbols-from-mobile-style-file/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/symbology/read-symbols-from-mobile-style-file/build.gradle
+++ b/symbology/read-symbols-from-mobile-style-file/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/simple-fill-symbol/build.gradle
+++ b/symbology/simple-fill-symbol/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/simple-fill-symbol/build.gradle
+++ b/symbology/simple-fill-symbol/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/simple-fill-symbol/build.gradle
+++ b/symbology/simple-fill-symbol/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/simple-fill-symbol/build.gradle
+++ b/symbology/simple-fill-symbol/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/symbology/simple-fill-symbol/build.gradle
+++ b/symbology/simple-fill-symbol/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/simple-line-symbol/build.gradle
+++ b/symbology/simple-line-symbol/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/simple-line-symbol/build.gradle
+++ b/symbology/simple-line-symbol/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/simple-line-symbol/build.gradle
+++ b/symbology/simple-line-symbol/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/simple-line-symbol/build.gradle
+++ b/symbology/simple-line-symbol/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/symbology/simple-line-symbol/build.gradle
+++ b/symbology/simple-line-symbol/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/simple-marker-symbol/build.gradle
+++ b/symbology/simple-marker-symbol/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/simple-marker-symbol/build.gradle
+++ b/symbology/simple-marker-symbol/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/simple-marker-symbol/build.gradle
+++ b/symbology/simple-marker-symbol/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/simple-marker-symbol/build.gradle
+++ b/symbology/simple-marker-symbol/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/symbology/simple-marker-symbol/build.gradle
+++ b/symbology/simple-marker-symbol/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/simple-renderer/build.gradle
+++ b/symbology/simple-renderer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/simple-renderer/build.gradle
+++ b/symbology/simple-renderer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/simple-renderer/build.gradle
+++ b/symbology/simple-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/simple-renderer/build.gradle
+++ b/symbology/simple-renderer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/symbology/simple-renderer/build.gradle
+++ b/symbology/simple-renderer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/symbol-dictionary/build.gradle
+++ b/symbology/symbol-dictionary/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/symbol-dictionary/build.gradle
+++ b/symbology/symbol-dictionary/build.gradle
@@ -70,7 +70,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/symbol-dictionary/build.gradle
+++ b/symbology/symbol-dictionary/build.gradle
@@ -68,7 +68,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/symbol-dictionary/build.gradle
+++ b/symbology/symbol-dictionary/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/symbology/symbol-dictionary/build.gradle
+++ b/symbology/symbol-dictionary/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/symbolize-shapefile/build.gradle
+++ b/symbology/symbolize-shapefile/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/symbolize-shapefile/build.gradle
+++ b/symbology/symbolize-shapefile/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/symbolize-shapefile/build.gradle
+++ b/symbology/symbolize-shapefile/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/symbolize-shapefile/build.gradle
+++ b/symbology/symbolize-shapefile/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/symbology/symbolize-shapefile/build.gradle
+++ b/symbology/symbolize-shapefile/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/symbology/unique-value-renderer/build.gradle
+++ b/symbology/unique-value-renderer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/symbology/unique-value-renderer/build.gradle
+++ b/symbology/unique-value-renderer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/symbology/unique-value-renderer/build.gradle
+++ b/symbology/unique-value-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/symbology/unique-value-renderer/build.gradle
+++ b/symbology/unique-value-renderer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/symbology/unique-value-renderer/build.gradle
+++ b/symbology/unique-value-renderer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/tiled_layers/export-tiles/build.gradle
+++ b/tiled_layers/export-tiles/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/tiled_layers/export-tiles/build.gradle
+++ b/tiled_layers/export-tiles/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/tiled_layers/export-tiles/build.gradle
+++ b/tiled_layers/export-tiles/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/tiled_layers/export-tiles/build.gradle
+++ b/tiled_layers/export-tiles/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/tiled_layers/export-tiles/build.gradle
+++ b/tiled_layers/export-tiles/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/tiled_layers/export-vector-tiles/build.gradle
+++ b/tiled_layers/export-vector-tiles/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/tiled_layers/export-vector-tiles/build.gradle
+++ b/tiled_layers/export-vector-tiles/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/tiled_layers/export-vector-tiles/build.gradle
+++ b/tiled_layers/export-vector-tiles/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/tiled_layers/export-vector-tiles/build.gradle
+++ b/tiled_layers/export-vector-tiles/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/tiled_layers/export-vector-tiles/build.gradle
+++ b/tiled_layers/export-vector-tiles/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/tiled_layers/tile-cache/build.gradle
+++ b/tiled_layers/tile-cache/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/tiled_layers/tile-cache/build.gradle
+++ b/tiled_layers/tile-cache/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/tiled_layers/tile-cache/build.gradle
+++ b/tiled_layers/tile-cache/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/tiled_layers/tile-cache/build.gradle
+++ b/tiled_layers/tile-cache/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/tiled_layers/tile-cache/build.gradle
+++ b/tiled_layers/tile-cache/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/tiled_layers/tiled-layer/build.gradle
+++ b/tiled_layers/tiled-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/tiled_layers/tiled-layer/build.gradle
+++ b/tiled_layers/tiled-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/tiled_layers/tiled-layer/build.gradle
+++ b/tiled_layers/tiled-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/tiled_layers/tiled-layer/build.gradle
+++ b/tiled_layers/tiled-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/tiled_layers/tiled-layer/build.gradle
+++ b/tiled_layers/tiled-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/tiled_layers/vector-tiled-layer-url/build.gradle
+++ b/tiled_layers/vector-tiled-layer-url/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/tiled_layers/vector-tiled-layer-url/build.gradle
+++ b/tiled_layers/vector-tiled-layer-url/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/tiled_layers/vector-tiled-layer-url/build.gradle
+++ b/tiled_layers/vector-tiled-layer-url/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/tiled_layers/vector-tiled-layer-url/build.gradle
+++ b/tiled_layers/vector-tiled-layer-url/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/tiled_layers/vector-tiled-layer-url/build.gradle
+++ b/tiled_layers/vector-tiled-layer-url/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/tiled_layers/web-tiled-layer/build.gradle
+++ b/tiled_layers/web-tiled-layer/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/tiled_layers/web-tiled-layer/build.gradle
+++ b/tiled_layers/web-tiled-layer/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/tiled_layers/web-tiled-layer/build.gradle
+++ b/tiled_layers/web-tiled-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/tiled_layers/web-tiled-layer/build.gradle
+++ b/tiled_layers/web-tiled-layer/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/tiled_layers/web-tiled-layer/build.gradle
+++ b/tiled_layers/web-tiled-layer/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/utility_network/configure-subnetwork-trace/build.gradle
+++ b/utility_network/configure-subnetwork-trace/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/utility_network/configure-subnetwork-trace/build.gradle
+++ b/utility_network/configure-subnetwork-trace/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/utility_network/configure-subnetwork-trace/build.gradle
+++ b/utility_network/configure-subnetwork-trace/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/utility_network/configure-subnetwork-trace/build.gradle
+++ b/utility_network/configure-subnetwork-trace/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/utility_network/configure-subnetwork-trace/build.gradle
+++ b/utility_network/configure-subnetwork-trace/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -64,7 +64,7 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -66,7 +66,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/utility_network/perform-valve-isolation-trace/build.gradle
+++ b/utility_network/perform-valve-isolation-trace/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/utility_network/perform-valve-isolation-trace/build.gradle
+++ b/utility_network/perform-valve-isolation-trace/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/utility_network/perform-valve-isolation-trace/build.gradle
+++ b/utility_network/perform-valve-isolation-trace/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/utility_network/perform-valve-isolation-trace/build.gradle
+++ b/utility_network/perform-valve-isolation-trace/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/utility_network/perform-valve-isolation-trace/build.gradle
+++ b/utility_network/perform-valve-isolation-trace/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/utility_network/trace-a-utility-network/build.gradle
+++ b/utility_network/trace-a-utility-network/build.gradle
@@ -67,7 +67,7 @@ task productionZip(type: Zip) {
         into "samples-data"
     }
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
     baseName = project.name
 }

--- a/utility_network/trace-a-utility-network/build.gradle
+++ b/utility_network/trace-a-utility-network/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'

--- a/utility_network/trace-a-utility-network/build.gradle
+++ b/utility_network/trace-a-utility-network/build.gradle
@@ -69,7 +69,7 @@ task productionZip(type: Zip) {
     from copyNatives
     from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archiveBaseName = project.name
 }
 
 wrapper {

--- a/utility_network/trace-a-utility-network/build.gradle
+++ b/utility_network/trace-a-utility-network/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }

--- a/utility_network/trace-a-utility-network/build.gradle
+++ b/utility_network/trace-a-utility-network/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.bintray.com/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 


### PR DESCRIPTION
This PR makes the following changes to the build.gradle files to remove the features that will be deprecated in Gradle 7.0 :

- replace `id 'org.openjfx.javafxplugin' version '0.0.5`' with `id 'org.openjfx.javafxplugin' version '0.0.8'` 

- replace `compile` with `implementation` under dependencies `compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"`

- replace the `http` with `https` for `maven {url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'}`

- under `task productionZip(type: Zip)` replace `baseName` with `archiveBaseName` and replace `destinationDir` with `destinationDirectory` 

Thanks! 

@JonLavi 
