### PR TITLE
New Basemaps: Local Server and Map View Categories

### DIFF
--- a/local_server/local-server-feature-layer/build.gradle
+++ b/local_server/local-server-feature-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/local_server/local-server-feature-layer/src/main/java/com/esri/samples/local_server_feature_layer/LocalServerFeatureLayerSample.java
+++ b/local_server/local-server-feature-layer/src/main/java/com/esri/samples/local_server_feature_layer/LocalServerFeatureLayerSample.java
@@ -71,10 +71,10 @@ public class LocalServerFeatureLayerSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
@@ -108,7 +108,7 @@ public class LocalServerFeatureLayerSample extends Application {
         });
       }
 
-      // add view to application window
+      // add the map view and progress indicator to the stack pane
       stackPane.getChildren().addAll(mapView, featureLayerProgress);
       StackPane.setAlignment(featureLayerProgress, Pos.CENTER);
     } catch (Exception e) {

--- a/local_server/local-server-feature-layer/src/main/java/com/esri/samples/local_server_feature_layer/LocalServerFeatureLayerSample.java
+++ b/local_server/local-server-feature-layer/src/main/java/com/esri/samples/local_server_feature_layer/LocalServerFeatureLayerSample.java
@@ -28,6 +28,7 @@ import javafx.scene.control.ProgressIndicator;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.layers.FeatureLayer;
@@ -37,7 +38,7 @@ import com.esri.arcgisruntime.localserver.LocalServer;
 import com.esri.arcgisruntime.localserver.LocalServerStatus;
 import com.esri.arcgisruntime.localserver.LocalService.StatusChangedEvent;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -66,8 +67,14 @@ public class LocalServerFeatureLayerSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a view with a map and basemap
-      map = new ArcGISMap(Basemap.createStreets());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/local_server/local-server-geoprocessing/build.gradle
+++ b/local_server/local-server-geoprocessing/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/local_server/local-server-geoprocessing/src/main/java/com/esri/samples/local_server_geoprocessing/LocalServerGeoprocessingController.java
+++ b/local_server/local-server-geoprocessing/src/main/java/com/esri/samples/local_server_geoprocessing/LocalServerGeoprocessingController.java
@@ -70,7 +70,7 @@ public class LocalServerGeoprocessingController {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the light gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
 
       // set the map to the map view

--- a/local_server/local-server-geoprocessing/src/main/java/com/esri/samples/local_server_geoprocessing/LocalServerGeoprocessingController.java
+++ b/local_server/local-server-geoprocessing/src/main/java/com/esri/samples/local_server_geoprocessing/LocalServerGeoprocessingController.java
@@ -27,6 +27,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ProgressBar;
 import javafx.scene.control.TextField;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.Job;
 import com.esri.arcgisruntime.data.TileCache;
 import com.esri.arcgisruntime.layers.ArcGISMapImageLayer;
@@ -37,7 +38,7 @@ import com.esri.arcgisruntime.localserver.LocalGeoprocessingService.ServiceType;
 import com.esri.arcgisruntime.localserver.LocalServer;
 import com.esri.arcgisruntime.localserver.LocalServerStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.tasks.geoprocessing.GeoprocessingDouble;
 import com.esri.arcgisruntime.tasks.geoprocessing.GeoprocessingJob;
@@ -65,8 +66,14 @@ public class LocalServerGeoprocessingController {
   public void initialize() {
 
     try {
-      // create a view with a map and basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createLightGrayCanvas());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
+
+      // set the map to the map view
       mapView.setMap(map);
 
       //load tiled layer and zoom to location

--- a/local_server/local-server-map-image-layer/build.gradle
+++ b/local_server/local-server-map-image-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/local_server/local-server-map-image-layer/src/main/java/com/esri/samples/local_server_map_image_layer/LocalServerMapImageLayerSample.java
+++ b/local_server/local-server-map-image-layer/src/main/java/com/esri/samples/local_server_map_image_layer/LocalServerMapImageLayerSample.java
@@ -28,6 +28,7 @@ import javafx.scene.control.ProgressIndicator;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.layers.ArcGISMapImageLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
@@ -36,7 +37,7 @@ import com.esri.arcgisruntime.localserver.LocalServer;
 import com.esri.arcgisruntime.localserver.LocalServerStatus;
 import com.esri.arcgisruntime.localserver.LocalService.StatusChangedEvent;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -64,8 +65,14 @@ public class LocalServerMapImageLayerSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a view with a map and basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createStreets());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/local_server/local-server-map-image-layer/src/main/java/com/esri/samples/local_server_map_image_layer/LocalServerMapImageLayerSample.java
+++ b/local_server/local-server-map-image-layer/src/main/java/com/esri/samples/local_server_map_image_layer/LocalServerMapImageLayerSample.java
@@ -69,10 +69,10 @@ public class LocalServerMapImageLayerSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
@@ -104,7 +104,7 @@ public class LocalServerMapImageLayerSample extends Application {
         });
       }
 
-      // add view to application window with progress bar
+      // add the map view and progress indicator to the stack pane
       stackPane.getChildren().addAll(mapView, imageLayerProgress);
       StackPane.setAlignment(imageLayerProgress, Pos.CENTER);
     } catch (Exception e) {

--- a/map_view/change-viewpoint/build.gradle
+++ b/map_view/change-viewpoint/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map_view/change-viewpoint/src/main/java/com/esri/samples/change_viewpoint/ChangeViewpointSample.java
+++ b/map_view/change-viewpoint/src/main/java/com/esri/samples/change_viewpoint/ChangeViewpointSample.java
@@ -29,13 +29,14 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.PointCollection;
 import com.esri.arcgisruntime.geometry.Polyline;
 import com.esri.arcgisruntime.geometry.SpatialReference;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -61,6 +62,10 @@ public class ChangeViewpointSample extends Application {
       stage.setHeight(700);
       stage.setScene(scene);
       stage.show();
+
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
       // create a control panel
       VBox controlsVBox = new VBox(6);
@@ -111,10 +116,10 @@ public class ChangeViewpointSample extends Application {
       // add controls to the user interface panel
       controlsVBox.getChildren().addAll(animateButton, centerButton, geometryButton);
 
-      // create ArcGISMap with imagery basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createImageryWithLabels());
+      // create a map with an imagery basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY);
 
-      // create a view and set ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map_view/change-viewpoint/src/main/java/com/esri/samples/change_viewpoint/ChangeViewpointSample.java
+++ b/map_view/change-viewpoint/src/main/java/com/esri/samples/change_viewpoint/ChangeViewpointSample.java
@@ -116,10 +116,10 @@ public class ChangeViewpointSample extends Application {
       // add controls to the user interface panel
       controlsVBox.getChildren().addAll(animateButton, centerButton, geometryButton);
 
-      // create a map with an imagery basemap style
+      // create a map with the imagery basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map_view/display-device-location-with-autopan-modes/build.gradle
+++ b/map_view/display-device-location-with-autopan-modes/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.10.0-2934'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map_view/display-device-location-with-autopan-modes/src/main/java/com/esri/samples/display_device_location_with_autopan_modes/DisplayDeviceLocationWithAutopanModesSample.java
+++ b/map_view/display-device-location-with-autopan-modes/src/main/java/com/esri/samples/display_device_location_with_autopan_modes/DisplayDeviceLocationWithAutopanModesSample.java
@@ -74,10 +74,10 @@ public class DisplayDeviceLocationWithAutopanModesSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with the imagery basemap style
+      // create a map with the standard imagery basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // create a map view and add the map to it
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map_view/display-device-location-with-autopan-modes/src/main/java/com/esri/samples/display_device_location_with_autopan_modes/DisplayDeviceLocationWithAutopanModesSample.java
+++ b/map_view/display-device-location-with-autopan-modes/src/main/java/com/esri/samples/display_device_location_with_autopan_modes/DisplayDeviceLocationWithAutopanModesSample.java
@@ -36,6 +36,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Geometry;
 import com.esri.arcgisruntime.geometry.Polyline;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
@@ -43,7 +44,7 @@ import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.location.SimulatedLocationDataSource;
 import com.esri.arcgisruntime.location.SimulationParameters;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.LocationDisplay;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
@@ -69,8 +70,12 @@ public class DisplayDeviceLocationWithAutopanModesSample extends Application {
       stage.show();
       scene.getStylesheets().add(getClass().getResource("/display_device_location_with_autopan_modes/style.css").toExternalForm());
 
-      // create an ArcGISMap with the imagery basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createImagery());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with the imagery basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
       // create a map view and add the map to it
       mapView = new MapView();

--- a/map_view/display-drawing-status/build.gradle
+++ b/map_view/display-drawing-status/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map_view/display-drawing-status/src/main/java/com/esri/samples/display_drawing_status/DisplayDrawingStatusSample.java
+++ b/map_view/display-drawing-status/src/main/java/com/esri/samples/display_drawing_status/DisplayDrawingStatusSample.java
@@ -67,16 +67,6 @@ public class DisplayDrawingStatusSample extends Application {
       // create a map with the topographic basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a starting viewpoint for the map
-      SpatialReference spatialReference = SpatialReferences.getWebMercator();
-      Point bottomLeftPoint = new Point(-1.5054808160556655E7, 2718975.702666207, spatialReference);
-      Point topRightPoint = new Point(-6810317.90634398, 6850505.377826911, spatialReference);
-      Envelope envelope = new Envelope(bottomLeftPoint, topRightPoint);
-      Viewpoint viewpoint = new Viewpoint(envelope);
-
-      // set the initial viewpoint of the map
-      map.setInitialViewpoint(viewpoint);
-
       // create a feature table from a service URL
       final ServiceFeatureTable featureTable = new ServiceFeatureTable(
           "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
@@ -84,12 +74,18 @@ public class DisplayDrawingStatusSample extends Application {
       // create a feature layer from service table
       final FeatureLayer featureLayer = new FeatureLayer(featureTable);
 
-      // add the feature layer to the map
+      // add the feature layer to the map's operational layers
       map.getOperationalLayers().add(featureLayer);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
+
+      // create a viewpoint and set it to the map view
+      Point bottomLeftPoint = new Point(-1.5054808160556655E7, 2718975.702666207, SpatialReferences.getWebMercator());
+      Point topRightPoint = new Point(-6810317.90634398, 6850505.377826911, SpatialReferences.getWebMercator());
+      Envelope envelope = new Envelope(bottomLeftPoint, topRightPoint);
+      mapView.setViewpoint(new Viewpoint(envelope));
 
       mapView.addDrawStatusChangedListener(e -> {
         // check to see if draw status is in progress
@@ -104,7 +100,7 @@ public class DisplayDrawingStatusSample extends Application {
         }
       });
 
-      // add map view and progressBar to stack pane
+      // add the map view and progress bar to stack pane
       stackPane.getChildren().addAll(mapView, progressBar);
       StackPane.setAlignment(progressBar, Pos.TOP_LEFT);
       StackPane.setMargin(progressBar, new Insets(10, 0, 0, 10));

--- a/map_view/display-drawing-status/src/main/java/com/esri/samples/display_drawing_status/DisplayDrawingStatusSample.java
+++ b/map_view/display-drawing-status/src/main/java/com/esri/samples/display_drawing_status/DisplayDrawingStatusSample.java
@@ -24,6 +24,7 @@ import javafx.scene.control.ProgressBar;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.Point;
@@ -31,7 +32,7 @@ import com.esri.arcgisruntime.geometry.SpatialReference;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.DrawStatus;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -55,12 +56,16 @@ public class DisplayDrawingStatusSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create progress bar
       ProgressBar progressBar = new ProgressBar();
       progressBar.setMaxWidth(240.0);
 
-      // create a ArcGISMap with topographic basemap
-      final ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+      // create an ArcGISMap with a topographic basemap style
+      final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // create a starting viewpoint for the ArcGISMap
       SpatialReference spatialReference = SpatialReferences.getWebMercator();

--- a/map_view/display-drawing-status/src/main/java/com/esri/samples/display_drawing_status/DisplayDrawingStatusSample.java
+++ b/map_view/display-drawing-status/src/main/java/com/esri/samples/display_drawing_status/DisplayDrawingStatusSample.java
@@ -64,17 +64,17 @@ public class DisplayDrawingStatusSample extends Application {
       ProgressBar progressBar = new ProgressBar();
       progressBar.setMaxWidth(240.0);
 
-      // create an ArcGISMap with a topographic basemap style
+      // create a map with the topographic basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a starting viewpoint for the ArcGISMap
+      // create a starting viewpoint for the map
       SpatialReference spatialReference = SpatialReferences.getWebMercator();
       Point bottomLeftPoint = new Point(-1.5054808160556655E7, 2718975.702666207, spatialReference);
       Point topRightPoint = new Point(-6810317.90634398, 6850505.377826911, spatialReference);
       Envelope envelope = new Envelope(bottomLeftPoint, topRightPoint);
       Viewpoint viewpoint = new Viewpoint(envelope);
 
-      // set the initial viewpoint of ArcGISMap to viewpoint
+      // set the initial viewpoint of the map
       map.setInitialViewpoint(viewpoint);
 
       // create a feature table from a service URL
@@ -84,13 +84,11 @@ public class DisplayDrawingStatusSample extends Application {
       // create a feature layer from service table
       final FeatureLayer featureLayer = new FeatureLayer(featureTable);
 
-      // add feature layer to ArcGISMap
+      // add the feature layer to the map
       map.getOperationalLayers().add(featureLayer);
 
-      // create a view for this ArcGISMap
+      // create a map view and set its map
       mapView = new MapView();
-
-      // set map to be displayed in map view
       mapView.setMap(map);
 
       mapView.addDrawStatusChangedListener(e -> {

--- a/map_view/display-layer-view-state/build.gradle
+++ b/map_view/display-layer-view-state/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map_view/display-layer-view-state/src/main/java/com/esri/samples/display_layer_view_state/DisplayLayerViewStateSample.java
+++ b/map_view/display-layer-view-state/src/main/java/com/esri/samples/display_layer_view_state/DisplayLayerViewStateSample.java
@@ -75,10 +75,10 @@ public class DisplayLayerViewStateSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create an ArcGISMap with the topographic basemap style
+      // create a map with the topographic basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a map view and set the ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map_view/display-layer-view-state/src/main/java/com/esri/samples/display_layer_view_state/DisplayLayerViewStateSample.java
+++ b/map_view/display-layer-view-state/src/main/java/com/esri/samples/display_layer_view_state/DisplayLayerViewStateSample.java
@@ -78,7 +78,7 @@ public class DisplayLayerViewStateSample extends Application {
       // create a map with the topographic basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map_view/display-layer-view-state/src/main/java/com/esri/samples/display_layer_view_state/DisplayLayerViewStateSample.java
+++ b/map_view/display-layer-view-state/src/main/java/com/esri/samples/display_layer_view_state/DisplayLayerViewStateSample.java
@@ -36,13 +36,14 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.ArcGISRuntimeException;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.LayerViewStatus;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -70,8 +71,12 @@ public class DisplayLayerViewStateSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create an ArcGISMap with the topographic basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create an ArcGISMap with the topographic basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // create a map view and set the ArcGISMap to it
       mapView = new MapView();

--- a/map_view/identify-layers/build.gradle
+++ b/map_view/identify-layers/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map_view/identify-layers/src/main/java/com/esri/samples/identify_layers/IdentifyLayersSample.java
+++ b/map_view/identify-layers/src/main/java/com/esri/samples/identify_layers/IdentifyLayersSample.java
@@ -27,6 +27,7 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.FeatureTable;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
@@ -36,7 +37,7 @@ import com.esri.arcgisruntime.layers.ArcGISMapImageLayer;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -73,8 +74,12 @@ public class IdentifyLayersSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with an initial viewpoint
-      ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style and an initial viewpoint
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
       map.setInitialViewpoint(new Viewpoint(new Point(-10977012.785807, 4514257.550369, SpatialReference.create(3857)), 68015210));
 
       // set the map to a map view

--- a/map_view/identify-layers/src/main/java/com/esri/samples/identify_layers/IdentifyLayersSample.java
+++ b/map_view/identify-layers/src/main/java/com/esri/samples/identify_layers/IdentifyLayersSample.java
@@ -78,13 +78,15 @@ public class IdentifyLayersSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style and an initial viewpoint
+      // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
-      map.setInitialViewpoint(new Viewpoint(new Point(-10977012.785807, 4514257.550369, SpatialReference.create(3857)), 68015210));
 
       // set the map to a map view
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(new Point(-10977012.785807, 4514257.550369, SpatialReference.create(3857)), 68015210));
 
       // add a map image layer with one sublayer visible
       mapImageLayer = new ArcGISMapImageLayer("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");

--- a/map_view/identify-layers/src/main/java/com/esri/samples/identify_layers/IdentifyLayersSample.java
+++ b/map_view/identify-layers/src/main/java/com/esri/samples/identify_layers/IdentifyLayersSample.java
@@ -81,12 +81,12 @@ public class IdentifyLayersSample extends Application {
       // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // set the map to a map view
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(new Point(-10977012.785807, 4514257.550369, SpatialReference.create(3857)), 68015210));
+      mapView.setViewpoint(new Viewpoint(40.26684, -100.98579, 68015210));
 
       // add a map image layer with one sublayer visible
       mapImageLayer = new ArcGISMapImageLayer("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");

--- a/map_view/identify-layers/src/main/java/com/esri/samples/identify_layers/IdentifyLayersSample.java
+++ b/map_view/identify-layers/src/main/java/com/esri/samples/identify_layers/IdentifyLayersSample.java
@@ -78,10 +78,10 @@ public class IdentifyLayersSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the topographic basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
@@ -101,7 +101,7 @@ public class IdentifyLayersSample extends Application {
       });
       map.getOperationalLayers().add(mapImageLayer);
 
-      // add a feature layer
+      // add a feature layer to the map's operational layers
       FeatureTable featureTable = new ServiceFeatureTable("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
       featureLayer = new FeatureLayer(featureTable);
       featureLayer.addDoneLoadingListener(() -> {

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map_view/map-rotation/src/main/java/com/esri/samples/map_rotation/MapRotationSample.java
+++ b/map_view/map-rotation/src/main/java/com/esri/samples/map_rotation/MapRotationSample.java
@@ -75,7 +75,7 @@ public class MapRotationSample extends Application {
         mapView.setViewpointRotationAsync(slider.getValue());
       });
 
-      // create a ArcGISMap with a basemap style
+      // create a map with a basemap style
       map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // enable slider when map view is done loading
@@ -88,7 +88,7 @@ public class MapRotationSample extends Application {
         }
       });
 
-      // create a view and add an ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map_view/map-rotation/src/main/java/com/esri/samples/map_rotation/MapRotationSample.java
+++ b/map_view/map-rotation/src/main/java/com/esri/samples/map_rotation/MapRotationSample.java
@@ -25,13 +25,14 @@ import javafx.scene.control.Slider;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.SpatialReference;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.toolkit.Compass;
@@ -56,6 +57,10 @@ public class MapRotationSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a slider with a range of 360 units and start it half way
       Slider slider = new Slider(-180.0, 180.0, 0.0);
       slider.setMaxWidth(240.0);
@@ -70,8 +75,8 @@ public class MapRotationSample extends Application {
         mapView.setViewpointRotationAsync(slider.getValue());
       });
 
-      // create a ArcGISMap with topographic basemap
-      map = new ArcGISMap(Basemap.createStreetsVector());
+      // create a ArcGISMap with a basemap style
+      map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // enable slider when map view is done loading
       map.addDoneLoadingListener(() -> {
@@ -83,7 +88,7 @@ public class MapRotationSample extends Application {
         }
       });
 
-      // create a view and add a ArcGISMap to it
+      // create a view and add an ArcGISMap to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map_view/map-rotation/src/main/java/com/esri/samples/map_rotation/MapRotationSample.java
+++ b/map_view/map-rotation/src/main/java/com/esri/samples/map_rotation/MapRotationSample.java
@@ -75,7 +75,7 @@ public class MapRotationSample extends Application {
         mapView.setViewpointRotationAsync(slider.getValue());
       });
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // enable slider when map view is done loading
@@ -88,7 +88,7 @@ public class MapRotationSample extends Application {
         }
       });
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map_view/scale-bar/src/main/java/com/esri/samples/scale_bar/ScaleBarSample.java
+++ b/map_view/scale-bar/src/main/java/com/esri/samples/scale_bar/ScaleBarSample.java
@@ -27,9 +27,11 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.UnitSystem;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.toolkit.Scalebar;
 
@@ -51,9 +53,16 @@ public class ScaleBarSample extends Application {
     stage.setScene(scene);
     stage.show();
 
-    // create a map view
+    // authentication with an API key or named user is required to access basemaps and other location services
+    String yourAPIKey = System.getProperty("apiKey");
+    ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+    // create a map with a basemap style
+    ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
+    map.setInitialViewpoint(new Viewpoint(64.1405, -16.2426, 9000));
+
+    // create a map view and set its map
     mapView = new MapView();
-    ArcGISMap map = new ArcGISMap(Basemap.Type.IMAGERY, 64.1405, -16.2426, 16);
     mapView.setMap(map);
 
     // create a scale bar for the map view

--- a/map_view/scale-bar/src/main/java/com/esri/samples/scale_bar/ScaleBarSample.java
+++ b/map_view/scale-bar/src/main/java/com/esri/samples/scale_bar/ScaleBarSample.java
@@ -57,15 +57,15 @@ public class ScaleBarSample extends Application {
     String yourAPIKey = System.getProperty("apiKey");
     ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-    // create a map with a basemap style
+    // create a map with the standard imagery basemap style
     ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-    // create a map view and set its map
+    // create a map view and set the map to it
     mapView = new MapView();
     mapView.setMap(map);
 
     // set a viewpoint on the map view
-    mapView.setViewpoint(new Viewpoint(64.1405, -16.2426, 9000));
+    mapView.setViewpoint(new Viewpoint(64.1405, -16.2426, 9028));
 
     // create a scale bar for the map view
     Scalebar scaleBar = new Scalebar(mapView);

--- a/map_view/scale-bar/src/main/java/com/esri/samples/scale_bar/ScaleBarSample.java
+++ b/map_view/scale-bar/src/main/java/com/esri/samples/scale_bar/ScaleBarSample.java
@@ -57,13 +57,15 @@ public class ScaleBarSample extends Application {
     String yourAPIKey = System.getProperty("apiKey");
     ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-    // create a map with a basemap style and an initial viewpoint
+    // create a map with a basemap style
     ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
-    map.setInitialViewpoint(new Viewpoint(64.1405, -16.2426, 9000));
 
     // create a map view and set its map
     mapView = new MapView();
     mapView.setMap(map);
+
+    // set a viewpoint on the map view
+    mapView.setViewpoint(new Viewpoint(64.1405, -16.2426, 9000));
 
     // create a scale bar for the map view
     Scalebar scaleBar = new Scalebar(mapView);

--- a/map_view/scale-bar/src/main/java/com/esri/samples/scale_bar/ScaleBarSample.java
+++ b/map_view/scale-bar/src/main/java/com/esri/samples/scale_bar/ScaleBarSample.java
@@ -57,7 +57,7 @@ public class ScaleBarSample extends Application {
     String yourAPIKey = System.getProperty("apiKey");
     ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-    // create a map with a basemap style
+    // create a map with a basemap style and an initial viewpoint
     ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
     map.setInitialViewpoint(new Viewpoint(64.1405, -16.2426, 9000));
 

--- a/map_view/show-location-history/build.gradle
+++ b/map_view/show-location-history/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.10.0-2902'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java
+++ b/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java
@@ -36,6 +36,7 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Geometry;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.Polyline;
@@ -47,7 +48,7 @@ import com.esri.arcgisruntime.location.LocationDataSource.LocationChangedListene
 import com.esri.arcgisruntime.location.SimulatedLocationDataSource;
 import com.esri.arcgisruntime.location.SimulationParameters;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
@@ -81,8 +82,12 @@ public class ShowLocationHistorySample extends Application {
       stage.show();
       scene.getStylesheets().add(getClass().getResource("/show_location_history/style.css").toExternalForm());
 
-      // create a map with a dark gray canvas basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createDarkGrayCanvasVector());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a dark gray basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
 
       // create a map view and set its map
       mapView = new MapView();

--- a/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java
+++ b/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java
@@ -89,13 +89,12 @@ public class ShowLocationHistorySample extends Application {
       // create a map with the dark gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
-      // set the map views's viewpoint centered on Los Angeles, California and scaled
-      mapView.setViewpoint(new Viewpoint(new Point(-13185535.98, 4037766.28,
-        SpatialReferences.getWebMercator()), 7000));
+      // set a viewpoint on the map view centered on Los Angeles, California
+      mapView.setViewpoint(new Viewpoint(new Point(-13185535.98, 4037766.28, SpatialReferences.getWebMercator()), 7000));
 
       // create a label
       Label trackingLabel = new Label("Tracking Status: ");

--- a/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java
+++ b/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java
@@ -86,7 +86,7 @@ public class ShowLocationHistorySample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a dark gray basemap style
+      // create a map with the dark gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
 
       // create a map view and set its map

--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/map_view/take-screenshot/src/main/java/com/esri/samples/take_screenshot/TakeScreenshotSample.java
+++ b/map_view/take-screenshot/src/main/java/com/esri/samples/take_screenshot/TakeScreenshotSample.java
@@ -61,10 +61,10 @@ public class TakeScreenshotSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create map with a basemap style
+      // create map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/map_view/take-screenshot/src/main/java/com/esri/samples/take_screenshot/TakeScreenshotSample.java
+++ b/map_view/take-screenshot/src/main/java/com/esri/samples/take_screenshot/TakeScreenshotSample.java
@@ -32,9 +32,10 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class TakeScreenshotSample extends Application {
@@ -56,8 +57,14 @@ public class TakeScreenshotSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create map and set to map view
-      ArcGISMap map = new ArcGISMap(Basemap.createStreets());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 


### PR DESCRIPTION
### Description

This PR is for the following sample categories:
- Local Server
- Map View

### General comments on Basemap updates:

It updates `Map` and/or `Basemap` Constructors as per the new design. This may include the following changes depending on the sample:
- Replace `Basemap.Type` with `BasemapStyle`
- If a lat/long/zoom was being set in the `Map` constructor, this is replaced with a `Viewpoint` being set on the `MapView`.
- Any Readme Updates identified

In addition, the samples that include the above changes, or other services requiring an API Key going forward, have the API Key  set within the sample. This will then work in conjunction with the Gradle Task being added in PR 593.

Once 593 is approved and merged into `dev` we will merge those changes into these PRs and then update all the Samples to `100.10.0-xxxx` and do a round of testing of the Samples with all the API Key / Basemap changes at that time. (We have left them as 100.9.0 (in most cases) for now to minimize merge conflicts in the `build.gradle` file).

In the meantime, the updates listed above can be reviewed. Thanks!