### PR TITLE
New Basemaps: Map Category - part 1 of 2

### DIFF
--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2977'
 }
 
 javafx {

--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.10.0-2977'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map/access-load-status/src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java
+++ b/map/access-load-status/src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java
@@ -120,7 +120,7 @@ public class AccessLoadStatusSample extends Application {
       // create a map with the standard imagery basemap style
       map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map/access-load-status/src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java
+++ b/map/access-load-status/src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java
@@ -32,8 +32,9 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class AccessLoadStatusSample extends Application {
@@ -57,6 +58,10 @@ public class AccessLoadStatusSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a control panel
       VBox controlsVBox = new VBox(6);
       controlsVBox.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(0,0,0,0.3)"), CornerRadii.EMPTY,
@@ -74,12 +79,12 @@ public class AccessLoadStatusSample extends Application {
       Button reloadMapButton = new Button("Reload ArcGISMap");
       reloadMapButton.setMaxWidth(Double.MAX_VALUE);
 
-      // reload ArcGISMap when button clicked
+      // reload the map when the button is clicked
       reloadMapButton.setOnAction(event -> {
         loadStatusText.clear();
 
-        // reload the same ArcGISMap
-        map = new ArcGISMap(Basemap.createImagery());
+        // reload the map
+        map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
         map.addLoadStatusChangedListener(e -> {
           String loadingStatus;
@@ -112,10 +117,10 @@ public class AccessLoadStatusSample extends Application {
       // add label, text and button to the control panel
       controlsVBox.getChildren().addAll(loadStatusLabel, loadStatusText, reloadMapButton);
 
-      // create ArcGISMap with the imagery basemap
-      map = new ArcGISMap(Basemap.createImagery());
+      // create a map with the imagery standard basemap style
+      map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // create a view for this ArcGISMap and set ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map/access-load-status/src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java
+++ b/map/access-load-status/src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java
@@ -117,7 +117,7 @@ public class AccessLoadStatusSample extends Application {
       // add label, text and button to the control panel
       controlsVBox.getChildren().addAll(loadStatusLabel, loadStatusText, reloadMapButton);
 
-      // create a map with the imagery standard basemap style
+      // create a map with the standard imagery basemap style
       map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
       // create a map view and set its map

--- a/map/change-basemap/README.md
+++ b/map/change-basemap/README.md
@@ -6,21 +6,21 @@ Change a map's basemap. A basemap is beneath all layers on an `ArcGISMap` and is
 
 ## Use case
 
-Basemaps should selected contextually, for example, in maritime applications, it would be more appropriate to use a basemap of the world's oceans as opposed to a basemap of the world's streets.
+Basemaps should be selected contextually, for example, in maritime applications, it would be more appropriate to use a basemap of the world's oceans as opposed to a basemap of the world's streets.
 
 ## How to use the sample
 
-Select a basemap from the list of available basemaps to set it to the map.
+Select a basemap style from the list to set it to the map.
 
 ## How it works
 
 1. Create an `ArcGISMap` object.
 2. Set the map to the `MapView` object.
-3. Choose a new basemap type with `Basemap.Type` and set it on the map.
+3. Choose a new basemap style with `BasemapStyle` and set it on the map.
 
 ## Relevant API
 * ArcGISMap
-* Basemap
+* BasemapStyle
 * MapView
 
 ## Tags

--- a/map/change-basemap/README.metadata.json
+++ b/map/change-basemap/README.metadata.json
@@ -9,7 +9,7 @@
         "basemap",
         "map",
         "ArcGISMap",
-        "Basemap",
+        "BasemapStyle",
         "MapView"
     ],
     "redirect_from": [
@@ -17,7 +17,7 @@
     ],
     "relevant_apis": [
         "ArcGISMap",
-        "Basemap",
+        "BasemapStyle",
         "MapView"
     ],
     "snippets": [

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2977'
 }
 
 javafx {

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.10.0-2977'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
+++ b/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
@@ -25,18 +25,16 @@ import javafx.scene.control.ListView;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class ChangeBasemapSample extends Application {
 
   private MapView mapView;
   private ArcGISMap map;
-
-  private static final double LATITUDE = 57.5000;
-  private static final double LONGITUDE = -5.0000;
-  private static final int LOD = 6;
 
   @Override
   public void start(Stage stage) {
@@ -53,27 +51,32 @@ public class ChangeBasemapSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // creates a map view
       mapView = new MapView();
 
-      // setup listview of basemaps
-      ListView<Basemap.Type> basemapList = new ListView<>(FXCollections.observableArrayList(Basemap.Type.values()));
-      basemapList.setMaxSize(250, 150);
+      // setup a listview of basemaps styles
+      ListView<BasemapStyle> basemapStyleList = new ListView<>(FXCollections.observableArrayList(BasemapStyle.values()));
+      basemapStyleList.setMaxSize(250, 150);
 
-      // change the basemap when list option is selected
-      basemapList.getSelectionModel().selectedItemProperty().addListener(o -> {
-        String basemapString = basemapList.getSelectionModel().getSelectedItem().toString();
-        map = new ArcGISMap(Basemap.Type.valueOf(basemapString), LATITUDE, LONGITUDE, LOD);
+      // change the basemap when a list option is selected
+      basemapStyleList.getSelectionModel().selectedItemProperty().addListener(o -> {
+        BasemapStyle selectedBasemapStyle = basemapStyleList.getSelectionModel().getSelectedItem();
+        map = new ArcGISMap(selectedBasemapStyle);
+        map.setInitialViewpoint(new Viewpoint(57.5000, -5.0000, 10000000.0));
         mapView.setMap(map);
       });
 
-      // select the first basemap
-      basemapList.getSelectionModel().selectFirst();
+      // select the first basemap style
+      basemapStyleList.getSelectionModel().selectFirst();
 
       // add the map view and control panel to stack pane
-      stackPane.getChildren().addAll(mapView, basemapList);
-      StackPane.setAlignment(basemapList, Pos.TOP_LEFT);
-      StackPane.setMargin(basemapList, new Insets(10, 0, 0, 10));
+      stackPane.getChildren().addAll(mapView, basemapStyleList);
+      StackPane.setAlignment(basemapStyleList, Pos.TOP_LEFT);
+      StackPane.setMargin(basemapStyleList, new Insets(10, 0, 0, 10));
 
     } catch (Exception e) {
       // on any error, display the stack trace.

--- a/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
+++ b/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
@@ -58,25 +58,25 @@ public class ChangeBasemapSample extends Application {
       // creates a map view
       mapView = new MapView();
 
-      // setup a listview of basemaps styles
-      ListView<BasemapStyle> basemapStyleList = new ListView<>(FXCollections.observableArrayList(BasemapStyle.values()));
-      basemapStyleList.setMaxSize(250, 150);
+      // setup a list view of basemap styles
+      ListView<BasemapStyle> basemapStyleListView = new ListView<>(FXCollections.observableArrayList(BasemapStyle.values()));
+      basemapStyleListView.setMaxSize(250, 150);
 
       // change the basemap when a list option is selected
-      basemapStyleList.getSelectionModel().selectedItemProperty().addListener(o -> {
-        BasemapStyle selectedBasemapStyle = basemapStyleList.getSelectionModel().getSelectedItem();
+      basemapStyleListView.getSelectionModel().selectedItemProperty().addListener(o -> {
+        BasemapStyle selectedBasemapStyle = basemapStyleListView.getSelectionModel().getSelectedItem();
         map = new ArcGISMap(selectedBasemapStyle);
         mapView.setMap(map);
         mapView.setViewpoint(new Viewpoint(57.5000, -5.0000, 10000000.0));
       });
 
       // select the first basemap style
-      basemapStyleList.getSelectionModel().selectFirst();
+      basemapStyleListView.getSelectionModel().selectFirst();
 
       // add the map view and control panel to stack pane
-      stackPane.getChildren().addAll(mapView, basemapStyleList);
-      StackPane.setAlignment(basemapStyleList, Pos.TOP_LEFT);
-      StackPane.setMargin(basemapStyleList, new Insets(10, 0, 0, 10));
+      stackPane.getChildren().addAll(mapView, basemapStyleListView);
+      StackPane.setAlignment(basemapStyleListView, Pos.TOP_LEFT);
+      StackPane.setMargin(basemapStyleListView, new Insets(10, 0, 0, 10));
 
     } catch (Exception e) {
       // on any error, display the stack trace.

--- a/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
+++ b/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
@@ -66,8 +66,8 @@ public class ChangeBasemapSample extends Application {
       basemapStyleList.getSelectionModel().selectedItemProperty().addListener(o -> {
         BasemapStyle selectedBasemapStyle = basemapStyleList.getSelectionModel().getSelectedItem();
         map = new ArcGISMap(selectedBasemapStyle);
-        map.setInitialViewpoint(new Viewpoint(57.5000, -5.0000, 10000000.0));
         mapView.setMap(map);
+        mapView.setViewpoint(new Viewpoint(57.5000, -5.0000, 10000000.0));
       });
 
       // select the first basemap style

--- a/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
+++ b/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
@@ -67,7 +67,7 @@ public class ChangeBasemapSample extends Application {
         BasemapStyle selectedBasemapStyle = basemapStyleListView.getSelectionModel().getSelectedItem();
         map = new ArcGISMap(selectedBasemapStyle);
         mapView.setMap(map);
-        mapView.setViewpoint(new Viewpoint(57.5000, -5.0000, 10000000.0));
+        mapView.setViewpoint(new Viewpoint(57.5000, -5.0000, 9244648));
       });
 
       // select the first basemap style

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2977'
 }
 
 javafx {

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.10.0-2977'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map/create-and-save-map/src/main/java/com/esri/samples/create_and_save_map/CreateAndSaveMapController.java
+++ b/map/create-and-save-map/src/main/java/com/esri/samples/create_and_save_map/CreateAndSaveMapController.java
@@ -62,7 +62,7 @@ public class CreateAndSaveMapController {
   @FXML
   private ComboBox<PortalFolder> folderList;
   @FXML
-  private ListView<BasemapStyle> basemapStyleList;
+  private ListView<BasemapStyle> basemapStyleListView;
   @FXML
   private ListView<Layer> layersList;
   @FXML
@@ -81,29 +81,31 @@ public class CreateAndSaveMapController {
     ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
     // set the basemap style options
-    basemapStyleList.getItems().addAll(BasemapStyle.ARCGIS_STREETS, BasemapStyle.ARCGIS_IMAGERY_STANDARD,
-      BasemapStyle.ARCGIS_TOPOGRAPHIC, BasemapStyle.ARCGIS_OCEANS);
+    basemapStyleListView.getItems().addAll(
+      BasemapStyle.ARCGIS_STREETS,
+      BasemapStyle.ARCGIS_IMAGERY_STANDARD,
+      BasemapStyle.ARCGIS_TOPOGRAPHIC,
+      BasemapStyle.ARCGIS_OCEANS);
+
+    basemapStyleListView.setCellFactory(c -> new BasemapCell());
 
     // update the basemap when the selection changes
-    basemapStyleList.getSelectionModel().select(0);
-    basemapStyleList.getSelectionModel().selectedItemProperty()
-      .addListener(o -> map.setBasemap(new Basemap(basemapStyleList.getSelectionModel().getSelectedItem())));
-
-    basemapStyleList.setCellFactory(c -> new BasemapCell());
-    mapView.setMap(map);
+    basemapStyleListView.getSelectionModel().select(0);
+    basemapStyleListView.getSelectionModel().selectedItemProperty()
+      .addListener(o -> map.setBasemap(new Basemap(basemapStyleListView.getSelectionModel().getSelectedItem())));
 
     // create a basemap with the first basemap style option and set it to the map
-    Basemap basemap = new Basemap(basemapStyleList.getSelectionModel().getSelectedItem());
+    Basemap basemap = new Basemap(basemapStyleListView.getSelectionModel().getSelectedItem());
     map = new ArcGISMap(basemap);
     mapView.setMap(map);
 
     // set operational layer options
-    String worldElevationService = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer";
-    ArcGISMapImageLayer worldElevation = new ArcGISMapImageLayer(worldElevationService);
+    ArcGISMapImageLayer worldElevation = new ArcGISMapImageLayer(
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer");
     worldElevation.loadAsync();
 
-    String worldCensusService = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer";
-    ArcGISMapImageLayer worldCensus = new ArcGISMapImageLayer(worldCensusService);
+    ArcGISMapImageLayer worldCensus = new ArcGISMapImageLayer(
+      "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer");
     worldCensus.loadAsync();
 
     layersList.getItems().addAll(worldElevation, worldCensus);

--- a/map/create-and-save-map/src/main/resources/create_and_save_map/main.fxml
+++ b/map/create-and-save-map/src/main/resources/create_and_save_map/main.fxml
@@ -66,7 +66,7 @@
         </VBox>
         <VBox>
             <Label text="Basemap"/>
-            <ListView fx:id="basemapStyleList"/>
+            <ListView fx:id="basemapStyleListView"/>
         </VBox>
         <VBox>
             <Label text="Operational layers"/>

--- a/map/create-and-save-map/src/main/resources/create_and_save_map/main.fxml
+++ b/map/create-and-save-map/src/main/resources/create_and_save_map/main.fxml
@@ -66,7 +66,7 @@
         </VBox>
         <VBox>
             <Label text="Basemap"/>
-            <ListView fx:id="basemapList"/>
+            <ListView fx:id="basemapStyleList"/>
         </VBox>
         <VBox>
             <Label text="Operational layers"/>

--- a/map/display-map/README.md
+++ b/map/display-map/README.md
@@ -14,14 +14,14 @@ Run the sample to view the map. Pan and zoom to navigate the map.
 
 ## How it works
 
-1. Create an ArcGIS map using a default `Basemap` such use `Basemap.createImagery()`.
+1. Create an ArcGIS map using a default `BasemapStyle` such as `BasemapStyle.ARCGIS_IMAGERY_STANDARD`.
 2. Create a `MapView` object to display the map.
 3. Set the map to the map view.
 
 ## Relevant API
 
 * ArcGISMap
-* Basemap
+* BasemapStyle
 * MapView
 
 ## Tags

--- a/map/display-map/README.metadata.json
+++ b/map/display-map/README.metadata.json
@@ -9,7 +9,7 @@
         "basemap",
         "map",
         "ArcGISMap",
-        "Basemap",
+        "BasemapStyle",
         "MapView"
     ],
     "redirect_from": [
@@ -17,7 +17,7 @@
     ],
     "relevant_apis": [
         "ArcGISMap",
-        "Basemap",
+        "BasemapStyle",
         "MapView"
     ],
     "snippets": [

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2977'
 }
 
 javafx {

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.10.0-2977'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map/display-map/src/main/java/com/esri/samples/display_map/DisplayMapSample.java
+++ b/map/display-map/src/main/java/com/esri/samples/display_map/DisplayMapSample.java
@@ -49,14 +49,14 @@ public class DisplayMapSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with the imagery standard basemap style
+      // create a map with the standard imagery basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
-      // add the map view to stack pane
+      // add the map view to the stack pane
       stackPane.getChildren().addAll(mapView);
     } catch (Exception e) {
       // on any error, display the stack trace.

--- a/map/display-map/src/main/java/com/esri/samples/display_map/DisplayMapSample.java
+++ b/map/display-map/src/main/java/com/esri/samples/display_map/DisplayMapSample.java
@@ -21,8 +21,9 @@ import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class DisplayMapSample extends Application {
@@ -44,8 +45,12 @@ public class DisplayMapSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with the imagery basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createImagery());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with the imagery standard basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
       // create a map view and set its map
       mapView = new MapView();


### PR DESCRIPTION
### Description

This PR is for the following sample categories:
- Map category (part 1 of 2)

Notes specific to this PR: 
- Create and Save Map: because getting the name from the new Basemaps has to wait until they load, there is a Basemap being created everytime it's changed at the moment. This has been noted as a possible future optimization to explore further when time allows, but for now, the sample works with the new styles / API key.

### General comments on Basemap updates:

It updates `Map` and/or `Basemap` Constructors as per the new design. This may include the following changes depending on the sample:
- Replace `Basemap.Type` with `BasemapStyle`
- If a lat/long/zoom was being set in the `Map` constructor, this is replaced with a `Viewpoint` being set on the `MapView`.
- Any Readme Updates identified

In addition, the samples that include the above changes, or other services requiring an API Key going forward, have the API Key  set within the sample. This will then work in conjunction with the Gradle Task being added in PR 593.

Once 593 is approved and merged into `dev` we will merge those changes into these PRs and then update all the Samples to `100.10.0-xxxx` and do a round of testing of the Samples with all the API Key / Basemap changes at that time. (We have left them as 100.9.0 (in most cases) for now to minimize merge conflicts in the `build.gradle` file).

In the meantime, the updates listed above can be reviewed. Thanks!