### PR TITLE
Add jfrog artifactory to Maven repository to samples in dev branch

### DIFF
--- a/map_view/display-device-location-with-autopan-modes/build.gradle
+++ b/map_view/display-device-location-with-autopan-modes/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'

--- a/map_view/show-location-history/build.gradle
+++ b/map_view/show-location-history/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
-        url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
     }
 }
 

--- a/map_view/show-location-history/build.gradle
+++ b/map_view/show-location-history/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 group = 'com.esri.samples'
@@ -31,8 +31,8 @@ configurations {
 }
 
 dependencies {
-    compile 'commons-io:commons-io:2.4'
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation 'commons-io:commons-io:2.4'
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }
@@ -65,9 +65,9 @@ jar {
 task productionZip(type: Zip) {
     group = 'distribution'
     from copyNatives
-    from jar.destinationDir
+    from jar.destinationDirectory
     into (project.name)
-    baseName = project.name
+    archivesBaseName = project.name
 }
 
 wrapper {

--- a/map_view/show-location-history/build.gradle
+++ b/map_view/show-location-history/build.gradle
@@ -19,7 +19,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
     jcenter()
     maven {
-        url 'https://esri.bintray.com/arcgis'
+        url 'https://esri.jfrog.io/artifactory/arcgis'
     }
     maven {
         url 'http://olympus.esri.com/artifactory/arcgisruntime-repo'


### PR DESCRIPTION
This PR removes the references to bintray and adds the url to the jfrog artifactory to the Display Device Location with Autopan Modes sample and the Show Location History sample. 

The deprecated Gradle features have also been removed from the Show Location History sample. 
