### PR TITLE
Add jfrog artifactory to Maven repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ArcGIS Runtime Java SDK Samples
 
- [ ![Download](https://api.bintray.com/packages/esri/arcgis/arcgis-java/images/download.svg) ](https://bintray.com/esri/arcgis/arcgis-java/_latestVersion) ![Gradle build](https://github.com/Esri/arcgis-runtime-samples-java/workflows/Java%20CI%20with%20Gradle/badge.svg)
-
 This repo contains a set of sample projects demonstrating how to accomplish various mapping and GIS tasks with the ArcGIS Runtime SDK for Java.
 
 Browse the category directories to explore the samples. Each sample is an individual [Gradle](https://docs.gradle.org/current/userguide/userguide.html) project that can be run standalone. The Gradle buildscripts have tasks for running the application, building a jar, and distributing the app as a zip.

--- a/analysis/analyze-hotspots/build.gradle
+++ b/analysis/analyze-hotspots/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/analysis/distance-measurement-analysis/build.gradle
+++ b/analysis/distance-measurement-analysis/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/analysis/line-of-sight-geoelement/build.gradle
+++ b/analysis/line-of-sight-geoelement/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/analysis/line-of-sight-location/build.gradle
+++ b/analysis/line-of-sight-location/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/analysis/viewshed-camera/build.gradle
+++ b/analysis/viewshed-camera/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/analysis/viewshed-geoelement/build.gradle
+++ b/analysis/viewshed-geoelement/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/analysis/viewshed-geoprocessing/build.gradle
+++ b/analysis/viewshed-geoprocessing/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/analysis/viewshed-location/build.gradle
+++ b/analysis/viewshed-location/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/add-graphics-with-renderer/build.gradle
+++ b/display_information/add-graphics-with-renderer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/add-graphics-with-symbols/build.gradle
+++ b/display_information/add-graphics-with-symbols/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/control-annotation-sublayer-visibility/build.gradle
+++ b/display_information/control-annotation-sublayer-visibility/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/dictionary-renderer-graphics-overlay/build.gradle
+++ b/display_information/dictionary-renderer-graphics-overlay/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/display-annotation/build.gradle
+++ b/display_information/display-annotation/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/display-grid/build.gradle
+++ b/display_information/display-grid/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/format-coordinates/build.gradle
+++ b/display_information/format-coordinates/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/identify-graphics/build.gradle
+++ b/display_information/identify-graphics/build.gradle
@@ -18,7 +18,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/show-callout/build.gradle
+++ b/display_information/show-callout/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/show-labels-on-layer/build.gradle
+++ b/display_information/show-labels-on-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/sketch-on-map/build.gradle
+++ b/display_information/sketch-on-map/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/display_information/update-graphics/build.gradle
+++ b/display_information/update-graphics/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/editing/add-features/build.gradle
+++ b/editing/add-features/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/editing/delete-features/build.gradle
+++ b/editing/delete-features/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/editing/edit-and-sync-features/build.gradle
+++ b/editing/edit-and-sync-features/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/editing/edit-features-with-feature-linked-annotation/build.gradle
+++ b/editing/edit-features-with-feature-linked-annotation/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/editing/edit-with-branch-versioning/build.gradle
+++ b/editing/edit-with-branch-versioning/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/editing/update-attributes/build.gradle
+++ b/editing/update-attributes/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/editing/update-geometries/build.gradle
+++ b/editing/update-geometries/build.gradle
@@ -18,7 +18,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/change-feature-layer-renderer/build.gradle
+++ b/feature_layers/change-feature-layer-renderer/build.gradle
@@ -18,7 +18,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-collection-layer-from-portal/build.gradle
+++ b/feature_layers/feature-collection-layer-from-portal/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-collection-layer-query/build.gradle
+++ b/feature_layers/feature-collection-layer-query/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-collection-layer/build.gradle
+++ b/feature_layers/feature-collection-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-layer-definition-expression/build.gradle
+++ b/feature_layers/feature-layer-definition-expression/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-layer-dictionary-renderer/build.gradle
+++ b/feature_layers/feature-layer-dictionary-renderer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-layer-extrusion/build.gradle
+++ b/feature_layers/feature-layer-extrusion/build.gradle
@@ -18,7 +18,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-layer-feature-service/build.gradle
+++ b/feature_layers/feature-layer-feature-service/build.gradle
@@ -18,7 +18,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-layer-geodatabase/build.gradle
+++ b/feature_layers/feature-layer-geodatabase/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-layer-geopackage/build.gradle
+++ b/feature_layers/feature-layer-geopackage/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-layer-query/build.gradle
+++ b/feature_layers/feature-layer-query/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-layer-rendering-mode-map/build.gradle
+++ b/feature_layers/feature-layer-rendering-mode-map/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-layer-selection/build.gradle
+++ b/feature_layers/feature-layer-selection/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/feature-layer-shapefile/build.gradle
+++ b/feature_layers/feature-layer-shapefile/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/generate-geodatabase/build.gradle
+++ b/feature_layers/generate-geodatabase/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/list-related-features/build.gradle
+++ b/feature_layers/list-related-features/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/service-feature-table-cache/build.gradle
+++ b/feature_layers/service-feature-table-cache/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/service-feature-table-manual-cache/build.gradle
+++ b/feature_layers/service-feature-table-manual-cache/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/service-feature-table-no-cache/build.gradle
+++ b/feature_layers/service-feature-table-no-cache/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/statistical-query-group-and-sort/build.gradle
+++ b/feature_layers/statistical-query-group-and-sort/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/statistical-query/build.gradle
+++ b/feature_layers/statistical-query/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/feature_layers/time-based-query/build.gradle
+++ b/feature_layers/time-based-query/build.gradle
@@ -18,7 +18,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/buffer-list/build.gradle
+++ b/geometry/buffer-list/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/buffer/build.gradle
+++ b/geometry/buffer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/clip-geometry/build.gradle
+++ b/geometry/clip-geometry/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/convex-hull-list/build.gradle
+++ b/geometry/convex-hull-list/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/convex-hull/build.gradle
+++ b/geometry/convex-hull/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/create-geometries/build.gradle
+++ b/geometry/create-geometries/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/cut-geometry/build.gradle
+++ b/geometry/cut-geometry/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/densify-and-generalize/build.gradle
+++ b/geometry/densify-and-generalize/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/geodesic-operations/build.gradle
+++ b/geometry/geodesic-operations/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/geodesic-sector-and-ellipse/build.gradle
+++ b/geometry/geodesic-sector-and-ellipse/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/geometry-engine-simplify/build.gradle
+++ b/geometry/geometry-engine-simplify/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/list-transformations-by-suitability/build.gradle
+++ b/geometry/list-transformations-by-suitability/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/nearest-vertex/build.gradle
+++ b/geometry/nearest-vertex/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/project/build.gradle
+++ b/geometry/project/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/spatial-operations/build.gradle
+++ b/geometry/spatial-operations/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/geometry/spatial-relationships/build.gradle
+++ b/geometry/spatial-relationships/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/group_layers/group-layers/build.gradle
+++ b/group_layers/group-layers/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/hydrography/add-enc-exchange-set/build.gradle
+++ b/hydrography/add-enc-exchange-set/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/image_layers/change-sublayer-renderer/build.gradle
+++ b/image_layers/change-sublayer-renderer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/image_layers/map-image-layer-sublayer-visibility/build.gradle
+++ b/image_layers/map-image-layer-sublayer-visibility/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/image_layers/map-image-layer-tables/build.gradle
+++ b/image_layers/map-image-layer-tables/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/image_layers/map-image-layer/build.gradle
+++ b/image_layers/map-image-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/image_layers/query-map-image-sublayer/build.gradle
+++ b/image_layers/query-map-image-sublayer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/kml/create-and-save-kml-file/build.gradle
+++ b/kml/create-and-save-kml-file/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/kml/display-kml-network-links/build.gradle
+++ b/kml/display-kml-network-links/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/kml/display-kml/build.gradle
+++ b/kml/display-kml/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/kml/edit-kml-ground-overlay/build.gradle
+++ b/kml/edit-kml-ground-overlay/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/kml/identify-kml-features/build.gradle
+++ b/kml/identify-kml-features/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/kml/list-kml-contents/build.gradle
+++ b/kml/list-kml-contents/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/kml/play-a-kml-tour/build.gradle
+++ b/kml/play-a-kml-tour/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/local_server/local-server-feature-layer/build.gradle
+++ b/local_server/local-server-feature-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/local_server/local-server-geoprocessing/build.gradle
+++ b/local_server/local-server-geoprocessing/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/local_server/local-server-map-image-layer/build.gradle
+++ b/local_server/local-server-map-image-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/local_server/local-server-services/build.gradle
+++ b/local_server/local-server-services/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/download-preplanned-map/build.gradle
+++ b/map/download-preplanned-map/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/generate-offline-map-overrides/build.gradle
+++ b/map/generate-offline-map-overrides/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/generate-offline-map-with-local-basemap/build.gradle
+++ b/map/generate-offline-map-with-local-basemap/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/generate-offline-map/build.gradle
+++ b/map/generate-offline-map/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/honor-mobile-map-package-expiration-date/build.gradle
+++ b/map/honor-mobile-map-package-expiration-date/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/manage-bookmarks/build.gradle
+++ b/map/manage-bookmarks/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/manage-operational-layers/build.gradle
+++ b/map/manage-operational-layers/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/map-initial-extent/build.gradle
+++ b/map/map-initial-extent/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/map-reference-scale/build.gradle
+++ b/map/map-reference-scale/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/map-spatial-reference/build.gradle
+++ b/map/map-spatial-reference/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/min-max-scale/build.gradle
+++ b/map/min-max-scale/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/mobile-map-search-and-route/build.gradle
+++ b/map/mobile-map-search-and-route/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/open-map-url/build.gradle
+++ b/map/open-map-url/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/open-mobile-map-package/build.gradle
+++ b/map/open-mobile-map-package/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/read-geopackage/build.gradle
+++ b/map/read-geopackage/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map/set-initial-map-location/build.gradle
+++ b/map/set-initial-map-location/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map_view/change-viewpoint/build.gradle
+++ b/map_view/change-viewpoint/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map_view/display-drawing-status/build.gradle
+++ b/map_view/display-drawing-status/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map_view/display-layer-view-state/build.gradle
+++ b/map_view/display-layer-view-state/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map_view/identify-layers/build.gradle
+++ b/map_view/identify-layers/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/network_analysis/closest-facility-static/build.gradle
+++ b/network_analysis/closest-facility-static/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/network_analysis/closest-facility/build.gradle
+++ b/network_analysis/closest-facility/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/network_analysis/find-route/build.gradle
+++ b/network_analysis/find-route/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
+++ b/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/network_analysis/offline-routing/build.gradle
+++ b/network_analysis/offline-routing/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/network_analysis/routing-around-barriers/build.gradle
+++ b/network_analysis/routing-around-barriers/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/network_analysis/service-area-task/build.gradle
+++ b/network_analysis/service-area-task/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/ogc/browse-wfs-layers/build.gradle
+++ b/ogc/browse-wfs-layers/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/ogc/display-wfs-layer/build.gradle
+++ b/ogc/display-wfs-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/ogc/open-street-map-layer/build.gradle
+++ b/ogc/open-street-map-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/ogc/style-wms-layer/build.gradle
+++ b/ogc/style-wms-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/ogc/wfs-xml-query/build.gradle
+++ b/ogc/wfs-xml-query/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/ogc/wms-layer-url/build.gradle
+++ b/ogc/wms-layer-url/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/ogc/wmts-layer/build.gradle
+++ b/ogc/wmts-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/portal/integrated-windows-authentication/build.gradle
+++ b/portal/integrated-windows-authentication/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/portal/oauth/build.gradle
+++ b/portal/oauth/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/portal/token-authentication/build.gradle
+++ b/portal/token-authentication/build.gradle
@@ -18,7 +18,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/portal/webmap-keyword-search/build.gradle
+++ b/portal/webmap-keyword-search/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/blend-renderer/build.gradle
+++ b/raster/blend-renderer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/colormap-renderer/build.gradle
+++ b/raster/colormap-renderer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/hillshade-renderer/build.gradle
+++ b/raster/hillshade-renderer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/raster-function/build.gradle
+++ b/raster/raster-function/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/raster-layer-file/build.gradle
+++ b/raster/raster-layer-file/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/raster-layer-geopackage/build.gradle
+++ b/raster/raster-layer-geopackage/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/raster-layer-url/build.gradle
+++ b/raster/raster-layer-url/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/raster-rendering-rule/build.gradle
+++ b/raster/raster-rendering-rule/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/rgb-renderer/build.gradle
+++ b/raster/rgb-renderer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/raster/stretch-renderer/build.gradle
+++ b/raster/stretch-renderer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/add-a-point-scene-layer/build.gradle
+++ b/scene/add-a-point-scene-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/add-an-integrated-mesh-layer/build.gradle
+++ b/scene/add-an-integrated-mesh-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/animate-3d-graphic/build.gradle
+++ b/scene/animate-3d-graphic/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/animate-images-with-image-overlay/build.gradle
+++ b/scene/animate-images-with-image-overlay/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/change-atmosphere-effect/build.gradle
+++ b/scene/change-atmosphere-effect/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/choose-camera-controller/build.gradle
+++ b/scene/choose-camera-controller/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/create-terrain-surface-from-local-raster/build.gradle
+++ b/scene/create-terrain-surface-from-local-raster/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/create-terrain-surface-from-local-tile-package/build.gradle
+++ b/scene/create-terrain-surface-from-local-tile-package/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/display-scene/build.gradle
+++ b/scene/display-scene/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/distance-composite-symbol/build.gradle
+++ b/scene/distance-composite-symbol/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/extrude-graphics/build.gradle
+++ b/scene/extrude-graphics/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/feature-layer-rendering-mode-scene/build.gradle
+++ b/scene/feature-layer-rendering-mode-scene/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/get-elevation-at-a-point/build.gradle
+++ b/scene/get-elevation-at-a-point/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/open-mobile-scene-package/build.gradle
+++ b/scene/open-mobile-scene-package/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/open-scene-portal-item/build.gradle
+++ b/scene/open-scene-portal-item/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/orbit-the-camera-around-an-object/build.gradle
+++ b/scene/orbit-the-camera-around-an-object/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/realistic-lighting-and-shadows/build.gradle
+++ b/scene/realistic-lighting-and-shadows/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/scene-layer-selection/build.gradle
+++ b/scene/scene-layer-selection/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/scene-layer/build.gradle
+++ b/scene/scene-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/scene-properties-expressions/build.gradle
+++ b/scene/scene-properties-expressions/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/surface-placement/build.gradle
+++ b/scene/surface-placement/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/symbols/build.gradle
+++ b/scene/symbols/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/sync-map-and-scene-viewpoints/build.gradle
+++ b/scene/sync-map-and-scene-viewpoints/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/terrain-exaggeration/build.gradle
+++ b/scene/terrain-exaggeration/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/view-content-beneath-terrain-surface/build.gradle
+++ b/scene/view-content-beneath-terrain-surface/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/scene/view-point-cloud-data-offline/build.gradle
+++ b/scene/view-point-cloud-data-offline/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/search/find-address/build.gradle
+++ b/search/find-address/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/search/find-place/build.gradle
+++ b/search/find-place/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/search/offline-geocode/build.gradle
+++ b/search/offline-geocode/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/search/reverse-geocode-online/build.gradle
+++ b/search/reverse-geocode-online/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/custom-dictionary-style/build.gradle
+++ b/symbology/custom-dictionary-style/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/picture-marker-symbol/build.gradle
+++ b/symbology/picture-marker-symbol/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/read-symbols-from-mobile-style-file/build.gradle
+++ b/symbology/read-symbols-from-mobile-style-file/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/simple-fill-symbol/build.gradle
+++ b/symbology/simple-fill-symbol/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/simple-line-symbol/build.gradle
+++ b/symbology/simple-line-symbol/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/simple-marker-symbol/build.gradle
+++ b/symbology/simple-marker-symbol/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/simple-renderer/build.gradle
+++ b/symbology/simple-renderer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/symbol-dictionary/build.gradle
+++ b/symbology/symbol-dictionary/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/symbolize-shapefile/build.gradle
+++ b/symbology/symbolize-shapefile/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/symbology/unique-value-renderer/build.gradle
+++ b/symbology/unique-value-renderer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/tiled_layers/export-tiles/build.gradle
+++ b/tiled_layers/export-tiles/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/tiled_layers/export-vector-tiles/build.gradle
+++ b/tiled_layers/export-vector-tiles/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/tiled_layers/tile-cache/build.gradle
+++ b/tiled_layers/tile-cache/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/tiled_layers/tiled-layer/build.gradle
+++ b/tiled_layers/tiled-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/tiled_layers/vector-tiled-layer-url/build.gradle
+++ b/tiled_layers/vector-tiled-layer-url/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/tiled_layers/web-tiled-layer/build.gradle
+++ b/tiled_layers/web-tiled-layer/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/utility_network/configure-subnetwork-trace/build.gradle
+++ b/utility_network/configure-subnetwork-trace/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/utility_network/perform-valve-isolation-trace/build.gradle
+++ b/utility_network/perform-valve-isolation-trace/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/utility_network/trace-a-utility-network/build.gradle
+++ b/utility_network/trace-a-utility-network/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'


### PR DESCRIPTION
This PR removes the references to bintray and adds the url to the jfrog artifactory.

@jenmerritt and I have checked a few samples, including samples that use the toolkit. 