### PR TITLE
Remove alert from Update Graphics sample

### DIFF
--- a/display_information/update-graphics/src/main/java/com/esri/samples/update_graphics/UpdateGraphicsSample.java
+++ b/display_information/update-graphics/src/main/java/com/esri/samples/update_graphics/UpdateGraphicsSample.java
@@ -193,7 +193,7 @@ public class UpdateGraphicsSample extends Application {
                     Point mapPoint = mapView.screenToLocation(mapViewPoint);
                     // update the location of the graphic to the dragged location
                     identifiedGraphic.setGeometry(mapPoint);
-                  } else new Alert(Alert.AlertType.ERROR, "Error selecting graphic").show();
+                  }
                 });
               } else {
                 disableUI(true);


### PR DESCRIPTION
This PR removes the alert that is generated when the map view is dragged and a feature is not selected, noticed by @TADraeseke and @jenmerritt during verification. 

Thanks! 

@Rachael-E 

Checklist:
- [x] Set target branch to master (current release) or dev (next release)
- [x] Request a reviewer
- [x] Assign a reviewer
- [x] Tag reviewer in comment
