### PR TITLE
New Basemaps: Editing Category

### DIFF
--- a/editing/add-features/build.gradle
+++ b/editing/add-features/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/editing/add-features/src/main/java/com/esri/samples/add_features/AddFeaturesSample.java
+++ b/editing/add-features/src/main/java/com/esri/samples/add_features/AddFeaturesSample.java
@@ -74,10 +74,13 @@ public class AddFeaturesSample extends Application {
 
       // create a map with streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
-      map.setInitialViewpoint(new Viewpoint(40, -95, 40000000));
 
-      // create a view for this ArcGISMap
+      // create a map view and set its map
       mapView = new MapView();
+      mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(40, -95, 40000000));
 
       // create service feature table from URL
       featureTable = new ServiceFeatureTable(SERVICE_LAYER_URL);
@@ -105,9 +108,6 @@ public class AddFeaturesSample extends Application {
           addFeature(normalizedMapPoint, featureTable);
         }
       });
-
-      // set ArcGISMap to be displayed in map view
-      mapView.setMap(map);
 
       // add the map view to stack pane
       stackPane.getChildren().addAll(mapView);

--- a/editing/add-features/src/main/java/com/esri/samples/add_features/AddFeaturesSample.java
+++ b/editing/add-features/src/main/java/com/esri/samples/add_features/AddFeaturesSample.java
@@ -72,7 +72,7 @@ public class AddFeaturesSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with streets basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // create a map view and set its map

--- a/editing/add-features/src/main/java/com/esri/samples/add_features/AddFeaturesSample.java
+++ b/editing/add-features/src/main/java/com/esri/samples/add_features/AddFeaturesSample.java
@@ -31,6 +31,7 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.Feature;
 import com.esri.arcgisruntime.data.FeatureEditResult;
@@ -39,7 +40,8 @@ import com.esri.arcgisruntime.geometry.GeometryEngine;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class AddFeaturesSample extends Application {
@@ -66,8 +68,13 @@ public class AddFeaturesSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with streets basemap
-      ArcGISMap map = new ArcGISMap(Basemap.Type.STREETS, 40, -95, 4);
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with streets basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+      map.setInitialViewpoint(new Viewpoint(40, -95, 40000000));
 
       // create a view for this ArcGISMap
       mapView = new MapView();

--- a/editing/add-features/src/main/java/com/esri/samples/add_features/AddFeaturesSample.java
+++ b/editing/add-features/src/main/java/com/esri/samples/add_features/AddFeaturesSample.java
@@ -75,12 +75,12 @@ public class AddFeaturesSample extends Application {
       // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(40, -95, 40000000));
+      mapView.setViewpoint(new Viewpoint(40, -95, 36978595));
 
       // create service feature table from URL
       featureTable = new ServiceFeatureTable(SERVICE_LAYER_URL);

--- a/editing/delete-features/build.gradle
+++ b/editing/delete-features/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/editing/delete-features/src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java
+++ b/editing/delete-features/src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java
@@ -96,7 +96,7 @@ public class DeleteFeaturesSample extends Application {
         });
       });
 
-      // create a map with streets basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // create a map view and set its map

--- a/editing/delete-features/src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java
+++ b/editing/delete-features/src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java
@@ -33,6 +33,7 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.Feature;
 import com.esri.arcgisruntime.data.FeatureEditResult;
@@ -40,7 +41,8 @@ import com.esri.arcgisruntime.data.FeatureQueryResult;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -70,6 +72,10 @@ public class DeleteFeaturesSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a delete button and fill the width of the screen
       deleteButton = new Button("Delete");
       deleteButton.setMaxWidth(130);
@@ -90,8 +96,9 @@ public class DeleteFeaturesSample extends Application {
         });
       });
 
-      // create a map with streets basemap
-      ArcGISMap map = new ArcGISMap(Basemap.Type.STREETS, 40, -95, 4);
+      // create a map with streets basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+      map.setInitialViewpoint(new Viewpoint(40, -95, 40000000));
 
       // create a view for this ArcGISMap
       mapView = new MapView();

--- a/editing/delete-features/src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java
+++ b/editing/delete-features/src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java
@@ -98,10 +98,13 @@ public class DeleteFeaturesSample extends Application {
 
       // create a map with streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
-      map.setInitialViewpoint(new Viewpoint(40, -95, 40000000));
 
-      // create a view for this ArcGISMap
+      // create a map view and set its map
       mapView = new MapView();
+      mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(40, -95, 40000000));
 
       // create service feature table from URL
       featureTable = new ServiceFeatureTable(FEATURE_LAYER_URL);
@@ -136,9 +139,6 @@ public class DeleteFeaturesSample extends Application {
           });
         }
       });
-
-      // set ArcGISMap to be displayed in map view
-      mapView.setMap(map);
 
       // add the map view and control box to stack pane
       stackPane.getChildren().addAll(mapView, deleteButton);

--- a/editing/delete-features/src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java
+++ b/editing/delete-features/src/main/java/com/esri/samples/delete_features/DeleteFeaturesSample.java
@@ -99,12 +99,12 @@ public class DeleteFeaturesSample extends Application {
       // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(40, -95, 40000000));
+      mapView.setViewpoint(new Viewpoint(40, -95, 36978595));
 
       // create service feature table from URL
       featureTable = new ServiceFeatureTable(FEATURE_LAYER_URL);

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
+++ b/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
@@ -119,7 +119,7 @@ public class EditFeatureAttachmentsSample extends Application {
       // add controls to the panel
       controlsVBox.getChildren().addAll(addAttachmentButton, deleteAttachmentButton, attachmentsLabel, attachmentList);
 
-      // create a map with streets basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // create a map view and set its map

--- a/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
+++ b/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
@@ -119,13 +119,15 @@ public class EditFeatureAttachmentsSample extends Application {
       // add controls to the panel
       controlsVBox.getChildren().addAll(addAttachmentButton, deleteAttachmentButton, attachmentsLabel, attachmentList);
 
-      // create a map with streets basemap style and an initial viewpoint
+      // create a map with streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
-      map.setInitialViewpoint(new Viewpoint(40, -95, 40000000));
 
       // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set the viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(40, -95, 40000000));
 
       // set selection color
       mapView.getSelectionProperties().setColor(0xff0000ff);

--- a/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
+++ b/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
@@ -119,12 +119,12 @@ public class EditFeatureAttachmentsSample extends Application {
       // add controls to the panel
       controlsVBox.getChildren().addAll(addAttachmentButton, deleteAttachmentButton, attachmentsLabel, attachmentList);
 
-      // create a map view
-      mapView = new MapView();
-
-      // create a map with streets basemap style and set it to the map view
+      // create a map with streets basemap style and an initial viewpoint
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
       map.setInitialViewpoint(new Viewpoint(40, -95, 40000000));
+
+      // create a map view and set its map
+      mapView = new MapView();
       mapView.setMap(map);
 
       // set selection color

--- a/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
+++ b/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
@@ -39,6 +39,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.ArcGISFeature;
 import com.esri.arcgisruntime.data.Attachment;
@@ -47,8 +48,9 @@ import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.GeoElement;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -77,6 +79,10 @@ public class EditFeatureAttachmentsSample extends Application {
       stage.setHeight(700);
       stage.setScene(scene);
       stage.show();
+
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
       // create a control panel
       VBox controlsVBox = new VBox(6);
@@ -116,8 +122,9 @@ public class EditFeatureAttachmentsSample extends Application {
       // create a map view
       mapView = new MapView();
 
-      // create a map with streets basemap and set it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.Type.STREETS, 40, -95, 4);
+      // create a map with streets basemap style and set it to the map view
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+      map.setInitialViewpoint(new Viewpoint(40, -95, 40000000));
       mapView.setMap(map);
 
       // set selection color

--- a/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
+++ b/editing/edit-feature-attachments/src/main/java/com/esri/samples/edit_feature_attachments/EditFeatureAttachmentsSample.java
@@ -122,12 +122,12 @@ public class EditFeatureAttachmentsSample extends Application {
       // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
-      // set the viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(40, -95, 40000000));
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(40, -95, 36978595));
 
       // set selection color
       mapView.getSelectionProperties().setColor(0xff0000ff);

--- a/editing/edit-features-with-feature-linked-annotation/build.gradle
+++ b/editing/edit-features-with-feature-linked-annotation/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
+++ b/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
@@ -30,6 +30,7 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.Feature;
 import com.esri.arcgisruntime.data.Geodatabase;
@@ -44,7 +45,8 @@ import com.esri.arcgisruntime.layers.AnnotationLayer;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -69,8 +71,13 @@ public class EditFeaturesWithFeatureLinkedAnnotationSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create the map with a light gray canvas basemap centered on Loudoun, Virginia
-      ArcGISMap map = new ArcGISMap(Basemap.Type.LIGHT_GRAY_CANVAS_VECTOR, 39.0204, -77.4159, 18);
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create the map with a light gray canvas basemap style centered on Loudoun, Virginia
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
+      map.setInitialViewpoint(new Viewpoint(39.0204, -77.4159, 2000));
 
       // create a map view and set its map
       mapView = new MapView();

--- a/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
+++ b/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
@@ -75,7 +75,7 @@ public class EditFeaturesWithFeatureLinkedAnnotationSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create the map with a light gray canvas basemap style centered on Loudoun, Virginia
+      // create the map with a light gray basemap style centered on Loudoun, Virginia
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
       map.setInitialViewpoint(new Viewpoint(39.0204, -77.4159, 2000));
 

--- a/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
+++ b/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
@@ -75,15 +75,15 @@ public class EditFeaturesWithFeatureLinkedAnnotationSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the light gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view centered on Loudoun, Virginia
-      mapView.setViewpoint(new Viewpoint(39.0204, -77.4159, 2000));
+      mapView.setViewpoint(new Viewpoint(39.0204, -77.4159, 2257));
 
       // add the map view to stack pane
       stackPane.getChildren().addAll(mapView);

--- a/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
+++ b/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
@@ -75,13 +75,15 @@ public class EditFeaturesWithFeatureLinkedAnnotationSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create the map with a light gray basemap style centered on Loudoun, Virginia
+      // create the map with a light gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
-      map.setInitialViewpoint(new Viewpoint(39.0204, -77.4159, 2000));
 
       // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view centered on Loudoun, Virginia
+      mapView.setViewpoint(new Viewpoint(39.0204, -77.4159, 2000));
 
       // add the map view to stack pane
       stackPane.getChildren().addAll(mapView);

--- a/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
+++ b/editing/edit-features-with-feature-linked-annotation/src/main/java/com.esri.samples.edit_features_with_feature_linked_annotation/EditFeaturesWithFeatureLinkedAnnotationSample.java
@@ -75,7 +75,7 @@ public class EditFeaturesWithFeatureLinkedAnnotationSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create the map with a light gray basemap style
+      // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
 
       // create a map view and set its map

--- a/editing/edit-with-branch-versioning/build.gradle
+++ b/editing/edit-with-branch-versioning/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/editing/edit-with-branch-versioning/src/main/java/com/esri/samples/edit_with_branch_versioning/EditWithBranchVersioningController.java
+++ b/editing/edit-with-branch-versioning/src/main/java/com/esri/samples/edit_with_branch_versioning/EditWithBranchVersioningController.java
@@ -78,8 +78,10 @@ public class EditWithBranchVersioningController {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with the streets vector basemap style and set it to the map view
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+
+      // set the map to the map view
       mapView.setMap(map);
 
       // add the version access types to the access type combo box

--- a/editing/edit-with-branch-versioning/src/main/java/com/esri/samples/edit_with_branch_versioning/EditWithBranchVersioningController.java
+++ b/editing/edit-with-branch-versioning/src/main/java/com/esri/samples/edit_with_branch_versioning/EditWithBranchVersioningController.java
@@ -30,6 +30,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.VBox;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.arcgisservices.ServiceVersionInfo;
 import com.esri.arcgisruntime.arcgisservices.ServiceVersionParameters;
 import com.esri.arcgisruntime.arcgisservices.VersionAccess;
@@ -42,7 +43,7 @@ import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.GeoElement;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
@@ -73,8 +74,12 @@ public class EditWithBranchVersioningController {
   public void initialize() {
 
     try {
-      // create a map with the streets vector basemap and set it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.createStreetsVector());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with the streets vector basemap style and set it to the map view
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
       mapView.setMap(map);
 
       // add the version access types to the access type combo box

--- a/editing/update-attributes/build.gradle
+++ b/editing/update-attributes/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
+++ b/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
@@ -120,13 +120,15 @@ public class UpdateAttributesSample extends Application {
       // add damage type label and comboBox to the control panel
       controlsVBox.getChildren().addAll(typeDamageLabel, comboBox);
 
-      // create a map with streets basemap style and an initial viewpoint
+      // create a map with streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
-      map.setInitialViewpoint(new Viewpoint(40, -95,40000000));
 
       // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(40, -95,40000000));
 
       // create service feature table from URL
       featureTable = new ServiceFeatureTable("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");

--- a/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
+++ b/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
@@ -123,12 +123,12 @@ public class UpdateAttributesSample extends Application {
       // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(40, -95,40000000));
+      mapView.setViewpoint(new Viewpoint(40, -95,36978595));
 
       // create service feature table from URL
       featureTable = new ServiceFeatureTable("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");

--- a/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
+++ b/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
@@ -39,6 +39,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.ArcGISFeature;
 import com.esri.arcgisruntime.data.FeatureEditResult;
@@ -46,8 +47,9 @@ import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.GeoElement;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -74,6 +76,10 @@ public class UpdateAttributesSample extends Application {
       stage.setWidth(800);
       stage.setScene(scene);
       stage.show();
+
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
       // create a control panel
       VBox controlsVBox = new VBox(6);
@@ -117,8 +123,9 @@ public class UpdateAttributesSample extends Application {
       // create a map view
       mapView = new MapView();
 
-      // create a map with streets basemap and set it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.Type.STREETS, 40, -95, 4);
+      // create a map with streets basemap style and set it to the map view
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+      map.setInitialViewpoint(new Viewpoint(40, -95,40000000));
       mapView.setMap(map);
 
       // create service feature table from URL

--- a/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
+++ b/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
@@ -120,7 +120,7 @@ public class UpdateAttributesSample extends Application {
       // add damage type label and comboBox to the control panel
       controlsVBox.getChildren().addAll(typeDamageLabel, comboBox);
 
-      // create a map with streets basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // create a map view and set its map

--- a/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
+++ b/editing/update-attributes/src/main/java/com/esri/samples/update_attributes/UpdateAttributesSample.java
@@ -120,12 +120,12 @@ public class UpdateAttributesSample extends Application {
       // add damage type label and comboBox to the control panel
       controlsVBox.getChildren().addAll(typeDamageLabel, comboBox);
 
-      // create a map view
-      mapView = new MapView();
-
-      // create a map with streets basemap style and set it to the map view
+      // create a map with streets basemap style and an initial viewpoint
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
       map.setInitialViewpoint(new Viewpoint(40, -95,40000000));
+
+      // create a map view and set its map
+      mapView = new MapView();
       mapView.setMap(map);
 
       // create service feature table from URL

--- a/editing/update-geometries/build.gradle
+++ b/editing/update-geometries/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 javafx {
     version = "11.0.2"

--- a/editing/update-geometries/src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java
+++ b/editing/update-geometries/src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java
@@ -75,7 +75,7 @@ public class UpdateGeometriesSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with streets basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // create a map view and set its map

--- a/editing/update-geometries/src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java
+++ b/editing/update-geometries/src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java
@@ -78,12 +78,12 @@ public class UpdateGeometriesSample extends Application {
       // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(40, -95, 40000000));
+      mapView.setViewpoint(new Viewpoint(40, -95, 36978595));
 
       // add features from a feature service
       featureTable = new ServiceFeatureTable(FEATURE_LAYER_URL);

--- a/editing/update-geometries/src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java
+++ b/editing/update-geometries/src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java
@@ -75,13 +75,15 @@ public class UpdateGeometriesSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with streets basemap style and set the initial viewpoint
+      // create a map with streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
-      map.setInitialViewpoint(new Viewpoint(40, -95, 40000000));
 
       // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(40, -95, 40000000));
 
       // add features from a feature service
       featureTable = new ServiceFeatureTable(FEATURE_LAYER_URL);

--- a/editing/update-geometries/src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java
+++ b/editing/update-geometries/src/main/java/com/esri/samples/update_geometries/UpdateGeometriesSample.java
@@ -30,6 +30,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.ArcGISFeature;
 import com.esri.arcgisruntime.data.Feature;
@@ -39,8 +40,9 @@ import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.GeoElement;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -69,8 +71,15 @@ public class UpdateGeometriesSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with streets basemap and set it to a map view
-      ArcGISMap map = new ArcGISMap(Basemap.Type.STREETS, 40, -95, 4);
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with streets basemap style and set the initial viewpoint
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+      map.setInitialViewpoint(new Viewpoint(40, -95, 40000000));
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 


### PR DESCRIPTION
### Description

This PR is for the following sample categories:
- Editing

### General comments on Basemap updates:

It updates `Map` and/or `Basemap` Constructors as per the new design. This may include the following changes depending on the sample:
- Replace `Basemap.Type` with `BasemapStyle`
- If a lat/long/zoom was being set in the `Map` constructor, this is replaced with a `Viewpoint` being set on the `MapView`.
- Any Readme Updates identified

In addition, the samples that include the above changes, or other services requiring an API Key going forward, have the API Key  set within the sample. This will then work in conjunction with the Gradle Task being added in PR 593.

Once 593 is approved and merged into `dev` we will merge those changes into these PRs and then update all the Samples to `100.10.0-xxxx` and do a round of testing of the Samples with all the API Key / Basemap changes at that time. (We have left them as 100.9.0 (in most cases) for now to minimize merge conflicts in the `build.gradle` file).

In the meantime, the updates listed above can be reviewed. Thanks!