### PR TITLE
 New Basemaps: Hydrography, Image layers and KML Categories

### DIFF
--- a/hydrography/add-enc-exchange-set/build.gradle
+++ b/hydrography/add-enc-exchange-set/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/hydrography/add-enc-exchange-set/src/main/java/com/esri/samples/add_enc_exchange_set/AddEncExchangeSetSample.java
+++ b/hydrography/add-enc-exchange-set/src/main/java/com/esri/samples/add_enc_exchange_set/AddEncExchangeSetSample.java
@@ -71,7 +71,7 @@ public class AddEncExchangeSetSample extends Application {
       // create a map with the oceans basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/hydrography/add-enc-exchange-set/src/main/java/com/esri/samples/add_enc_exchange_set/AddEncExchangeSetSample.java
+++ b/hydrography/add-enc-exchange-set/src/main/java/com/esri/samples/add_enc_exchange_set/AddEncExchangeSetSample.java
@@ -68,9 +68,12 @@ public class AddEncExchangeSetSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map view and add it to the stack pane
+      // create a map with the oceans basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
+
+      // create a map view and set its map
       mapView = new MapView();
-      stackPane.getChildren().add(mapView);
+      mapView.setMap(map);
 
       // show progress indicator when map is drawing
       ProgressIndicator progressIndicator = new ProgressIndicator();
@@ -87,10 +90,6 @@ public class AddEncExchangeSetSample extends Application {
           progressIndicator.setVisible(false);
         }
       });
-
-      // create a map with the oceans basemap style and set it on the map view
-      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
-      mapView.setMap(map);
 
       // load the ENC exchange set from local data
       File encPath = new File(System.getProperty("data.dir"), "./samples-data/enc/ExchangeSetwithoutUpdates/ENC_ROOT/CATALOG.031");
@@ -123,6 +122,10 @@ public class AddEncExchangeSetSample extends Application {
           new Alert(Alert.AlertType.ERROR, "Failed to load ENC exchange set.").show();
         }
       });
+
+      // add the map view to the stack pane
+      stackPane.getChildren().add(mapView);
+
     } catch (Exception e) {
       // on any error, display the stack trace.
       e.printStackTrace();

--- a/hydrography/add-enc-exchange-set/src/main/java/com/esri/samples/add_enc_exchange_set/AddEncExchangeSetSample.java
+++ b/hydrography/add-enc-exchange-set/src/main/java/com/esri/samples/add_enc_exchange_set/AddEncExchangeSetSample.java
@@ -27,6 +27,7 @@ import javafx.scene.control.ProgressIndicator;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.GeometryEngine;
 import com.esri.arcgisruntime.hydrography.EncCell;
@@ -35,7 +36,7 @@ import com.esri.arcgisruntime.hydrography.EncExchangeSet;
 import com.esri.arcgisruntime.layers.EncLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.DrawStatus;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -63,6 +64,10 @@ public class AddEncExchangeSetSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a map view and add it to the stack pane
       mapView = new MapView();
       stackPane.getChildren().add(mapView);
@@ -83,8 +88,8 @@ public class AddEncExchangeSetSample extends Application {
         }
       });
 
-      // create a map with the Oceans basemap and set it on the map view
-      ArcGISMap map = new ArcGISMap(Basemap.createOceans());
+      // create a map with the oceans basemap style and set it on the map view
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
       mapView.setMap(map);
 
       // load the ENC exchange set from local data

--- a/image_layers/change-sublayer-renderer/build.gradle
+++ b/image_layers/change-sublayer-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/image_layers/change-sublayer-renderer/src/main/java/com/esri/samples/change_sublayer_renderer/ChangeSublayerRendererSample.java
+++ b/image_layers/change-sublayer-renderer/src/main/java/com/esri/samples/change_sublayer_renderer/ChangeSublayerRendererSample.java
@@ -28,12 +28,14 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.layers.ArcGISMapImageLayer;
 import com.esri.arcgisruntime.layers.ArcGISMapImageSublayer;
 import com.esri.arcgisruntime.layers.SublayerList;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.ClassBreaksRenderer;
 import com.esri.arcgisruntime.symbology.ClassBreaksRenderer.ClassBreak;
@@ -63,8 +65,15 @@ public class ChangeSublayerRendererSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map and set it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.Type.STREETS, 48.354406, -99.998267, 2);
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+      map.setInitialViewpoint(new Viewpoint(48.354406, -99.998267, 40000));
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/image_layers/change-sublayer-renderer/src/main/java/com/esri/samples/change_sublayer_renderer/ChangeSublayerRendererSample.java
+++ b/image_layers/change-sublayer-renderer/src/main/java/com/esri/samples/change_sublayer_renderer/ChangeSublayerRendererSample.java
@@ -71,11 +71,13 @@ public class ChangeSublayerRendererSample extends Application {
 
       // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
-      map.setInitialViewpoint(new Viewpoint(48.354406, -99.998267, 40000));
 
       // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(48.354406, -99.998267, 40000));
 
       // create a button to apply the render (set up later)
       Button rendererButton = new Button("Change sublayer renderer");

--- a/image_layers/change-sublayer-renderer/src/main/java/com/esri/samples/change_sublayer_renderer/ChangeSublayerRendererSample.java
+++ b/image_layers/change-sublayer-renderer/src/main/java/com/esri/samples/change_sublayer_renderer/ChangeSublayerRendererSample.java
@@ -69,15 +69,15 @@ public class ChangeSublayerRendererSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(48.354406, -99.998267, 40000));
+      mapView.setViewpoint(new Viewpoint(48.354406, -99.998267, 147914382));
 
       // create a button to apply the render (set up later)
       Button rendererButton = new Button("Change sublayer renderer");
@@ -102,7 +102,7 @@ public class ChangeSublayerRendererSample extends Application {
         }
       });
 
-      // add the layer to the map
+      // add the map image layer to the map's operational layers
       map.getOperationalLayers().add(imageLayer);
 
       // create a class breaks renderer to switch to
@@ -115,7 +115,7 @@ public class ChangeSublayerRendererSample extends Application {
         rendererButton.setDisable(true);
       });
 
-      // add the MapView and checkboxes
+      // add the map view and button to the stack pane
       stackPane.getChildren().addAll(mapView, rendererButton);
       StackPane.setAlignment(rendererButton, Pos.TOP_LEFT);
       StackPane.setMargin(rendererButton, new Insets(10, 0, 0, 10));

--- a/image_layers/map-image-layer-sublayer-visibility/build.gradle
+++ b/image_layers/map-image-layer-sublayer-visibility/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/image_layers/map-image-layer-sublayer-visibility/src/main/java/com/esri/samples/map_image_layer_sublayer_visibility/MapImageLayerSublayerVisibilitySample.java
+++ b/image_layers/map-image-layer-sublayer-visibility/src/main/java/com/esri/samples/map_image_layer_sublayer_visibility/MapImageLayerSublayerVisibilitySample.java
@@ -79,20 +79,20 @@ public class MapImageLayerSublayerVisibilitySample extends Application {
       controlsVBox.getChildren().addAll(citiesBox, continentsBox, worldBox);
       controlsVBox.getChildren().forEach(c -> ((CheckBox) c).setSelected(true));
 
-      // create a map with a basemap style
+      // create a map with the topographic basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(48.354406, -99.998267, 150000000));
+      mapView.setViewpoint(new Viewpoint(48.354406, -99.998267, 147914382));
 
-      // create a Image Layer with dynamically generated ArcGISMap images
+      // create an image Layer with dynamically generated ArcGISMap images
       ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");
 
-      // add world cities layers as ArcGISMap operational layer
+      // add the image layer to the map's operational layers
       map.getOperationalLayers().add(imageLayer);
 
       // set the image layer's opacity so that the basemap is visible behind it
@@ -115,7 +115,7 @@ public class MapImageLayerSublayerVisibilitySample extends Application {
         }
       });
 
-      // add the MapView and checkboxes
+      // add the map view and controls to the stack pane
       stackPane.getChildren().addAll(mapView, controlsVBox);
       StackPane.setAlignment(controlsVBox, Pos.TOP_LEFT);
       StackPane.setMargin(controlsVBox, new Insets(10, 0, 0, 10));

--- a/image_layers/map-image-layer-sublayer-visibility/src/main/java/com/esri/samples/map_image_layer_sublayer_visibility/MapImageLayerSublayerVisibilitySample.java
+++ b/image_layers/map-image-layer-sublayer-visibility/src/main/java/com/esri/samples/map_image_layer_sublayer_visibility/MapImageLayerSublayerVisibilitySample.java
@@ -79,13 +79,15 @@ public class MapImageLayerSublayerVisibilitySample extends Application {
       controlsVBox.getChildren().addAll(citiesBox, continentsBox, worldBox);
       controlsVBox.getChildren().forEach(c -> ((CheckBox) c).setSelected(true));
 
-      // create a map with a basemap style and set an initial viewpoint
+      // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
-      map.setInitialViewpoint(new Viewpoint(48.354406, -99.998267, 150000000));
 
       // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(48.354406, -99.998267, 150000000));
 
       // create a Image Layer with dynamically generated ArcGISMap images
       ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");

--- a/image_layers/map-image-layer-sublayer-visibility/src/main/java/com/esri/samples/map_image_layer_sublayer_visibility/MapImageLayerSublayerVisibilitySample.java
+++ b/image_layers/map-image-layer-sublayer-visibility/src/main/java/com/esri/samples/map_image_layer_sublayer_visibility/MapImageLayerSublayerVisibilitySample.java
@@ -30,11 +30,13 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.layers.ArcGISMapImageLayer;
 import com.esri.arcgisruntime.layers.SublayerList;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MapImageLayerSublayerVisibilitySample extends Application {
@@ -57,6 +59,10 @@ public class MapImageLayerSublayerVisibilitySample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a control panel
       VBox controlsVBox = new VBox(6);
       controlsVBox.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(0,0,0,0.3)"), CornerRadii.EMPTY,
@@ -73,11 +79,12 @@ public class MapImageLayerSublayerVisibilitySample extends Application {
       controlsVBox.getChildren().addAll(citiesBox, continentsBox, worldBox);
       controlsVBox.getChildren().forEach(c -> ((CheckBox) c).setSelected(true));
 
-      // create a map view
-      mapView = new MapView();
+      // create a map with a basemap style and set an initial viewpoint
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
+      map.setInitialViewpoint(new Viewpoint(48.354406, -99.998267, 150000000));
 
-      // create an ArcGISMap with the topographic basemap and set it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 48.354406, -99.998267, 2);
+      // create a map view and set its map
+      mapView = new MapView();
       mapView.setMap(map);
 
       // create a Image Layer with dynamically generated ArcGISMap images

--- a/image_layers/map-image-layer-tables/build.gradle
+++ b/image_layers/map-image-layer-tables/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/image_layers/map-image-layer-tables/src/main/java/com/esri/samples/map_image_layer_tables/MapImageLayerTablesSample.java
+++ b/image_layers/map-image-layer-tables/src/main/java/com/esri/samples/map_image_layer_tables/MapImageLayerTablesSample.java
@@ -29,6 +29,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.arcgisservices.RelationshipInfo;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.ArcGISFeature;
@@ -42,7 +43,7 @@ import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.layers.ArcGISMapImageLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
@@ -84,8 +85,12 @@ public class MapImageLayerTablesSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with a basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createStreetsVector());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // create and add a map image layer to the map
       // the map image layer contains a feature table with related spatial and non-spatial comment features

--- a/image_layers/map-image-layer-tables/src/main/java/com/esri/samples/map_image_layer_tables/MapImageLayerTablesSample.java
+++ b/image_layers/map-image-layer-tables/src/main/java/com/esri/samples/map_image_layer_tables/MapImageLayerTablesSample.java
@@ -89,10 +89,10 @@ public class MapImageLayerTablesSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create and add a map image layer to the map
+      // create and add a map image layer to the map's operational layers
       // the map image layer contains a feature table with related spatial and non-spatial comment features
       ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer(
           "https://sampleserver6.arcgisonline.com/arcgis/rest/services/ServiceRequest/MapServer");
@@ -160,7 +160,7 @@ public class MapImageLayerTablesSample extends Application {
         }
       });
 
-      // add the mapview and controls to the stack pane
+      // add the map view and list view to the stack pane
       stackPane.getChildren().addAll(mapView, commentsListView);
       StackPane.setAlignment(commentsListView, Pos.TOP_LEFT);
       StackPane.setMargin(commentsListView, new Insets(10, 0, 0, 10));

--- a/image_layers/query-map-image-sublayer/build.gradle
+++ b/image_layers/query-map-image-sublayer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/image_layers/query-map-image-sublayer/src/main/java/com/esri/samples/query_map_image_sublayer/QueryMapImageSublayerSample.java
+++ b/image_layers/query-map-image-sublayer/src/main/java/com/esri/samples/query_map_image_sublayer/QueryMapImageSublayerSample.java
@@ -75,19 +75,19 @@ public class QueryMapImageSublayerSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create and add a map image layer to the map
+      // create and add a map image layer to the map's operational layers
       ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer("https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer");
       map.getOperationalLayers().add(imageLayer);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(36.75056, -115.44154, 9000000));
+      mapView.setViewpoint(new Viewpoint(36.75056, -115.44154, 6000000));
 
       // create a graphics overlay to show the results in
       GraphicsOverlay graphicsOverlay = new GraphicsOverlay();

--- a/image_layers/query-map-image-sublayer/src/main/java/com/esri/samples/query_map_image_sublayer/QueryMapImageSublayerSample.java
+++ b/image_layers/query-map-image-sublayer/src/main/java/com/esri/samples/query_map_image_sublayer/QueryMapImageSublayerSample.java
@@ -38,8 +38,6 @@ import com.esri.arcgisruntime.data.Feature;
 import com.esri.arcgisruntime.data.FeatureQueryResult;
 import com.esri.arcgisruntime.data.QueryParameters;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
-import com.esri.arcgisruntime.geometry.Point;
-import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.ArcGISMapImageLayer;
 import com.esri.arcgisruntime.layers.ArcGISMapImageSublayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
@@ -77,19 +75,19 @@ public class QueryMapImageSublayerSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style and set its initial viewpoint
+      // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
-      Point initialLocation = new Point(-12716000.00, 4170400.00, SpatialReferences.getWebMercator());
-      Viewpoint viewpoint = new Viewpoint(initialLocation, 6000000);
-      map.setInitialViewpoint(viewpoint);
 
       // create and add a map image layer to the map
       ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer("https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer");
       map.getOperationalLayers().add(imageLayer);
 
-      // create a map view and set the map to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(36.75056, -115.44154, 9000000));
 
       // create a graphics overlay to show the results in
       GraphicsOverlay graphicsOverlay = new GraphicsOverlay();

--- a/image_layers/query-map-image-sublayer/src/main/java/com/esri/samples/query_map_image_sublayer/QueryMapImageSublayerSample.java
+++ b/image_layers/query-map-image-sublayer/src/main/java/com/esri/samples/query_map_image_sublayer/QueryMapImageSublayerSample.java
@@ -32,6 +32,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.Feature;
 import com.esri.arcgisruntime.data.FeatureQueryResult;
@@ -43,7 +44,7 @@ import com.esri.arcgisruntime.layers.ArcGISMapImageLayer;
 import com.esri.arcgisruntime.layers.ArcGISMapImageSublayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
@@ -72,8 +73,12 @@ public class QueryMapImageSublayerSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with a basemap and set its initial viewpoint
-      ArcGISMap map = new ArcGISMap(Basemap.createStreetsVector());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style and set its initial viewpoint
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
       Point initialLocation = new Point(-12716000.00, 4170400.00, SpatialReferences.getWebMercator());
       Viewpoint viewpoint = new Viewpoint(initialLocation, 6000000);
       map.setInitialViewpoint(viewpoint);

--- a/kml/create-and-save-kml-file/build.gradle
+++ b/kml/create-and-save-kml-file/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/kml/create-and-save-kml-file/src/main/java/com/esri/samples/create_and_save_kml_file/CreateAndSaveKMLFileController.java
+++ b/kml/create-and-save-kml-file/src/main/java/com/esri/samples/create_and_save_kml_file/CreateAndSaveKMLFileController.java
@@ -16,12 +16,13 @@
 
 package com.esri.samples.create_and_save_kml_file;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Geometry;
 import com.esri.arcgisruntime.geometry.GeometryEngine;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.KmlLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.mapping.view.SketchCreationMode;
 import com.esri.arcgisruntime.mapping.view.SketchEditor;
@@ -57,8 +58,12 @@ public class CreateAndSaveKMLFileController {
   @FXML
   public void initialize() {
 
+    // authentication with an API key or named user is required to access basemaps and other location services
+    String yourAPIKey = System.getProperty("apiKey");
+    ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
     // create a map and add it to the map view
-    map = new ArcGISMap(Basemap.createDarkGrayCanvasVector());
+    map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
     mapView.setMap(map);
 
     // create a sketch editor and add it to the map view

--- a/kml/display-kml/build.gradle
+++ b/kml/display-kml/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/kml/display-kml/src/main/java/com/esri/samples/display_kml/DisplayKMLSample.java
+++ b/kml/display-kml/src/main/java/com/esri/samples/display_kml/DisplayKMLSample.java
@@ -67,8 +67,10 @@ public class DisplayKMLSample extends Application {
       ProgressIndicator progressIndicator = new ProgressIndicator();
       progressIndicator.setVisible(false);
 
-      // create a map and add it to the map view
+      // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/kml/display-kml/src/main/java/com/esri/samples/display_kml/DisplayKMLSample.java
+++ b/kml/display-kml/src/main/java/com/esri/samples/display_kml/DisplayKMLSample.java
@@ -28,12 +28,13 @@ import javafx.scene.control.ProgressIndicator;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.KmlLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.ogc.kml.KmlDataset;
 import com.esri.arcgisruntime.portal.Portal;
@@ -58,12 +59,16 @@ public class DisplayKMLSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a progress indicator
       ProgressIndicator progressIndicator = new ProgressIndicator();
       progressIndicator.setVisible(false);
 
       // create a map and add it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.createDarkGrayCanvasVector());
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/kml/display-kml/src/main/java/com/esri/samples/display_kml/DisplayKMLSample.java
+++ b/kml/display-kml/src/main/java/com/esri/samples/display_kml/DisplayKMLSample.java
@@ -67,10 +67,10 @@ public class DisplayKMLSample extends Application {
       ProgressIndicator progressIndicator = new ProgressIndicator();
       progressIndicator.setVisible(false);
 
-      // create a map with a basemap style
+      // create a map with the dark gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/kml/identify-kml-features/build.gradle
+++ b/kml/identify-kml-features/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/kml/identify-kml-features/src/main/java/com/esri/samples/identify_kml_features/IdentifyKMLFeaturesSample.java
+++ b/kml/identify-kml-features/src/main/java/com/esri/samples/identify_kml_features/IdentifyKMLFeaturesSample.java
@@ -65,10 +65,10 @@ public class IdentifyKMLFeaturesSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the dark gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/kml/identify-kml-features/src/main/java/com/esri/samples/identify_kml_features/IdentifyKMLFeaturesSample.java
+++ b/kml/identify-kml-features/src/main/java/com/esri/samples/identify_kml_features/IdentifyKMLFeaturesSample.java
@@ -28,13 +28,14 @@ import javafx.scene.layout.VBox;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.KmlLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.GeoElement;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -60,8 +61,14 @@ public class IdentifyKMLFeaturesSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map and add it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.createDarkGrayCanvasVector());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 


### PR DESCRIPTION
### Description

This PR is for the following sample categories:
- Hydrography
- Image layers
- KML

### General comments on Basemap updates:

It updates `Map` and/or `Basemap` Constructors as per the new design. This may include the following changes depending on the sample:
- Replace `Basemap.Type` with `BasemapStyle`
- If a lat/long/zoom was being set in the `Map` constructor, this is replaced with a `Viewpoint` being set on the `MapView`.
- Any Readme Updates identified

In addition, the samples that include the above changes, or other services requiring an API Key going forward, have the API Key  set within the sample. This will then work in conjunction with the Gradle Task being added in PR 593.

Once 593 is approved and merged into `dev` we will merge those changes into these PRs and then update all the Samples to `100.10.0-xxxx` and do a round of testing of the Samples with all the API Key / Basemap changes at that time. (We have left them as 100.9.0 (in most cases) for now to minimize merge conflicts in the `build.gradle` file).

In the meantime, the updates listed above can be reviewed. Thanks!