### PR TITLE
Fix to Take Screenshot Sample

### DIFF
--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -48,7 +48,7 @@ task copyNatives(type: Copy) {
 
 run {
     dependsOn copyNatives
-    mainClassName = 'com.esri.samples.take_screen_shot.TakeScreenShotLauncher'
+    mainClassName = 'com.esri.samples.take_screenshot.TakeScreenshotLauncher'
 }
 
 jar {


### PR DESCRIPTION
Another small fix spotted in testing with the Basemap changes. Take Screenshot isn't running from the IDE due to the Launcher class being incorrectly referenced in the `build.gradle` file. This PR amends it.