### PR TITLE
New Basemaps: Portal and Raster Categories

### DIFF
--- a/portal/integrated-windows-authentication/build.gradle
+++ b/portal/integrated-windows-authentication/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/portal/integrated-windows-authentication/src/main/java/com/esri/samples/integrated_windows_authentication/IntegratedWindowsAuthenticationController.java
+++ b/portal/integrated-windows-authentication/src/main/java/com/esri/samples/integrated_windows_authentication/IntegratedWindowsAuthenticationController.java
@@ -55,7 +55,7 @@ public class IntegratedWindowsAuthenticationController {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // set the map to the map view

--- a/portal/integrated-windows-authentication/src/main/java/com/esri/samples/integrated_windows_authentication/IntegratedWindowsAuthenticationController.java
+++ b/portal/integrated-windows-authentication/src/main/java/com/esri/samples/integrated_windows_authentication/IntegratedWindowsAuthenticationController.java
@@ -26,10 +26,11 @@ import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.TextField;
 import javafx.scene.text.Text;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.DrawStatus;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.portal.Portal;
@@ -50,9 +51,14 @@ public class IntegratedWindowsAuthenticationController {
 
   public void initialize() {
     try {
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // add a map to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.createStreets());
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+
+      // set the map to the map view
       mapView.setMap(map);
 
       // set authentication challenge handler

--- a/portal/oauth/README.md
+++ b/portal/oauth/README.md
@@ -10,7 +10,7 @@ Your app may need to access items that are only shared with authorized users. Fo
 
 ## How to use the sample
 
-When you run the sample, the app will load a web map which contains premium content. You will be challenged for an ArcGIS Online login to view the private layers. Enter a user name and password for an ArcGIS Online named user account (such as your ArcGIS for Developers account). If you authenticate successfully, the traffic layer will display, otherwise the map will contain only the public basemap layer.
+When you run the sample, the app will load a web map which contains premium content. You will be challenged for an ArcGIS Online login to view the private layers. Enter a user name and password for an ArcGIS Online named user account (such as your ArcGIS for Developers account). If you authenticate successfully, the traffic layer will display, otherwise the map will contain only the public basemap style layer.
 
 ## How it works
 

--- a/portal/oauth/README.md
+++ b/portal/oauth/README.md
@@ -10,7 +10,7 @@ Your app may need to access items that are only shared with authorized users. Fo
 
 ## How to use the sample
 
-When you run the sample, the app will load a web map which contains premium content. You will be challenged for an ArcGIS Online login to view the private layers. Enter a user name and password for an ArcGIS Online named user account (such as your ArcGIS for Developers account). If you authenticate successfully, the traffic layer will display, otherwise the map will contain only the public basemap style layer.
+When you run the sample, the app will load a web map which contains premium content. You will be challenged for an ArcGIS Online login to view the private layers. Enter a user name and password for an ArcGIS Online named user account (such as your ArcGIS for Developers account). If you authenticate successfully, the traffic layer will display, otherwise the map will contain only the basemap style layer.
 
 ## How it works
 

--- a/portal/oauth/build.gradle
+++ b/portal/oauth/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/portal/oauth/src/main/java/com/esri/samples/oauth/OAuthSample.java
+++ b/portal/oauth/src/main/java/com/esri/samples/oauth/OAuthSample.java
@@ -54,7 +54,7 @@ public class OAuthSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with an imagery basemap style
+      // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
       // set the map to the map view

--- a/portal/oauth/src/main/java/com/esri/samples/oauth/OAuthSample.java
+++ b/portal/oauth/src/main/java/com/esri/samples/oauth/OAuthSample.java
@@ -54,10 +54,10 @@ public class OAuthSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the standard imagery basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // set the map to the map view
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/portal/oauth/src/main/java/com/esri/samples/oauth/OAuthSample.java
+++ b/portal/oauth/src/main/java/com/esri/samples/oauth/OAuthSample.java
@@ -21,8 +21,9 @@ import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.portal.Portal;
 import com.esri.arcgisruntime.portal.PortalItem;
@@ -49,8 +50,12 @@ public class OAuthSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with imagery basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createImagery());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with an imagery basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
       // set the map to the map view
       mapView = new MapView();

--- a/raster/colormap-renderer/build.gradle
+++ b/raster/colormap-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/raster/colormap-renderer/src/main/java/com/esri/samples/colormap_renderer/ColormapRendererSample.java
+++ b/raster/colormap-renderer/src/main/java/com/esri/samples/colormap_renderer/ColormapRendererSample.java
@@ -65,14 +65,14 @@ public class ColormapRendererSample extends Application {
       // create a raster layer
       RasterLayer rasterLayer = new RasterLayer(raster);
 
-      // create a map with an imagery basemap style
+      // create a map with the standard imagery basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // add the map to a map view
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
-      // add the raster as an operational layer
+      // add the raster to the map's operational layers
       map.getOperationalLayers().add(rasterLayer);
 
       // create a color map where values 0-149 are red (0xFFFF0000) and 150-250 are yellow (0xFFFFFF00)

--- a/raster/colormap-renderer/src/main/java/com/esri/samples/colormap_renderer/ColormapRendererSample.java
+++ b/raster/colormap-renderer/src/main/java/com/esri/samples/colormap_renderer/ColormapRendererSample.java
@@ -27,10 +27,11 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.raster.ColormapRenderer;
 import com.esri.arcgisruntime.raster.Raster;
@@ -54,14 +55,18 @@ public class ColormapRendererSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a raster from a local raster file
       Raster raster = new Raster(new File(System.getProperty("data.dir"), "./samples-data/raster/ShastaBW.tif").getAbsolutePath());
 
       // create a raster layer
       RasterLayer rasterLayer = new RasterLayer(raster);
 
-      // create a Map with imagery basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createImagery());
+      // create a map with an imagery basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
       // add the map to a map view
       mapView = new MapView();

--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/raster/identify-raster-cell/src/main/java/com/esri/samples/identify_raster_cell/IdentifyRasterCellSample.java
+++ b/raster/identify-raster-cell/src/main/java/com/esri/samples/identify_raster_cell/IdentifyRasterCellSample.java
@@ -45,182 +45,182 @@ import com.esri.arcgisruntime.raster.RasterCell;
 
 public class IdentifyRasterCellSample extends Application {
 
-    private boolean calloutLocked = false;
-    private Callout callout;
-    private MapView mapView;
-    private RasterLayer rasterLayer;
+  private boolean calloutLocked = false;
+  private Callout callout;
+  private MapView mapView;
+  private RasterLayer rasterLayer;
 
-    @Override
-    public void start(Stage stage) {
+  @Override
+  public void start(Stage stage) {
 
-        try {
-            // create stack pane and application scene
-            StackPane stackPane = new StackPane();
-            Scene scene = new Scene(stackPane);
+    try {
+      // create stack pane and application scene
+      StackPane stackPane = new StackPane();
+      Scene scene = new Scene(stackPane);
 
-            // set title, size, and add scene to stage
-            stage.setTitle("Identify Raster Cell Sample");
-            stage.setWidth(800);
-            stage.setHeight(700);
-            stage.setScene(scene);
-            stage.show();
+      // set title, size, and add scene to stage
+      stage.setTitle("Identify Raster Cell Sample");
+      stage.setWidth(800);
+      stage.setHeight(700);
+      stage.setScene(scene);
+      stage.show();
 
-            // authentication with an API key or named user is required to access basemaps and other location services
-            String yourAPIKey = System.getProperty("apiKey");
-            ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-            // create a map with an oceans basemap style
-            ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
+      // create a map with an oceans basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
 
-            // create a map view and set its map
-            mapView = new MapView();
-            mapView.setMap(map);
+      // create a map view and set its map
+      mapView = new MapView();
+      mapView.setMap(map);
 
-            // create a raster from a local raster file
-            Raster raster = new Raster(new File(System.getProperty("data.dir"), "./samples-data/SA_EVI_8Day_03May20/SA_EVI_8Day_03May20.tif").getAbsolutePath());
+      // create a raster from a local raster file
+      Raster raster = new Raster(new File(System.getProperty("data.dir"), "./samples-data/SA_EVI_8Day_03May20/SA_EVI_8Day_03May20.tif").getAbsolutePath());
 
-            // create a raster layer
-            rasterLayer = new RasterLayer(raster);
+      // create a raster layer
+      rasterLayer = new RasterLayer(raster);
 
-            // add the raster as an operational layer
-            map.getOperationalLayers().add(rasterLayer);
+      // add the raster as an operational layer
+      map.getOperationalLayers().add(rasterLayer);
 
-            // set viewpoint on the raster
-            rasterLayer.addDoneLoadingListener(() -> {
-                if (map.getLoadStatus() == LoadStatus.LOADED) {
-                    mapView.setViewpointGeometryAsync(rasterLayer.getFullExtent(), 50);
-                } else {
-                    Alert alert = new Alert(Alert.AlertType.ERROR, "Raster Layer Failed to Load!");
-                    alert.show();
-                }
-            });
-
-            // get a handle on the callout
-            callout = mapView.getCallout();
-            callout.setTitle("Raster cell attributes:");
-            // make the callout transparent to mouse interactions, so that we keep identifying raster cells behind it
-            callout.setMouseTransparent(true);
-
-            // start identifying on-the-fly if the mouse enters the map view, and the callout is not locked
-            mapView.setOnMouseEntered(mouseEvent -> {
-                if (!calloutLocked) {
-                    mapView.setOnMouseMoved(this::identifyRasterCell);
-                }
-            });
-
-            // stop identifying on-the-fly when the mouse leaves the map view
-            mapView.setOnMouseExited(null);
-
-            // on click, either lock the callout in place if raster cells are identified on-the-fly,
-            // or release the callout again and start identifying on-the-fly
-            mapView.setOnMouseClicked(mouseEvent -> {
-                if (mouseEvent.getButton() == MouseButton.PRIMARY && mouseEvent.isStillSincePress()) {
-
-                    if (!calloutLocked) {
-                        // stop identifying on the fly
-                        mapView.setOnMouseMoved(null);
-                        // lock the callout in place
-                        calloutLocked = true;
-
-                    } else {
-                        // dismiss the callout
-                        callout.dismiss();
-                        // unlock the callout
-                        calloutLocked = false;
-                        // show a new callout at the clicked location
-                        identifyRasterCell(mouseEvent);
-                        // start identifying on-the-fly
-                        mapView.setOnMouseMoved(this::identifyRasterCell);
-                    }
-                }
-            });
-
-            // add the map view to stack pane
-            stackPane.getChildren().addAll(mapView);
-
-        } catch (Exception e) {
-            // on any error, display the stack trace
-            e.printStackTrace();
+      // set viewpoint on the raster
+      rasterLayer.addDoneLoadingListener(() -> {
+        if (map.getLoadStatus() == LoadStatus.LOADED) {
+          mapView.setViewpointGeometryAsync(rasterLayer.getFullExtent(), 50);
+        } else {
+          Alert alert = new Alert(Alert.AlertType.ERROR, "Raster Layer Failed to Load!");
+          alert.show();
         }
-    }
+      });
 
-    /**
-     * Identifies the raster cell at the mouse event's location and displays a callout at that location.
-     *
-     * @param mouseEvent the mouse event used to identify the raster cell and show the callout
-     */
-    private void identifyRasterCell(MouseEvent mouseEvent) {
+      // get a handle on the callout
+      callout = mapView.getCallout();
+      callout.setTitle("Raster cell attributes:");
+      // make the callout transparent to mouse interactions, so that we keep identifying raster cells behind it
+      callout.setMouseTransparent(true);
 
-        // get the map point where the user clicked
-        Point2D point = new Point2D(mouseEvent.getX(), mouseEvent.getY());
-        Point mapPoint = mapView.screenToLocation(point);
-
-        // identify the layers at the clicked location
-        ListenableFuture<IdentifyLayerResult> identifyLayerResultFuture
-                = mapView.identifyLayerAsync(rasterLayer, point, 10, false, 1);
-
-        identifyLayerResultFuture.addDoneListener(() -> {
-            try {
-                // get the result of the query
-                IdentifyLayerResult identifyLayerResult = identifyLayerResultFuture.get();
-
-                // get the read only list of geo-elements (they contain RasterCells)
-                List<GeoElement> geoElements = identifyLayerResult.getElements();
-
-                // create a StringBuilder to display information to the user
-                StringBuilder stringBuilder = new StringBuilder();
-
-                // loop through each RasterCell
-                for (GeoElement geoElement : geoElements) {
-
-                    if (geoElement instanceof RasterCell) {
-                        RasterCell rasterCell = (RasterCell) geoElement;
-
-                        // loop through the attributes (key/value pairs)
-                        rasterCell.getAttributes().forEach((key, value) ->
-                                // add the key-value pair to the string builder
-                                stringBuilder.append(key).append(": ").append(value).append("\n")
-                        );
-
-                        // get and format the X and Y values for the cell
-                        double x = rasterCell.getGeometry().getExtent().getXMin();
-                        double y = rasterCell.getGeometry().getExtent().getYMin();
-                        String string = "X: " + Math.round(x) + " Y: " + Math.round(y);
-
-                        // add the X & Y coordinates where the user clicked raster cell to the string builder
-                        stringBuilder.append(string);
-
-                        // define a callout based on the string builder
-                        callout.setDetail(stringBuilder.toString());
-                        callout.showCalloutAt(mapPoint);
-                    }
-                }
-            } catch (InterruptedException | ExecutionException e) {
-                new Alert(Alert.AlertType.ERROR, "Error identifying layer").show();
-            }
-        });
-
-    }
-
-    /**
-     * Stops and releases all resources used in application.
-     */
-    @Override
-    public void stop() {
-
-        if (mapView != null) {
-            mapView.dispose();
+      // start identifying on-the-fly if the mouse enters the map view, and the callout is not locked
+      mapView.setOnMouseEntered(mouseEvent -> {
+        if (!calloutLocked) {
+          mapView.setOnMouseMoved(this::identifyRasterCell);
         }
-    }
+      });
 
-    /**
-     * Opens and runs application.
-     *
-     * @param args arguments passed to this application
-     */
-    public static void main(String[] args) {
+      // stop identifying on-the-fly when the mouse leaves the map view
+      mapView.setOnMouseExited(null);
 
-        Application.launch(args);
+      // on click, either lock the callout in place if raster cells are identified on-the-fly,
+      // or release the callout again and start identifying on-the-fly
+      mapView.setOnMouseClicked(mouseEvent -> {
+        if (mouseEvent.getButton() == MouseButton.PRIMARY && mouseEvent.isStillSincePress()) {
+
+          if (!calloutLocked) {
+            // stop identifying on the fly
+            mapView.setOnMouseMoved(null);
+            // lock the callout in place
+            calloutLocked = true;
+
+          } else {
+            // dismiss the callout
+            callout.dismiss();
+            // unlock the callout
+            calloutLocked = false;
+            // show a new callout at the clicked location
+            identifyRasterCell(mouseEvent);
+            // start identifying on-the-fly
+            mapView.setOnMouseMoved(this::identifyRasterCell);
+          }
+        }
+      });
+
+      // add the map view to stack pane
+      stackPane.getChildren().addAll(mapView);
+
+    } catch (Exception e) {
+      // on any error, display the stack trace
+      e.printStackTrace();
     }
+  }
+
+  /**
+   * Identifies the raster cell at the mouse event's location and displays a callout at that location.
+   *
+   * @param mouseEvent the mouse event used to identify the raster cell and show the callout
+   */
+  private void identifyRasterCell(MouseEvent mouseEvent) {
+
+    // get the map point where the user clicked
+    Point2D point = new Point2D(mouseEvent.getX(), mouseEvent.getY());
+    Point mapPoint = mapView.screenToLocation(point);
+
+    // identify the layers at the clicked location
+    ListenableFuture<IdentifyLayerResult> identifyLayerResultFuture
+      = mapView.identifyLayerAsync(rasterLayer, point, 10, false, 1);
+
+    identifyLayerResultFuture.addDoneListener(() -> {
+      try {
+        // get the result of the query
+        IdentifyLayerResult identifyLayerResult = identifyLayerResultFuture.get();
+
+        // get the read only list of geo-elements (they contain RasterCells)
+        List<GeoElement> geoElements = identifyLayerResult.getElements();
+
+        // create a StringBuilder to display information to the user
+        StringBuilder stringBuilder = new StringBuilder();
+
+        // loop through each RasterCell
+        for (GeoElement geoElement : geoElements) {
+
+          if (geoElement instanceof RasterCell) {
+            RasterCell rasterCell = (RasterCell) geoElement;
+
+            // loop through the attributes (key/value pairs)
+            rasterCell.getAttributes().forEach((key, value) ->
+              // add the key-value pair to the string builder
+              stringBuilder.append(key).append(": ").append(value).append("\n")
+            );
+
+            // get and format the X and Y values for the cell
+            double x = rasterCell.getGeometry().getExtent().getXMin();
+            double y = rasterCell.getGeometry().getExtent().getYMin();
+            String string = "X: " + Math.round(x) + " Y: " + Math.round(y);
+
+            // add the X & Y coordinates where the user clicked raster cell to the string builder
+            stringBuilder.append(string);
+
+            // define a callout based on the string builder
+            callout.setDetail(stringBuilder.toString());
+            callout.showCalloutAt(mapPoint);
+          }
+        }
+      } catch (InterruptedException | ExecutionException e) {
+        new Alert(Alert.AlertType.ERROR, "Error identifying layer").show();
+      }
+    });
+
+  }
+
+  /**
+   * Stops and releases all resources used in application.
+   */
+  @Override
+  public void stop() {
+
+    if (mapView != null) {
+      mapView.dispose();
+    }
+  }
+
+  /**
+   * Opens and runs application.
+   *
+   * @param args arguments passed to this application
+   */
+  public static void main(String[] args) {
+
+    Application.launch(args);
+  }
 
 }

--- a/raster/identify-raster-cell/src/main/java/com/esri/samples/identify_raster_cell/IdentifyRasterCellSample.java
+++ b/raster/identify-raster-cell/src/main/java/com/esri/samples/identify_raster_cell/IdentifyRasterCellSample.java
@@ -69,7 +69,7 @@ public class IdentifyRasterCellSample extends Application {
             String yourAPIKey = System.getProperty("apiKey");
             ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-            // create a ap with an oceans basemap style
+            // create a map with an oceans basemap style
             ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
 
             // create a map view and set its map

--- a/raster/identify-raster-cell/src/main/java/com/esri/samples/identify_raster_cell/IdentifyRasterCellSample.java
+++ b/raster/identify-raster-cell/src/main/java/com/esri/samples/identify_raster_cell/IdentifyRasterCellSample.java
@@ -72,7 +72,7 @@ public class IdentifyRasterCellSample extends Application {
       // create a map with the oceans basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
@@ -82,7 +82,7 @@ public class IdentifyRasterCellSample extends Application {
       // create a raster layer
       rasterLayer = new RasterLayer(raster);
 
-      // add the raster as an operational layer
+      // add the raster layer to the map's operational layers
       map.getOperationalLayers().add(rasterLayer);
 
       // set viewpoint on the raster

--- a/raster/identify-raster-cell/src/main/java/com/esri/samples/identify_raster_cell/IdentifyRasterCellSample.java
+++ b/raster/identify-raster-cell/src/main/java/com/esri/samples/identify_raster_cell/IdentifyRasterCellSample.java
@@ -16,6 +16,10 @@
 
 package com.esri.samples.identify_raster_cell;
 
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
 import javafx.application.Application;
 import javafx.geometry.Point2D;
 import javafx.scene.Scene;
@@ -24,16 +28,14 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
-import java.io.File;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.GeoElement;
 import com.esri.arcgisruntime.mapping.view.Callout;
 import com.esri.arcgisruntime.mapping.view.IdentifyLayerResult;
@@ -63,13 +65,15 @@ public class IdentifyRasterCellSample extends Application {
             stage.setScene(scene);
             stage.show();
 
-            // create a map view
+            // authentication with an API key or named user is required to access basemaps and other location services
+            String yourAPIKey = System.getProperty("apiKey");
+            ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+            // create a ap with an oceans basemap style
+            ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
+
+            // create a map view and set its map
             mapView = new MapView();
-
-            // create a Map with an oceans basemap
-            ArcGISMap map = new ArcGISMap(Basemap.createOceans());
-
-            // add the map to a map view
             mapView.setMap(map);
 
             // create a raster from a local raster file

--- a/raster/identify-raster-cell/src/main/java/com/esri/samples/identify_raster_cell/IdentifyRasterCellSample.java
+++ b/raster/identify-raster-cell/src/main/java/com/esri/samples/identify_raster_cell/IdentifyRasterCellSample.java
@@ -69,7 +69,7 @@ public class IdentifyRasterCellSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with an oceans basemap style
+      // create a map with the oceans basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_OCEANS);
 
       // create a map view and set its map

--- a/raster/raster-function/build.gradle
+++ b/raster/raster-function/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/raster/raster-function/src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java
+++ b/raster/raster-function/src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java
@@ -26,10 +26,11 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.raster.ImageServiceRaster;
 import com.esri.arcgisruntime.raster.Raster;
@@ -56,10 +57,14 @@ public class RasterFunctionSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with dark canvas vector basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createDarkGrayCanvasVector());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // add the map to a map view
+      // create a map with a dark gray basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/raster/raster-function/src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java
+++ b/raster/raster-function/src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java
@@ -61,10 +61,10 @@ public class RasterFunctionSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the dark gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/raster/raster-function/src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java
+++ b/raster/raster-function/src/main/java/com/esri/samples/raster_function/RasterFunctionSample.java
@@ -61,7 +61,7 @@ public class RasterFunctionSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a dark gray basemap style
+      // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
 
       // create a map view and set its map

--- a/raster/raster-layer-file/build.gradle
+++ b/raster/raster-layer-file/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/raster/raster-layer-file/src/main/java/com/esri/samples/raster_layer_file/RasterLayerFileSample.java
+++ b/raster/raster-layer-file/src/main/java/com/esri/samples/raster_layer_file/RasterLayerFileSample.java
@@ -61,14 +61,14 @@ public class RasterLayerFileSample extends Application {
       // create a raster layer
       RasterLayer rasterLayer = new RasterLayer(raster);
 
-      // create a map with an imagery basemap style
+      // create a map with the standard imagery basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // add the map to a map view
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
-      // add the raster as an operational layer
+      // add the raster layer to the map's operational layers
       map.getOperationalLayers().add(rasterLayer);
 
       // set viewpoint on the raster

--- a/raster/raster-layer-file/src/main/java/com/esri/samples/raster_layer_file/RasterLayerFileSample.java
+++ b/raster/raster-layer-file/src/main/java/com/esri/samples/raster_layer_file/RasterLayerFileSample.java
@@ -24,10 +24,11 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.raster.Raster;
 
@@ -50,14 +51,18 @@ public class RasterLayerFileSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a raster from a local raster file
       Raster raster = new Raster(new File(System.getProperty("data.dir"), "./samples-data/raster/Shasta.tif").getAbsolutePath());
 
       // create a raster layer
       RasterLayer rasterLayer = new RasterLayer(raster);
 
-      // create a Map with imagery basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createImagery());
+      // create a map with an imagery basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
       // add the map to a map view
       mapView = new MapView();

--- a/raster/raster-layer-geopackage/build.gradle
+++ b/raster/raster-layer-geopackage/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/raster/raster-layer-geopackage/src/main/java/com/esri/samples/raster_layer_geopackage/RasterLayerGeopackageSample.java
+++ b/raster/raster-layer-geopackage/src/main/java/com/esri/samples/raster_layer_geopackage/RasterLayerGeopackageSample.java
@@ -57,10 +57,10 @@ public class RasterLayerGeopackageSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a light gray basemap style
+      // create a map with the light gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/raster/raster-layer-geopackage/src/main/java/com/esri/samples/raster_layer_geopackage/RasterLayerGeopackageSample.java
+++ b/raster/raster-layer-geopackage/src/main/java/com/esri/samples/raster_layer_geopackage/RasterLayerGeopackageSample.java
@@ -24,11 +24,12 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.GeoPackage;
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.raster.GeoPackageRaster;
 
@@ -52,8 +53,14 @@ public class RasterLayerGeopackageSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with light gray canvas vector basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createLightGrayCanvasVector());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a light gray basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_LIGHT_GRAY);
+
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/raster/raster-layer-url/build.gradle
+++ b/raster/raster-layer-url/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/raster/raster-layer-url/src/main/java/com/esri/samples/raster_layer_url/RasterLayerURLSample.java
+++ b/raster/raster-layer-url/src/main/java/com/esri/samples/raster_layer_url/RasterLayerURLSample.java
@@ -68,10 +68,10 @@ public class RasterLayerURLSample extends Application {
         }
       });
 
-      // create a map with a basemap style
+      // create a map with the dark gray basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
 
-      // add the map to a map view
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/raster/raster-layer-url/src/main/java/com/esri/samples/raster_layer_url/RasterLayerURLSample.java
+++ b/raster/raster-layer-url/src/main/java/com/esri/samples/raster_layer_url/RasterLayerURLSample.java
@@ -68,7 +68,7 @@ public class RasterLayerURLSample extends Application {
         }
       });
 
-      // create a map with dark gray basemap style
+      // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
 
       // add the map to a map view

--- a/raster/raster-layer-url/src/main/java/com/esri/samples/raster_layer_url/RasterLayerURLSample.java
+++ b/raster/raster-layer-url/src/main/java/com/esri/samples/raster_layer_url/RasterLayerURLSample.java
@@ -22,12 +22,13 @@ import javafx.scene.control.Alert;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.raster.ImageServiceRaster;
 
@@ -51,6 +52,10 @@ public class RasterLayerURLSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create an image service raster from an online raster service
       ImageServiceRaster imageServiceRaster = new ImageServiceRaster("https://gis.ngdc.noaa.gov/arcgis/rest/services/bag_hillshades/ImageServer");
 
@@ -63,8 +68,8 @@ public class RasterLayerURLSample extends Application {
         }
       });
 
-      // create a map with dark canvas vector basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createDarkGrayCanvasVector());
+      // create a map with dark gray basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_DARK_GRAY);
 
       // add the map to a map view
       mapView = new MapView();

--- a/raster/raster-rendering-rule/build.gradle
+++ b/raster/raster-rendering-rule/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/raster/raster-rendering-rule/src/main/java/com/esri/samples/raster_rendering_rule/RasterRenderingRuleSample.java
+++ b/raster/raster-rendering-rule/src/main/java/com/esri/samples/raster_rendering_rule/RasterRenderingRuleSample.java
@@ -103,10 +103,10 @@ public class RasterRenderingRuleSample extends Application {
       // add the ComboBox and Label to the controlsVBox
       controlsVBox.getChildren().addAll(renderingRuleInfoComboBox, renderingRuleInfoLabel);
 
-      // create a map with a streets basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // add the map to a new map view
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/raster/raster-rendering-rule/src/main/java/com/esri/samples/raster_rendering_rule/RasterRenderingRuleSample.java
+++ b/raster/raster-rendering-rule/src/main/java/com/esri/samples/raster_rendering_rule/RasterRenderingRuleSample.java
@@ -35,11 +35,12 @@ import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 import javafx.util.StringConverter;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.arcgisservices.RenderingRuleInfo;
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.raster.ImageServiceRaster;
 import com.esri.arcgisruntime.raster.RenderingRule;
@@ -63,6 +64,10 @@ public class RasterRenderingRuleSample extends Application {
       stage.setHeight(700);
       stage.setScene(scene);
       stage.show();
+
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
       // create a control panel
       VBox controlsVBox = new VBox(8);
@@ -98,8 +103,8 @@ public class RasterRenderingRuleSample extends Application {
       // add the ComboBox and Label to the controlsVBox
       controlsVBox.getChildren().addAll(renderingRuleInfoComboBox, renderingRuleInfoLabel);
 
-      // create a Streets BaseMap
-      ArcGISMap map = new ArcGISMap(Basemap.createStreets());
+      // create a map with a streets basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // add the map to a new map view
       mapView = new MapView();


### PR DESCRIPTION
### Description

This PR is for the following sample categories:
- Portal
- Raster

Notes specific to this PR: 
- Identify Raster Cell: indentation was tidied up

### General comments on Basemap updates:

It updates `Map` and/or `Basemap` Constructors as per the new design. This may include the following changes depending on the sample:
- Replace `Basemap.Type` with `BasemapStyle`
- If a lat/long/zoom was being set in the `Map` constructor, this is replaced with a `Viewpoint` being set on the `MapView`.
- Any Readme Updates identified

In addition, the samples that include the above changes, or other services requiring an API Key going forward, have the API Key  set within the sample. This will then work in conjunction with the Gradle Task being added in PR 593.

Once 593 is approved and merged into `dev` we will merge those changes into these PRs and then update all the Samples to `100.10.0-xxxx` and do a round of testing of the Samples with all the API Key / Basemap changes at that time. (We have left them as 100.9.0 (in most cases) for now to minimize merge conflicts in the `build.gradle` file).

In the meantime, the updates listed above can be reviewed. Thanks!