### PR TITLE
Update Display utility associations and Identify raster cell samples gradle versions

### DIFF
--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -73,5 +73,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '5.0'
+    gradleVersion = '6.5.1'
 }

--- a/raster/identify-raster-cell/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/identify-raster-cell/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.1"
+    version = "11.0.2"
     modules = [ 'javafx.controls' ]
 }
 
@@ -70,5 +70,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '5.0'
+    gradleVersion = '6.5.1'
 }

--- a/utility_network/display-utility-associations/gradle/wrapper/gradle-wrapper.properties
+++ b/utility_network/display-utility-associations/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Whilst running through all the samples making the basemap changes the Display utility associations and Identify raster cell samples were failing to run. After investigating this morning these 2 samples were merged just after the Gradle versions were all updated and still had Gradle version 5.0. They seemed to run fine until we removed the deprecated Gradle features (reverting that commit they ran successfully). So seems to just relate to the Gradle version.

In this PR I've just updated the Gradle version in each sample (from `5.0` to `6.5.1`), and also the JavaFX version in Display utility associations (from `11.0.1` to `11.0.2`)

Also did a search and the rest of the gradle versions / javafx versions all seem to be up to date and we've not had any other problems running other samples. As a sidenote, the Sample Viewer is building before / after these changes.