### PR TITLE
Fix Hbox width in Show location history sample

### DIFF
--- a/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java
+++ b/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java
@@ -194,7 +194,7 @@ public class ShowLocationHistorySample extends Application {
       controlsHBox.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(0,0,0,0.3)"), CornerRadii.EMPTY, Insets.EMPTY)));
       controlsHBox.setPadding(new Insets(10.0));
       controlsHBox.setAlignment(Pos.CENTER);
-      controlsHBox.setMaxSize(190, 50);
+      controlsHBox.setMaxSize(210, 50);
       controlsHBox.getStyleClass().add("panel-region");
       controlsHBox.getChildren().addAll(trackingLabel, trackingButton);
 

--- a/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java
+++ b/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java
@@ -194,7 +194,7 @@ public class ShowLocationHistorySample extends Application {
       controlsHBox.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(0,0,0,0.3)"), CornerRadii.EMPTY, Insets.EMPTY)));
       controlsHBox.setPadding(new Insets(10.0));
       controlsHBox.setAlignment(Pos.CENTER);
-      controlsHBox.setMaxSize(180, 50);
+      controlsHBox.setMaxSize(190, 50);
       controlsHBox.getStyleClass().add("panel-region");
       controlsHBox.getChildren().addAll(trackingLabel, trackingButton);
 


### PR DESCRIPTION
This PR changes a bug noticed during verification for Linux. The `Hbox` width has increased, as the label and button text was truncated when the button was clicked

I've run the sample from the IDE on Linux and the issue has been resolved, so hopefully it is fixed for the sample viewer.

@JonLavi 