### PR TITLE
New Basemaps: Feature Layers Category

### DIFF
--- a/feature_layers/change-feature-layer-renderer/build.gradle
+++ b/feature_layers/change-feature-layer-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 javafx {
     version = "11.0.2"

--- a/feature_layers/change-feature-layer-renderer/src/main/java/com/esri/samples/change_feature_layer_renderer/ChangeFeatureLayerRendererSample.java
+++ b/feature_layers/change-feature-layer-renderer/src/main/java/com/esri/samples/change_feature_layer_renderer/ChangeFeatureLayerRendererSample.java
@@ -89,13 +89,14 @@ public class ChangeFeatureLayerRendererSample extends Application {
       // create a map with the topographic basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create starting envelope for the ArcGISMap
+      // create a map view and set the map to it
+      mapView = new MapView();
+      mapView.setMap(map);
+
+      // set a viewpoint on the map view
       Point topLeftPoint = new Point(-9177811, 4247000);
       Point bottomRightPoint = new Point(-9176791, 4247784);
-      Envelope envelope = new Envelope(topLeftPoint, bottomRightPoint);
-
-      // set starting envelope for the ArcGISMap
-      map.setInitialViewpoint(new Viewpoint(envelope));
+      mapView.setViewpoint(new Viewpoint(new Envelope(topLeftPoint, bottomRightPoint)));
 
       // create a service feature table using the url
       final ServiceFeatureTable featureTable = new ServiceFeatureTable(FEATURE_SERVICE_URL);
@@ -113,10 +114,6 @@ public class ChangeFeatureLayerRendererSample extends Application {
           new Alert(Alert.AlertType.ERROR, "Error loading Feature Table from service").show();
         }
       });
-
-      // create a view for the ArcGISMap and set ArcGISMap to it
-      mapView = new MapView();
-      mapView.setMap(map);
 
       // add the map view and control panel to stack pane
       stackPane.getChildren().addAll(mapView, rendererSwitch);

--- a/feature_layers/change-feature-layer-renderer/src/main/java/com/esri/samples/change_feature_layer_renderer/ChangeFeatureLayerRendererSample.java
+++ b/feature_layers/change-feature-layer-renderer/src/main/java/com/esri/samples/change_feature_layer_renderer/ChangeFeatureLayerRendererSample.java
@@ -25,13 +25,14 @@ import javafx.scene.control.ToggleButton;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.SimpleMarkerSymbol;
@@ -61,6 +62,10 @@ public class ChangeFeatureLayerRendererSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a marker symbol renderer with a blue circle
       SimpleMarkerSymbol markerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.CIRCLE, 0xFF0000FF, 5 );
       SimpleRenderer blueRenderer = new SimpleRenderer(markerSymbol);
@@ -81,8 +86,8 @@ public class ChangeFeatureLayerRendererSample extends Application {
         }
       });
 
-      // create a ArcGISMap with basemap topographic
-      final ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+      // create a map with the topographic basemap style
+      final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // create starting envelope for the ArcGISMap
       Point topLeftPoint = new Point(-9177811, 4247000);

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/display-subtype-feature-layer/src/main/java/com/esri/samples/display_subtype_feature_layer/DisplaySubtypeFeatureLayerController.java
+++ b/feature_layers/display-subtype-feature-layer/src/main/java/com/esri/samples/display_subtype_feature_layer/DisplaySubtypeFeatureLayerController.java
@@ -17,6 +17,7 @@ package com.esri.samples.display_subtype_feature_layer;
 
 import java.nio.charset.StandardCharsets;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.arcgisservices.LabelDefinition;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Envelope;
@@ -24,7 +25,7 @@ import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.SubtypeFeatureLayer;
 import com.esri.arcgisruntime.layers.SubtypeSublayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.Renderer;
@@ -53,10 +54,12 @@ public class DisplaySubtypeFeatureLayerController {
   public void initialize() {
 
     try {
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with streets night vector basemap and add it to the map view
-      ArcGISMap map = new ArcGISMap();
-      map.setBasemap(Basemap.createStreetsNightVector());
+      // create a map with streets night vector basemap style and add it to the map view
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS_NIGHT);
       mapView.setMap(map);
       // display the current map scale 
       mapView.addMapScaleChangedListener(mapScaleChangedEvent ->

--- a/feature_layers/display-subtype-feature-layer/src/main/java/com/esri/samples/display_subtype_feature_layer/DisplaySubtypeFeatureLayerController.java
+++ b/feature_layers/display-subtype-feature-layer/src/main/java/com/esri/samples/display_subtype_feature_layer/DisplaySubtypeFeatureLayerController.java
@@ -58,7 +58,7 @@ public class DisplaySubtypeFeatureLayerController {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with streets night vector basemap style and add it to the map view
+      // create a map with the streets night vector basemap style and add it to the map view
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS_NIGHT);
       mapView.setMap(map);
       // display the current map scale 

--- a/feature_layers/display-subtype-feature-layer/src/main/java/com/esri/samples/display_subtype_feature_layer/DisplaySubtypeFeatureLayerController.java
+++ b/feature_layers/display-subtype-feature-layer/src/main/java/com/esri/samples/display_subtype_feature_layer/DisplaySubtypeFeatureLayerController.java
@@ -17,6 +17,12 @@ package com.esri.samples.display_subtype_feature_layer;
 
 import java.nio.charset.StandardCharsets;
 
+import javafx.fxml.FXML;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
+import org.apache.commons.io.IOUtils;
+
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.arcgisservices.LabelDefinition;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
@@ -32,12 +38,6 @@ import com.esri.arcgisruntime.symbology.Renderer;
 import com.esri.arcgisruntime.symbology.SimpleMarkerSymbol;
 import com.esri.arcgisruntime.symbology.SimpleRenderer;
 import com.esri.arcgisruntime.symbology.Symbol;
-
-import javafx.fxml.FXML;
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.Label;
-import javafx.scene.layout.VBox;
-import org.apache.commons.io.IOUtils;
 
 public class DisplaySubtypeFeatureLayerController {
   
@@ -58,17 +58,17 @@ public class DisplaySubtypeFeatureLayerController {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with the streets night vector basemap style and add it to the map view
+      // create a map with the streets night basemap style and add it to the map view
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS_NIGHT);
       mapView.setMap(map);
       // display the current map scale 
       mapView.addMapScaleChangedListener(mapScaleChangedEvent ->
         currentMapScaleLabel.setText("Current map scale: 1:" + Math.round(mapView.getMapScale())));
       
-      // set the viewpoint to Naperville, Illinois
+      // set a viewpoint on the map view, to Naperville, Illinois
       Viewpoint initialViewpoint = new Viewpoint(new Envelope(-9812691.11079696, 5128687.20710657,
         -9812377.9447607, 5128865.36767282, SpatialReferences.getWebMercator()));
-      map.setInitialViewpoint(initialViewpoint);
+      mapView.setViewpoint(initialViewpoint);
 
       // create a subtype feature layer from the service feature table, and add it to the map
       ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable("https://sampleserver7.arcgisonline" +

--- a/feature_layers/feature-collection-layer-from-portal/build.gradle
+++ b/feature_layers/feature-collection-layer-from-portal/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/feature-collection-layer-from-portal/src/main/java/com/esri/samples/feature_collection_layer_from_portal/FeatureCollectionLayerFromPortalSample.java
+++ b/feature_layers/feature-collection-layer-from-portal/src/main/java/com/esri/samples/feature_collection_layer_from_portal/FeatureCollectionLayerFromPortalSample.java
@@ -26,11 +26,12 @@ import javafx.application.Application;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.FeatureCollection;
 import com.esri.arcgisruntime.layers.FeatureCollectionLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.portal.Portal;
 import com.esri.arcgisruntime.portal.PortalItem;
@@ -58,8 +59,12 @@ public class FeatureCollectionLayerFromPortalSample extends Application {
             stage.setScene(scene);
             stage.show();
 
-            // create a new ArcGISMap with the oceans basemap
-            map = new ArcGISMap(Basemap.createOceans());
+            // authentication with an API key or named user is required to access basemaps and other location services
+            String yourAPIKey = System.getProperty("apiKey");
+            ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+            // create a map with the oceans basemap style
+            map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
 
             // create a map view and set the map to it
             mapView = new MapView();

--- a/feature_layers/feature-collection-layer-from-portal/src/main/java/com/esri/samples/feature_collection_layer_from_portal/FeatureCollectionLayerFromPortalSample.java
+++ b/feature_layers/feature-collection-layer-from-portal/src/main/java/com/esri/samples/feature_collection_layer_from_portal/FeatureCollectionLayerFromPortalSample.java
@@ -38,122 +38,122 @@ import com.esri.arcgisruntime.portal.PortalItem;
 
 public class FeatureCollectionLayerFromPortalSample extends Application {
 
-    private ArcGISMap map;
-    private MapView mapView;
-    private Portal portal;
-    private TextField inputTextField;
-    private PortalItem portalItem; // keep loadable in scope to avoid garbage collection
+  private ArcGISMap map;
+  private MapView mapView;
+  private Portal portal;
+  private TextField inputTextField;
+  private PortalItem portalItem; // keep loadable in scope to avoid garbage collection
 
-    @Override
-    public void start(Stage stage) {
-        // set up the application scene
-        try {
-            // create stack pane and application scene
-            StackPane stackPane = new StackPane();
-            Scene scene = new Scene(stackPane);
+  @Override
+  public void start(Stage stage) {
+    // set up the application scene
+    try {
+      // create stack pane and application scene
+      StackPane stackPane = new StackPane();
+      Scene scene = new Scene(stackPane);
 
-            // set title, size, and add scene to stage
-            stage.setTitle("Feature Collection Layer From Portal");
-            stage.setWidth(800);
-            stage.setHeight(700);
-            stage.setScene(scene);
-            stage.show();
+      // set title, size, and add scene to stage
+      stage.setTitle("Feature Collection Layer From Portal");
+      stage.setWidth(800);
+      stage.setHeight(700);
+      stage.setScene(scene);
+      stage.show();
 
-            // authentication with an API key or named user is required to access basemaps and other location services
-            String yourAPIKey = System.getProperty("apiKey");
-            ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-            // create a map with the oceans basemap style
-            map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
+      // create a map with the oceans basemap style
+      map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
 
-            // create a map view and set the map to it
-            mapView = new MapView();
-            mapView.setMap(map);
+      // create a map view and set the map to it
+      mapView = new MapView();
+      mapView.setMap(map);
 
-            // create portal
-            portal = new Portal("https://www.arcgis.com/");
+      // create portal
+      portal = new Portal("https://www.arcgis.com/");
 
-            // create text field to input user's own portal item ID
-            inputTextField = new TextField("32798dfad17942858d5eef82ee802f0b");
-            inputTextField.setMaxWidth(250);
+      // create text field to input user's own portal item ID
+      inputTextField = new TextField("32798dfad17942858d5eef82ee802f0b");
+      inputTextField.setMaxWidth(250);
 
-            // fetch the default feature collection layer from the portal
-            fetchFeatureCollectionFromPortal();
+      // fetch the default feature collection layer from the portal
+      fetchFeatureCollectionFromPortal();
 
-            // create button to perform action
-            Button fetchFromPortalButton = new Button("Open from portal item");
-            fetchFromPortalButton.setMaxWidth(250);
+      // create button to perform action
+      Button fetchFromPortalButton = new Button("Open from portal item");
+      fetchFromPortalButton.setMaxWidth(250);
 
-            // verify the input and fetch the portal item
-            fetchFromPortalButton.setOnAction(e -> fetchFeatureCollectionFromPortal());
+      // verify the input and fetch the portal item
+      fetchFromPortalButton.setOnAction(e -> fetchFeatureCollectionFromPortal());
 
-            // add the map view and control panel to stack pane
-            stackPane.getChildren().addAll(mapView, inputTextField, fetchFromPortalButton);
-            StackPane.setAlignment(inputTextField, Pos.TOP_LEFT);
-            StackPane.setMargin(inputTextField, new Insets(10, 0, 0, 10));
-            StackPane.setAlignment(fetchFromPortalButton, Pos.TOP_LEFT);
-            StackPane.setMargin(fetchFromPortalButton, new Insets(40, 0, 0, 10));
+      // add the map view and control panel to stack pane
+      stackPane.getChildren().addAll(mapView, inputTextField, fetchFromPortalButton);
+      StackPane.setAlignment(inputTextField, Pos.TOP_LEFT);
+      StackPane.setMargin(inputTextField, new Insets(10, 0, 0, 10));
+      StackPane.setAlignment(fetchFromPortalButton, Pos.TOP_LEFT);
+      StackPane.setMargin(fetchFromPortalButton, new Insets(40, 0, 0, 10));
 
-        } catch (Exception e) {
-            // on any error, display the stack trace
-            e.printStackTrace();
-        }
+    } catch (Exception e) {
+      // on any error, display the stack trace
+      e.printStackTrace();
     }
+  }
 
-    /**
-     * Fetch feature collection from portal and load as feature layer.
-     */
-    private void fetchFeatureCollectionFromPortal() {
+  /**
+   * Fetch feature collection from portal and load as feature layer.
+   */
+  private void fetchFeatureCollectionFromPortal() {
 
-        if (!inputTextField.getText().isEmpty()) {
-            // crate portal item
-            portalItem = new PortalItem(portal, inputTextField.getText());
-            portalItem.loadAsync();
+    if (!inputTextField.getText().isEmpty()) {
+      // crate portal item
+      portalItem = new PortalItem(portal, inputTextField.getText());
+      portalItem.loadAsync();
 
-            portalItem.addDoneLoadingListener(() -> {
+      portalItem.addDoneLoadingListener(() -> {
 
-                if (portalItem.getLoadStatus() == LoadStatus.LOADED) {
+        if (portalItem.getLoadStatus() == LoadStatus.LOADED) {
 
-                    if (portalItem.getType() == PortalItem.Type.FEATURE_COLLECTION) {
+          if (portalItem.getType() == PortalItem.Type.FEATURE_COLLECTION) {
 
-                        // create feature collection and add to the map as a layer
-                        FeatureCollection  featureCollection = new FeatureCollection(portalItem);
-                        FeatureCollectionLayer featureCollectionLayer = new FeatureCollectionLayer(featureCollection);
+            // create feature collection and add to the map as a layer
+            FeatureCollection  featureCollection = new FeatureCollection(portalItem);
+            FeatureCollectionLayer featureCollectionLayer = new FeatureCollectionLayer(featureCollection);
 
-                        // add feature collection layer to the map
-                        map.getOperationalLayers().clear();
-                        map.getOperationalLayers().add(featureCollectionLayer);
+            // add feature collection layer to the map
+            map.getOperationalLayers().clear();
+            map.getOperationalLayers().add(featureCollectionLayer);
 
-                        } else {
-                        new Alert(Alert.AlertType.ERROR, "Portal item is not a feature collection").show();
-                    }
-                } else {
-                    new Alert(Alert.AlertType.ERROR, "Portal item failed to load").show();
-                }
-            });
+          } else {
+            new Alert(Alert.AlertType.ERROR, "Portal item is not a feature collection").show();
+          }
         } else {
-            new Alert(Alert.AlertType.ERROR, "Portal Item ID is empty").show();
+          new Alert(Alert.AlertType.ERROR, "Portal item failed to load").show();
         }
-
-    }
-    /**
-     * Stops and releases all resources used in application.
-     */
-    @Override
-    public void stop() {
-
-        if (mapView != null) {
-            mapView.dispose();
-        }
+      });
+    } else {
+      new Alert(Alert.AlertType.ERROR, "Portal Item ID is empty").show();
     }
 
-    /**
-     * Opens and runs application.
-     *
-     * @param args arguments passed to this application
-     */
-    public static void main(String[] args) {
+  }
+  /**
+   * Stops and releases all resources used in application.
+   */
+  @Override
+  public void stop() {
 
-        Application.launch(args);
+    if (mapView != null) {
+      mapView.dispose();
     }
+  }
+
+  /**
+   * Opens and runs application.
+   *
+   * @param args arguments passed to this application
+   */
+  public static void main(String[] args) {
+
+    Application.launch(args);
+  }
 }

--- a/feature_layers/feature-collection-layer-query/build.gradle
+++ b/feature_layers/feature-collection-layer-query/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/feature-collection-layer-query/src/main/java/com/esri/samples/feature_collection_layer_query/FeatureCollectionLayerQuerySample.java
+++ b/feature_layers/feature-collection-layer-query/src/main/java/com/esri/samples/feature_collection_layer_query/FeatureCollectionLayerQuerySample.java
@@ -16,6 +16,7 @@
 
 package com.esri.samples.feature_collection_layer_query;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.FeatureCollection;
 import com.esri.arcgisruntime.data.FeatureCollectionTable;
@@ -25,7 +26,7 @@ import com.esri.arcgisruntime.data.QueryParameters;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.layers.FeatureCollectionLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import javafx.application.Application;
 import javafx.scene.Scene;
@@ -51,9 +52,12 @@ public class FeatureCollectionLayerQuerySample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a ArcGISMap with a imagery basemap
-      ArcGISMap map = new ArcGISMap();
-      map.setBasemap(Basemap.createTopographic());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // create a map view and set the map to it
       mapView = new MapView();

--- a/feature_layers/feature-collection-layer-query/src/main/java/com/esri/samples/feature_collection_layer_query/FeatureCollectionLayerQuerySample.java
+++ b/feature_layers/feature-collection-layer-query/src/main/java/com/esri/samples/feature_collection_layer_query/FeatureCollectionLayerQuerySample.java
@@ -56,7 +56,7 @@ public class FeatureCollectionLayerQuerySample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the topographic basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // create a map view and set the map to it

--- a/feature_layers/feature-collection-layer/build.gradle
+++ b/feature_layers/feature-collection-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/feature-collection-layer/src/main/java/com/esri/samples/feature_collection_layer/FeatureCollectionLayerSample.java
+++ b/feature_layers/feature-collection-layer/src/main/java/com/esri/samples/feature_collection_layer/FeatureCollectionLayerSample.java
@@ -26,6 +26,7 @@ import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.Feature;
 import com.esri.arcgisruntime.data.FeatureCollection;
 import com.esri.arcgisruntime.data.FeatureCollectionTable;
@@ -38,7 +39,7 @@ import com.esri.arcgisruntime.geometry.SpatialReference;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureCollectionLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.SimpleFillSymbol;
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol;
@@ -67,8 +68,14 @@ public class FeatureCollectionLayerSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create amp and set it to be displayed in this view
-      ArcGISMap map = new ArcGISMap(Basemap.createOceans());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/feature_layers/feature-collection-layer/src/main/java/com/esri/samples/feature_collection_layer/FeatureCollectionLayerSample.java
+++ b/feature_layers/feature-collection-layer/src/main/java/com/esri/samples/feature_collection_layer/FeatureCollectionLayerSample.java
@@ -72,10 +72,10 @@ public class FeatureCollectionLayerSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the oceans basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/feature_layers/feature-layer-definition-expression/build.gradle
+++ b/feature_layers/feature-layer-definition-expression/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/feature-layer-definition-expression/src/main/java/com/esri/samples/feature_layer_definition_expression/FeatureLayerDefinitionExpressionSample.java
+++ b/feature_layers/feature-layer-definition-expression/src/main/java/com/esri/samples/feature_layer_definition_expression/FeatureLayerDefinitionExpressionSample.java
@@ -24,12 +24,13 @@ import javafx.scene.control.ToggleButton;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class FeatureLayerDefinitionExpressionSample extends Application {
@@ -56,6 +57,10 @@ public class FeatureLayerDefinitionExpressionSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create renderer toggle switch
       ToggleButton definitionSwitch = new ToggleButton();
       definitionSwitch.setText("expression");
@@ -76,8 +81,8 @@ public class FeatureLayerDefinitionExpressionSample extends Application {
       // create feature layer from service feature table
       featureLayer = new FeatureLayer(featureTable);
 
-      // create a ArcGISMap using the basemap topographic
-      final ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+      // create a map with a basemap style
+      final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // add the feature layer to the ArcGISMap
       map.getOperationalLayers().add(featureLayer);

--- a/feature_layers/feature-layer-definition-expression/src/main/java/com/esri/samples/feature_layer_definition_expression/FeatureLayerDefinitionExpressionSample.java
+++ b/feature_layers/feature-layer-definition-expression/src/main/java/com/esri/samples/feature_layer_definition_expression/FeatureLayerDefinitionExpressionSample.java
@@ -81,13 +81,13 @@ public class FeatureLayerDefinitionExpressionSample extends Application {
       // create feature layer from service feature table
       featureLayer = new FeatureLayer(featureTable);
 
-      // create a map with a basemap style
+      // create a map with the topographic basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // add the feature layer to the ArcGISMap
+      // add the feature layer to the map's operational layers
       map.getOperationalLayers().add(featureLayer);
 
-      // create a view for this ArcGISMap and set map to it
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/feature_layers/feature-layer-dictionary-renderer/build.gradle
+++ b/feature_layers/feature-layer-dictionary-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
+++ b/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
@@ -59,7 +59,7 @@ public class FeatureLayerDictionaryRendererSample extends Application {
     String yourAPIKey = System.getProperty("apiKey");
     ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-    // create a map with a basemap style and set it to the map view
+    // create a map with the topographic basemap style and set it to the map view
     ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
     mapView.setMap(map);
 

--- a/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
+++ b/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
@@ -22,11 +22,12 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.Geodatabase;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.DictionaryRenderer;
 import com.esri.arcgisruntime.symbology.DictionarySymbolStyle;
@@ -54,7 +55,12 @@ public class FeatureLayerDictionaryRendererSample extends Application {
     stage.setScene(scene);
     stage.show();
 
-    ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+    // authentication with an API key or named user is required to access basemaps and other location services
+    String yourAPIKey = System.getProperty("apiKey");
+    ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+    // create a map with a basemap style and set it to the map view
+    ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
     mapView.setMap(map);
 
     // load geo-database from local location

--- a/feature_layers/feature-layer-feature-service/build.gradle
+++ b/feature_layers/feature-layer-feature-service/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 javafx {
     version = "11.0.2"

--- a/feature_layers/feature-layer-feature-service/src/main/java/com/esri/samples/feature_layer_feature_service/FeatureLayerFeatureServiceSample.java
+++ b/feature_layers/feature-layer-feature-service/src/main/java/com/esri/samples/feature_layer_feature_service/FeatureLayerFeatureServiceSample.java
@@ -21,12 +21,13 @@ import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -52,11 +53,15 @@ public class FeatureLayerFeatureServiceSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a view for this ArcGISMap
       mapView = new MapView();
 
-      // create a ArcGISMap with the terrain with labels basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createTerrainWithLabels());
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TERRAIN);
 
       // set an initial viewpoint
       map.setInitialViewpoint(new Viewpoint(new Point(-13176752, 4090404, SpatialReferences.getWebMercator()), 500000));

--- a/feature_layers/feature-layer-feature-service/src/main/java/com/esri/samples/feature_layer_feature_service/FeatureLayerFeatureServiceSample.java
+++ b/feature_layers/feature-layer-feature-service/src/main/java/com/esri/samples/feature_layer_feature_service/FeatureLayerFeatureServiceSample.java
@@ -57,14 +57,15 @@ public class FeatureLayerFeatureServiceSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a view for this ArcGISMap
-      mapView = new MapView();
-
-      // create a map with a basemap style
+      // create a map with the terrain basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TERRAIN);
 
-      // set an initial viewpoint
-      map.setInitialViewpoint(new Viewpoint(new Point(-13176752, 4090404, SpatialReferences.getWebMercator()), 500000));
+      // create a map view and set the map to it
+      mapView = new MapView();
+      mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(new Point(-13176752, 4090404, SpatialReferences.getWebMercator()), 500000));
 
       // create feature layer with its service feature table
       // create the service feature table
@@ -73,11 +74,8 @@ public class FeatureLayerFeatureServiceSample extends Application {
       // create the feature layer using the service feature table
       FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
 
-      // add the layer to the ArcGISMap
+      // add the layer to the map
       map.getOperationalLayers().add(featureLayer);
-
-      // set the ArcGISMap to be displayed in the view
-      mapView.setMap(map);
 
       // add the map view to stack pane
       stackPane.getChildren().add(mapView);

--- a/feature_layers/feature-layer-feature-service/src/main/java/com/esri/samples/feature_layer_feature_service/FeatureLayerFeatureServiceSample.java
+++ b/feature_layers/feature-layer-feature-service/src/main/java/com/esri/samples/feature_layer_feature_service/FeatureLayerFeatureServiceSample.java
@@ -74,7 +74,7 @@ public class FeatureLayerFeatureServiceSample extends Application {
       // create the feature layer using the service feature table
       FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
 
-      // add the layer to the map
+      // add the feature layer to the map's operational layers
       map.getOperationalLayers().add(featureLayer);
 
       // add the map view to stack pane

--- a/feature_layers/feature-layer-geodatabase/build.gradle
+++ b/feature_layers/feature-layer-geodatabase/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/feature-layer-geodatabase/src/main/java/com/esri/samples/feature_layer_geodatabase/FeatureLayerGeodatabaseSample.java
+++ b/feature_layers/feature-layer-geodatabase/src/main/java/com/esri/samples/feature_layer_geodatabase/FeatureLayerGeodatabaseSample.java
@@ -24,12 +24,13 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.Geodatabase;
 import com.esri.arcgisruntime.data.GeodatabaseFeatureTable;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class FeatureLayerGeodatabaseSample extends Application {
@@ -55,8 +56,14 @@ public class FeatureLayerGeodatabaseSample extends Application {
       stage.setScene(fxScene);
       stage.show();
 
-      // create map and add to view
-      ArcGISMap map = new ArcGISMap(Basemap.createStreets());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/feature_layers/feature-layer-geodatabase/src/main/java/com/esri/samples/feature_layer_geodatabase/FeatureLayerGeodatabaseSample.java
+++ b/feature_layers/feature-layer-geodatabase/src/main/java/com/esri/samples/feature_layer_geodatabase/FeatureLayerGeodatabaseSample.java
@@ -60,10 +60,10 @@ public class FeatureLayerGeodatabaseSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/feature_layers/feature-layer-geopackage/build.gradle
+++ b/feature_layers/feature-layer-geopackage/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/feature-layer-geopackage/src/main/java/com/esri/samples/feature_layer_geopackage/FeatureLayerGeoPackageSample.java
+++ b/feature_layers/feature-layer-geopackage/src/main/java/com/esri/samples/feature_layer_geopackage/FeatureLayerGeoPackageSample.java
@@ -59,10 +59,10 @@ public class FeatureLayerGeoPackageSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/feature_layers/feature-layer-geopackage/src/main/java/com/esri/samples/feature_layer_geopackage/FeatureLayerGeoPackageSample.java
+++ b/feature_layers/feature-layer-geopackage/src/main/java/com/esri/samples/feature_layer_geopackage/FeatureLayerGeoPackageSample.java
@@ -25,12 +25,13 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.GeoPackage;
 import com.esri.arcgisruntime.data.GeoPackageFeatureTable;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -54,8 +55,16 @@ public class FeatureLayerGeoPackageSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with the streets vector basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createStreetsVector());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+
+      // create a map view and set its map
+      mapView = new MapView();
+      mapView.setMap(map);
 
       // create a GeoPackage from a local gpkg file
       File geoPackageFile = new File(System.getProperty("data.dir"), "./samples-data/auroraCO/AuroraCO.gpkg");
@@ -79,10 +88,6 @@ public class FeatureLayerGeoPackageSample extends Application {
           alert.show();
         }
       });
-
-      // set the map to be displayed in this view
-      mapView = new MapView();
-      mapView.setMap(map);
 
       // add the map view to stack pane
       stackPane.getChildren().add(mapView);

--- a/feature_layers/feature-layer-query/build.gradle
+++ b/feature_layers/feature-layer-query/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/feature-layer-query/src/main/java/com/esri/samples/feature_layer_query/FeatureLayerQuerySample.java
+++ b/feature_layers/feature-layer-query/src/main/java/com/esri/samples/feature_layer_query/FeatureLayerQuerySample.java
@@ -35,6 +35,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.Feature;
 import com.esri.arcgisruntime.data.FeatureQueryResult;
@@ -46,7 +47,7 @@ import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.SimpleFillSymbol;
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol;
@@ -79,6 +80,10 @@ public class FeatureLayerQuerySample extends Application {
       stage.setHeight(700);
       stage.setScene(scene);
       stage.show();
+
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
       // create a control panel
       VBox controlsVBox = new VBox(6);
@@ -148,15 +153,15 @@ public class FeatureLayerQuerySample extends Application {
       // set renderer for feature layer
       featureLayer.setRenderer(new SimpleRenderer(fillSymbol));
 
-      // create a ArcGISMap with basemap topographic
-      final ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+      // create a map with a basemap style
+      final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
+
+      // create a map view and set its map
+      mapView = new MapView();
+      mapView.setMap(map);
 
       // add feature layer to operational layers
       map.getOperationalLayers().add(featureLayer);
-
-      // create a view for this ArcGISMap
-      mapView = new MapView();
-      mapView.setMap(map);
 
       // set viewpoint to the start point
       mapView.setViewpointCenterAsync(startPoint, SCALE);

--- a/feature_layers/feature-layer-query/src/main/java/com/esri/samples/feature_layer_query/FeatureLayerQuerySample.java
+++ b/feature_layers/feature-layer-query/src/main/java/com/esri/samples/feature_layer_query/FeatureLayerQuerySample.java
@@ -153,10 +153,10 @@ public class FeatureLayerQuerySample extends Application {
       // set renderer for feature layer
       featureLayer.setRenderer(new SimpleRenderer(fillSymbol));
 
-      // create a map with a basemap style
+      // create a map with the topographic basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/feature_layers/feature-layer-query/src/main/java/com/esri/samples/feature_layer_query/FeatureLayerQuerySample.java
+++ b/feature_layers/feature-layer-query/src/main/java/com/esri/samples/feature_layer_query/FeatureLayerQuerySample.java
@@ -160,7 +160,7 @@ public class FeatureLayerQuerySample extends Application {
       mapView = new MapView();
       mapView.setMap(map);
 
-      // add feature layer to operational layers
+      // add the feature layer to the map's operational layers
       map.getOperationalLayers().add(featureLayer);
 
       // set viewpoint to the start point

--- a/feature_layers/feature-layer-selection/build.gradle
+++ b/feature_layers/feature-layer-selection/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/feature-layer-selection/src/main/java/com/esri/samples/feature_layer_selection/FeatureLayerSelectionSample.java
+++ b/feature_layers/feature-layer-selection/src/main/java/com/esri/samples/feature_layer_selection/FeatureLayerSelectionSample.java
@@ -26,6 +26,7 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.Feature;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
@@ -33,7 +34,7 @@ import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -57,17 +58,19 @@ public class FeatureLayerSelectionSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a view for this ArcGISMap
-      mapView = new MapView();
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a ArcGISMap with the streets basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createLightGrayCanvas());
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
 
       // set an initial viewpoint
       map.setInitialViewpoint(new Viewpoint(new Envelope(-6603299.491810, 1679677.742046, 9002253.947487,
           8691318.054732, 0, 0, SpatialReferences.getWebMercator())));
 
-      // set the map to the map view
+      // create a map view and set its map
+      mapView = new MapView();
       mapView.setMap(map);
 
       // create the service feature table

--- a/feature_layers/feature-layer-selection/src/main/java/com/esri/samples/feature_layer_selection/FeatureLayerSelectionSample.java
+++ b/feature_layers/feature-layer-selection/src/main/java/com/esri/samples/feature_layer_selection/FeatureLayerSelectionSample.java
@@ -62,16 +62,16 @@ public class FeatureLayerSelectionSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the light gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
 
-      // set an initial viewpoint
-      map.setInitialViewpoint(new Viewpoint(new Envelope(-6603299.491810, 1679677.742046, 9002253.947487,
-          8691318.054732, 0, 0, SpatialReferences.getWebMercator())));
-
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(new Envelope(-6603299.491810, 1679677.742046, 9002253.947487,
+        8691318.054732, 0, 0, SpatialReferences.getWebMercator())));
 
       // create the service feature table
       String damageAssessmentFeatureService = "https://services1.arcgis.com/4yjifSiIG17X0gW4/arcgis/rest/services/GDP_per_capita_1960_2016/FeatureServer/0";
@@ -80,7 +80,7 @@ public class FeatureLayerSelectionSample extends Application {
       // create the feature layer
       final FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
 
-      // add the layer to the ArcGISMap
+      // add the layer to the map's operational layers
       map.getOperationalLayers().add(featureLayer);
 
       mapView.setOnMouseClicked(event -> {

--- a/feature_layers/feature-layer-shapefile/build.gradle
+++ b/feature_layers/feature-layer-shapefile/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/feature-layer-shapefile/src/main/java/com/esri/samples/feature_layer_shapefile/FeatureLayerShapefileSample.java
+++ b/feature_layers/feature-layer-shapefile/src/main/java/com/esri/samples/feature_layer_shapefile/FeatureLayerShapefileSample.java
@@ -56,10 +56,10 @@ public class FeatureLayerShapefileSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // set the map to the map view
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/feature_layers/feature-layer-shapefile/src/main/java/com/esri/samples/feature_layer_shapefile/FeatureLayerShapefileSample.java
+++ b/feature_layers/feature-layer-shapefile/src/main/java/com/esri/samples/feature_layer_shapefile/FeatureLayerShapefileSample.java
@@ -24,11 +24,12 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ShapefileFeatureTable;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class FeatureLayerShapefileSample extends Application {
@@ -51,8 +52,12 @@ public class FeatureLayerShapefileSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with a basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createStreetsVector());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // set the map to the map view
       mapView = new MapView();

--- a/feature_layers/service-feature-table-cache/build.gradle
+++ b/feature_layers/service-feature-table-cache/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/service-feature-table-cache/src/main/java/com/esri/samples/service_feature_table_cache/ServiceFeatureTableCacheSample.java
+++ b/feature_layers/service-feature-table-cache/src/main/java/com/esri/samples/service_feature_table_cache/ServiceFeatureTableCacheSample.java
@@ -22,13 +22,14 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -55,13 +56,15 @@ public class ServiceFeatureTableCacheSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map view
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
+
+      // create a map view and set its map
       mapView = new MapView();
-
-      // create a ArcGISMap with the light Gray Canvas basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createLightGrayCanvas());
-
-      // set ArcGISMap to be displayed in ArcGISMap view
       mapView.setMap(map);
 
       // set an initial viewpoint

--- a/feature_layers/service-feature-table-cache/src/main/java/com/esri/samples/service_feature_table_cache/ServiceFeatureTableCacheSample.java
+++ b/feature_layers/service-feature-table-cache/src/main/java/com/esri/samples/service_feature_table_cache/ServiceFeatureTableCacheSample.java
@@ -60,15 +60,15 @@ public class ServiceFeatureTableCacheSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the light gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
-      // set an initial viewpoint
-      map.setInitialViewpoint(new Viewpoint(new Envelope(-140.740858094945, 14.1552479740679, -47.693259181055,
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(new Envelope(-140.740858094945, 14.1552479740679, -47.693259181055,
               64.8874243113506, SpatialReferences.getWgs84())));
 
       // create the service feature table
@@ -86,7 +86,7 @@ public class ServiceFeatureTableCacheSample extends Application {
           // create the feature layer using the service feature table
           FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
 
-          // add the layer to the ArcGISMap
+          // add the feature layer to the map's operational layers
           map.getOperationalLayers().add(featureLayer);
 
         } else {

--- a/feature_layers/service-feature-table-manual-cache/build.gradle
+++ b/feature_layers/service-feature-table-manual-cache/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/service-feature-table-manual-cache/src/main/java/com/esri/samples/service_feature_table_manual_cache/ServiceFeatureTableManualCacheSample.java
+++ b/feature_layers/service-feature-table-manual-cache/src/main/java/com/esri/samples/service_feature_table_manual_cache/ServiceFeatureTableManualCacheSample.java
@@ -122,14 +122,14 @@ public class ServiceFeatureTableManualCacheSample extends Application {
         }
       });
 
-      // create a map with a basemap style
+      // create a map with the topographic basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
-      // add the feature layer to the operational layers
+      // add the feature layer to the map's operational layers
       map.getOperationalLayers().add(featureLayer);
 
       // set the starting viewpoint for the map view

--- a/feature_layers/service-feature-table-manual-cache/src/main/java/com/esri/samples/service_feature_table_manual_cache/ServiceFeatureTableManualCacheSample.java
+++ b/feature_layers/service-feature-table-manual-cache/src/main/java/com/esri/samples/service_feature_table_manual_cache/ServiceFeatureTableManualCacheSample.java
@@ -125,12 +125,12 @@ public class ServiceFeatureTableManualCacheSample extends Application {
       // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // add feature layer to the ArcGISMap
-      map.getOperationalLayers().add(featureLayer);
-
-      // create a view for this ArcGISMap and set ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // add the feature layer to the operational layers
+      map.getOperationalLayers().add(featureLayer);
 
       // set the starting viewpoint for the map view
       mapView.setViewpoint(new Viewpoint(new Point(-13630484, 4545415, SpatialReferences.getWebMercator()), 150000));

--- a/feature_layers/service-feature-table-manual-cache/src/main/java/com/esri/samples/service_feature_table_manual_cache/ServiceFeatureTableManualCacheSample.java
+++ b/feature_layers/service-feature-table-manual-cache/src/main/java/com/esri/samples/service_feature_table_manual_cache/ServiceFeatureTableManualCacheSample.java
@@ -36,6 +36,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.FeatureQueryResult;
 import com.esri.arcgisruntime.data.QueryParameters;
@@ -45,7 +46,7 @@ import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -75,6 +76,10 @@ public class ServiceFeatureTableManualCacheSample extends Application {
       stage.setHeight(700);
       stage.setScene(scene);
       stage.show();
+
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
       // create a control panel
       VBox controlsVBox = new VBox(6);
@@ -117,8 +122,8 @@ public class ServiceFeatureTableManualCacheSample extends Application {
         }
       });
 
-      // create a ArcGISMap with topographic basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // add feature layer to the ArcGISMap
       map.getOperationalLayers().add(featureLayer);

--- a/feature_layers/service-feature-table-no-cache/build.gradle
+++ b/feature_layers/service-feature-table-no-cache/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/service-feature-table-no-cache/src/main/java/com/esri/samples/service_feature_table_no_cache/ServiceFeatureTableNoCacheSample.java
+++ b/feature_layers/service-feature-table-no-cache/src/main/java/com/esri/samples/service_feature_table_no_cache/ServiceFeatureTableNoCacheSample.java
@@ -58,15 +58,15 @@ public class ServiceFeatureTableNoCacheSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the light gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
-      // set an initial viewpoint
-      map.setInitialViewpoint(new Viewpoint(new Envelope(-140.740858094945, 14.1552479740679, -47.693259181055,
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(new Envelope(-140.740858094945, 14.1552479740679, -47.693259181055,
               64.8874243113506, SpatialReferences.getWgs84())));
 
       // create the service feature table
@@ -83,7 +83,7 @@ public class ServiceFeatureTableNoCacheSample extends Application {
           // create the feature layer using the service feature table
           featureLayer = new FeatureLayer(serviceFeatureTable);
 
-          // add the layer to the ArcGISMap
+          // add the feature layer to the map's operational layers
           map.getOperationalLayers().add(featureLayer);
 
         } else {

--- a/feature_layers/service-feature-table-no-cache/src/main/java/com/esri/samples/service_feature_table_no_cache/ServiceFeatureTableNoCacheSample.java
+++ b/feature_layers/service-feature-table-no-cache/src/main/java/com/esri/samples/service_feature_table_no_cache/ServiceFeatureTableNoCacheSample.java
@@ -22,13 +22,14 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -53,13 +54,15 @@ public class ServiceFeatureTableNoCacheSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a view for this ArcGISMap
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
+
+      // create a map view and set its map
       mapView = new MapView();
-
-      // create a ArcGISMap with the light Gray Canvas basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createLightGrayCanvas());
-
-      // set ArcGISMap to be displayed in ArcGISMap view
       mapView.setMap(map);
 
       // set an initial viewpoint

--- a/feature_layers/statistical-query/build.gradle
+++ b/feature_layers/statistical-query/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/feature_layers/statistical-query/src/main/java/com/esri/samples/statistical_query/StatisticalQuerySample.java
+++ b/feature_layers/statistical-query/src/main/java/com/esri/samples/statistical_query/StatisticalQuerySample.java
@@ -75,10 +75,10 @@ public class StatisticalQuerySample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/feature_layers/statistical-query/src/main/java/com/esri/samples/statistical_query/StatisticalQuerySample.java
+++ b/feature_layers/statistical-query/src/main/java/com/esri/samples/statistical_query/StatisticalQuerySample.java
@@ -37,6 +37,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.QueryParameters;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
@@ -47,7 +48,7 @@ import com.esri.arcgisruntime.data.StatisticsQueryParameters;
 import com.esri.arcgisruntime.data.StatisticsQueryResult;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class StatisticalQuerySample extends Application {
@@ -70,8 +71,14 @@ public class StatisticalQuerySample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create and set a map with the streets vector basemap
-      final ArcGISMap map = new ArcGISMap(Basemap.createStreetsVector());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/feature_layers/time-based-query/build.gradle
+++ b/feature_layers/time-based-query/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 javafx {
     version = "11.0.2"

--- a/feature_layers/time-based-query/src/main/java/com/esri/samples/time_based_query/TimeBasedQuerySample.java
+++ b/feature_layers/time-based-query/src/main/java/com/esri/samples/time_based_query/TimeBasedQuerySample.java
@@ -26,12 +26,13 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.QueryParameters;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.TimeExtent;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -55,9 +56,15 @@ public class TimeBasedQuerySample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map and set it to a map view
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
+
+      // create a map view and set its map
       mapView = new MapView();
-      ArcGISMap map = new ArcGISMap(Basemap.createOceans());
       mapView.setMap(map);
 
       // create a feature table with the URL of the feature service

--- a/feature_layers/time-based-query/src/main/java/com/esri/samples/time_based_query/TimeBasedQuerySample.java
+++ b/feature_layers/time-based-query/src/main/java/com/esri/samples/time_based_query/TimeBasedQuerySample.java
@@ -60,10 +60,10 @@ public class TimeBasedQuerySample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the oceans basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
@@ -101,7 +101,7 @@ public class TimeBasedQuerySample extends Application {
       // create the feature layer using the service feature table
       FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
 
-      // add the layer to the map
+      // add the feature layer to the map's operational layers
       map.getOperationalLayers().add(featureLayer);
 
       // add the map view to stack pane


### PR DESCRIPTION
### Description

This PR is for the following sample categories:
- Feature Layers

Notes specific to this PR: 
- Feature collection layer from portal had it's indentation fixed

### General comments on Basemap updates:

It updates `Map` and/or `Basemap` Constructors as per the new design. This may include the following changes depending on the sample:
- Replace `Basemap.Type` with `BasemapStyle`
- If a lat/long/zoom was being set in the `Map` constructor, this is replaced with a `Viewpoint` being set on the `MapView`.
- Any Readme Updates identified

In addition, the samples that include the above changes, or other services requiring an API Key going forward, have the API Key  set within the sample. This will then work in conjunction with the Gradle Task being added in PR 593.

Once 593 is approved and merged into `dev` we will merge those changes into these PRs and then update all the Samples to `100.10.0-xxxx` and do a round of testing of the Samples with all the API Key / Basemap changes at that time. (We have left them as 100.9.0 (in most cases) for now to minimize merge conflicts in the `build.gradle` file).

In the meantime, the updates listed above can be reviewed. Thanks!