### PR TITLE
New Basemaps: Search and Symbology Categories

### DIFF
--- a/search/find-address/build.gradle
+++ b/search/find-address/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/search/find-address/src/main/java/com/esri/samples/find_address/FindAddressSample.java
+++ b/search/find-address/src/main/java/com/esri/samples/find_address/FindAddressSample.java
@@ -33,10 +33,12 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import javafx.util.Duration;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Callout;
 import com.esri.arcgisruntime.mapping.view.Callout.LeaderPosition;
 import com.esri.arcgisruntime.mapping.view.Graphic;
@@ -70,6 +72,10 @@ public class FindAddressSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create search box
       searchBox = new ComboBox<>();
       searchBox.setPromptText("Search");
@@ -82,8 +88,9 @@ public class FindAddressSample extends Application {
       };
       searchBox.getItems().addAll(examples);
 
-      // create ArcGISMap with imagery basemap
-      ArcGISMap map = new ArcGISMap(Basemap.Type.IMAGERY, 48.354406, -99.998267, 2);
+      // create ArcGISMap with imagery basemap style and an initial viewpoint
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
+      map.setInitialViewpoint(new Viewpoint(48.354406, -99.998267, 150000000));
 
       // create a view and set ArcGISMap to it
       mapView = new MapView();
@@ -98,7 +105,7 @@ public class FindAddressSample extends Application {
       callout.setLeaderPosition(LeaderPosition.BOTTOM);
 
       // create a locatorTask
-      locatorTask = new LocatorTask("https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
+      locatorTask = new LocatorTask("https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer");
 
       // create geocode task parameters
       GeocodeParameters geocodeParameters = new GeocodeParameters();

--- a/search/find-address/src/main/java/com/esri/samples/find_address/FindAddressSample.java
+++ b/search/find-address/src/main/java/com/esri/samples/find_address/FindAddressSample.java
@@ -88,15 +88,15 @@ public class FindAddressSample extends Application {
       };
       searchBox.getItems().addAll(examples);
 
-      // create a map with a basemap style
+      // create a map with the standard imagery basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(48.354406, -99.998267, 150000000));
+      mapView.setViewpoint(new Viewpoint(48.354406, -99.998267, 147914382));
 
       // add a graphics overlay
       graphicsOverlay = new GraphicsOverlay();

--- a/search/find-address/src/main/java/com/esri/samples/find_address/FindAddressSample.java
+++ b/search/find-address/src/main/java/com/esri/samples/find_address/FindAddressSample.java
@@ -88,13 +88,15 @@ public class FindAddressSample extends Application {
       };
       searchBox.getItems().addAll(examples);
 
-      // create ArcGISMap with imagery basemap style and an initial viewpoint
+      // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
-      map.setInitialViewpoint(new Viewpoint(48.354406, -99.998267, 150000000));
 
-      // create a view and set ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(48.354406, -99.998267, 150000000));
 
       // add a graphics overlay
       graphicsOverlay = new GraphicsOverlay();

--- a/search/find-place/README.md
+++ b/search/find-place/README.md
@@ -33,7 +33,7 @@ Choose a type of place in the first field and an area to search within in the se
 
 ## About the data  
 
-This sample uses the [world locator service](https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer).
+This sample uses the [world locator service](https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer).
 
 ## Relevant API
 

--- a/search/find-place/build.gradle
+++ b/search/find-place/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/search/find-place/src/main/java/com/esri/samples/find_place/FindPlaceController.java
+++ b/search/find-place/src/main/java/com/esri/samples/find_place/FindPlaceController.java
@@ -72,7 +72,7 @@ public class FindPlaceController {
     String yourAPIKey = System.getProperty("apiKey");
     ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-    // create a map with a basemap style
+    // create a map with the streets basemap style
     ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
     // set the map to the map view

--- a/search/find-place/src/main/java/com/esri/samples/find_place/FindPlaceController.java
+++ b/search/find-place/src/main/java/com/esri/samples/find_place/FindPlaceController.java
@@ -72,7 +72,7 @@ public class FindPlaceController {
     String yourAPIKey = System.getProperty("apiKey");
     ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-    // create ArcGISMap with streets basemap style
+    // create a map with a basemap style
     ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
     // set the map to the map view
@@ -87,7 +87,7 @@ public class FindPlaceController {
     callout = mapView.getCallout();
     callout.setLeaderPosition(Callout.LeaderPosition.BOTTOM);
 
-    // create a locatorTask task
+    // create a locator task
     locatorTask = new LocatorTask("https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer");
 
     // create a pin graphic

--- a/search/find-place/src/main/java/com/esri/samples/find_place/FindPlaceController.java
+++ b/search/find-place/src/main/java/com/esri/samples/find_place/FindPlaceController.java
@@ -32,11 +32,12 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.util.Duration;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Callout;
 import com.esri.arcgisruntime.mapping.view.Graphic;
@@ -67,9 +68,14 @@ public class FindPlaceController {
 
   @FXML
   public void initialize() {
+    // authentication with an API key or named user is required to access basemaps and other location services
+    String yourAPIKey = System.getProperty("apiKey");
+    ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-    // create ArcGISMap with streets basemap and add it to map view
-    ArcGISMap map = new ArcGISMap(Basemap.createStreets());
+    // create ArcGISMap with streets basemap style
+    ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+
+    // set the map to the map view
     mapView.setMap(map);
     mapView.setWrapAroundMode(WrapAroundMode.DISABLED);
 
@@ -82,7 +88,7 @@ public class FindPlaceController {
     callout.setLeaderPosition(Callout.LeaderPosition.BOTTOM);
 
     // create a locatorTask task
-    locatorTask = new LocatorTask("https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
+    locatorTask = new LocatorTask("https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer");
 
     // create a pin graphic
     Image img = new Image(getClass().getResourceAsStream("/find_place/pin.png"), 0, 80, true, true);

--- a/search/reverse-geocode-online/build.gradle
+++ b/search/reverse-geocode-online/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/search/reverse-geocode-online/src/main/java/com/esri/samples/reverse_geocode_online/ReverseGeocodeOnlineSample.java
+++ b/search/reverse-geocode-online/src/main/java/com/esri/samples/reverse_geocode_online/ReverseGeocodeOnlineSample.java
@@ -81,15 +81,15 @@ public class ReverseGeocodeOnlineSample extends Application {
       progressIndicator.setStyle("-fx-progress-color: white;");
       progressIndicator.setVisible(false);
 
-      // create a map with a basemap style
+      // create a map with the imagery basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(40, -95, 35000000));
+      mapView.setViewpoint(new Viewpoint(40, -95, 36978595));
 
       // add a graphics overlay
       graphicsOverlay = new GraphicsOverlay();

--- a/search/reverse-geocode-online/src/main/java/com/esri/samples/reverse_geocode_online/ReverseGeocodeOnlineSample.java
+++ b/search/reverse-geocode-online/src/main/java/com/esri/samples/reverse_geocode_online/ReverseGeocodeOnlineSample.java
@@ -32,10 +32,12 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import javafx.util.Duration;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Callout;
 import com.esri.arcgisruntime.mapping.view.Callout.LeaderPosition;
 import com.esri.arcgisruntime.mapping.view.Graphic;
@@ -69,14 +71,19 @@ public class ReverseGeocodeOnlineSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // add a progress indicator
       progressIndicator = new ProgressIndicator(ProgressIndicator.INDETERMINATE_PROGRESS);
       progressIndicator.setMaxSize(40, 40);
       progressIndicator.setStyle("-fx-progress-color: white;");
       progressIndicator.setVisible(false);
 
-      // create ArcGISMap with imagery basemap centered over the US
-      ArcGISMap map = new ArcGISMap(Basemap.Type.IMAGERY_WITH_LABELS, 40, -95, 4);
+      // create ArcGISMap with imagery basemap style centered over the US
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY);
+      map.setInitialViewpoint(new Viewpoint(40, -95, 35000000));
 
       // create a view and set ArcGISMap to it
       mapView = new MapView();
@@ -91,7 +98,7 @@ public class ReverseGeocodeOnlineSample extends Application {
       callout.setLeaderPosition(LeaderPosition.BOTTOM);
 
       // create a locator task
-      locatorTask = new LocatorTask("https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
+      locatorTask = new LocatorTask("https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer");
 
       // create geocode task parameters
       ReverseGeocodeParameters reverseGeocodeParameters = new ReverseGeocodeParameters();

--- a/search/reverse-geocode-online/src/main/java/com/esri/samples/reverse_geocode_online/ReverseGeocodeOnlineSample.java
+++ b/search/reverse-geocode-online/src/main/java/com/esri/samples/reverse_geocode_online/ReverseGeocodeOnlineSample.java
@@ -81,13 +81,15 @@ public class ReverseGeocodeOnlineSample extends Application {
       progressIndicator.setStyle("-fx-progress-color: white;");
       progressIndicator.setVisible(false);
 
-      // create ArcGISMap with imagery basemap style centered over the US
+      // create a map with a basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY);
-      map.setInitialViewpoint(new Viewpoint(40, -95, 35000000));
 
-      // create a view and set ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(40, -95, 35000000));
 
       // add a graphics overlay
       graphicsOverlay = new GraphicsOverlay();

--- a/symbology/custom-dictionary-style/build.gradle
+++ b/symbology/custom-dictionary-style/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/symbology/custom-dictionary-style/src/main/java/com/esri/samples/custom_dictionary_style/CustomDictionaryStyleSample.java
+++ b/symbology/custom-dictionary-style/src/main/java/com/esri/samples/custom_dictionary_style/CustomDictionaryStyleSample.java
@@ -21,11 +21,12 @@ import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.DictionaryRenderer;
@@ -52,11 +53,15 @@ public class CustomDictionaryStyleSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map view
-      mapView = new MapView();
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a new map with a streets basemap and set it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.createStreetsVector());
+      // create a new map with a streets basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
+
+      // create a map view and set its map
+      mapView = new MapView();
       mapView.setMap(map);
 
       // set the initial viewpoint to the Esri Redlands campus

--- a/symbology/custom-dictionary-style/src/main/java/com/esri/samples/custom_dictionary_style/CustomDictionaryStyleSample.java
+++ b/symbology/custom-dictionary-style/src/main/java/com/esri/samples/custom_dictionary_style/CustomDictionaryStyleSample.java
@@ -57,7 +57,7 @@ public class CustomDictionaryStyleSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a new map with a streets basemap style
+      // create a map with a streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
       // create a map view and set its map

--- a/symbology/custom-dictionary-style/src/main/java/com/esri/samples/custom_dictionary_style/CustomDictionaryStyleSample.java
+++ b/symbology/custom-dictionary-style/src/main/java/com/esri/samples/custom_dictionary_style/CustomDictionaryStyleSample.java
@@ -57,10 +57,10 @@ public class CustomDictionaryStyleSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a streets basemap style
+      // create a map with the streets basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/symbology/picture-marker-symbol/build.gradle
+++ b/symbology/picture-marker-symbol/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/symbology/picture-marker-symbol/src/main/java/com/esri/samples/picture_marker_symbol/PictureMarkerSymbolSample.java
+++ b/symbology/picture-marker-symbol/src/main/java/com/esri/samples/picture_marker_symbol/PictureMarkerSymbolSample.java
@@ -74,7 +74,7 @@ public class PictureMarkerSymbolSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a ArcGISMap with the topographic basemap style
+      // create a map with a basemap style
       map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // create a map view and set its map

--- a/symbology/picture-marker-symbol/src/main/java/com/esri/samples/picture_marker_symbol/PictureMarkerSymbolSample.java
+++ b/symbology/picture-marker-symbol/src/main/java/com/esri/samples/picture_marker_symbol/PictureMarkerSymbolSample.java
@@ -28,12 +28,13 @@ import javafx.scene.image.Image;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -69,15 +70,19 @@ public class PictureMarkerSymbolSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a ArcGISMap with the topographic basemap
-      map = new ArcGISMap(Basemap.createTopographic());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create view for this map
+      // create a ArcGISMap with the topographic basemap style
+      map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
+
+      // create a map view and set its map
       mapView = new MapView();
+      mapView.setMap(map);
 
       // create graphics overlay and add it to the mapview
       graphicsOverlay = new GraphicsOverlay();
-
       mapView.getGraphicsOverlays().add(graphicsOverlay);
 
       // create points for displaying graphics
@@ -111,9 +116,6 @@ public class PictureMarkerSymbolSample extends Application {
           alert.show();
         }
       });
-
-      // set ArcGISMap to be displayed in mapview
-      mapView.setMap(map);
 
       // set viewpoint on mapview with padding
       Envelope envelope = new Envelope(leftPoint, rightPoint);

--- a/symbology/picture-marker-symbol/src/main/java/com/esri/samples/picture_marker_symbol/PictureMarkerSymbolSample.java
+++ b/symbology/picture-marker-symbol/src/main/java/com/esri/samples/picture_marker_symbol/PictureMarkerSymbolSample.java
@@ -74,14 +74,14 @@ public class PictureMarkerSymbolSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the topographic basemap style
       map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
-      // create graphics overlay and add it to the mapview
+      // create graphics overlay and add it to the map view
       graphicsOverlay = new GraphicsOverlay();
       mapView.getGraphicsOverlays().add(graphicsOverlay);
 

--- a/symbology/read-symbols-from-mobile-style-file/build.gradle
+++ b/symbology/read-symbols-from-mobile-style-file/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/symbology/read-symbols-from-mobile-style-file/src/main/java/com/esri/samples/read_symbols_from_mobile_style_file/ReadSymbolsFromMobileStyleFileController.java
+++ b/symbology/read-symbols-from-mobile-style-file/src/main/java/com/esri/samples/read_symbols_from_mobile_style_file/ReadSymbolsFromMobileStyleFileController.java
@@ -33,11 +33,12 @@ import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -64,9 +65,13 @@ public class ReadSymbolsFromMobileStyleFileController {
 
   @FXML
   public void initialize() {
+    // authentication with an API key or named user is required to access basemaps and other location services
+    String yourAPIKey = System.getProperty("apiKey");
+    ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-    // create a map
-    ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+    // create a map with a topographic basemap style
+    ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
+
     // add the map to the map view
     mapView.setMap(map);
 

--- a/symbology/read-symbols-from-mobile-style-file/src/main/java/com/esri/samples/read_symbols_from_mobile_style_file/ReadSymbolsFromMobileStyleFileController.java
+++ b/symbology/read-symbols-from-mobile-style-file/src/main/java/com/esri/samples/read_symbols_from_mobile_style_file/ReadSymbolsFromMobileStyleFileController.java
@@ -69,10 +69,10 @@ public class ReadSymbolsFromMobileStyleFileController {
     String yourAPIKey = System.getProperty("apiKey");
     ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-    // create a map with a topographic basemap style
+    // create a map with the topographic basemap style
     ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-    // add the map to the map view
+    // set the map to the map view
     mapView.setMap(map);
 
     // create a graphics overlay and add it to the map

--- a/symbology/simple-fill-symbol/build.gradle
+++ b/symbology/simple-fill-symbol/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/symbology/simple-fill-symbol/src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java
+++ b/symbology/simple-fill-symbol/src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java
@@ -88,14 +88,14 @@ public class SimpleFillSymbolSample extends Application {
       // create a map with the topographic basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // set initial map view point
-      Point initialPoint = new Point(-12000000, 5400000, SpatialReferences.getWebMercator());
-      Viewpoint viewpoint = new Viewpoint(initialPoint, 10000000); // point, scale
-      map.setInitialViewpoint(viewpoint);
-
-      // create a view for this ArcGISMap and set ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      Point initialPoint = new Point(-12000000, 5400000, SpatialReferences.getWebMercator());
+      Viewpoint viewpoint = new Viewpoint(initialPoint, 10000000); // point, scale
+      mapView.setViewpoint(viewpoint);
 
       // creates a square from four points
       PointCollection points = new PointCollection(SpatialReferences.getWebMercator());

--- a/symbology/simple-fill-symbol/src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java
+++ b/symbology/simple-fill-symbol/src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java
@@ -87,7 +87,7 @@ public class SimpleFillSymbolSample extends Application {
       // create a map with the topographic basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/symbology/simple-fill-symbol/src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java
+++ b/symbology/simple-fill-symbol/src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java
@@ -33,12 +33,13 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.PointCollection;
 import com.esri.arcgisruntime.geometry.Polygon;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
@@ -70,6 +71,10 @@ public class SimpleFillSymbolSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a control panel
       controlsVBox = new VBox(6);
       controlsVBox.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(0,0,0,0.3)"), CornerRadii.EMPTY,
@@ -80,7 +85,8 @@ public class SimpleFillSymbolSample extends Application {
 
       createSymbolFunctionality();
 
-      final ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+      // create a map with the topographic basemap style
+      final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // set initial map view point
       Point initialPoint = new Point(-12000000, 5400000, SpatialReferences.getWebMercator());

--- a/symbology/simple-fill-symbol/src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java
+++ b/symbology/simple-fill-symbol/src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java
@@ -93,9 +93,7 @@ public class SimpleFillSymbolSample extends Application {
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      Point initialPoint = new Point(-12000000, 5400000, SpatialReferences.getWebMercator());
-      Viewpoint viewpoint = new Viewpoint(initialPoint, 10000000); // point, scale
-      mapView.setViewpoint(viewpoint);
+      mapView.setViewpoint(new Viewpoint(43.03922, -108.55818, 10000000));
 
       // creates a square from four points
       PointCollection points = new PointCollection(SpatialReferences.getWebMercator());

--- a/symbology/simple-fill-symbol/src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java
+++ b/symbology/simple-fill-symbol/src/main/java/com/esri/samples/simple_fill_symbol/SimpleFillSymbolSample.java
@@ -34,7 +34,6 @@ import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
-import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.PointCollection;
 import com.esri.arcgisruntime.geometry.Polygon;
 import com.esri.arcgisruntime.geometry.SpatialReferences;

--- a/symbology/simple-line-symbol/build.gradle
+++ b/symbology/simple-line-symbol/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/symbology/simple-line-symbol/src/main/java/com/esri/samples/simple_line_symbol/SimpleLineSymbolSample.java
+++ b/symbology/simple-line-symbol/src/main/java/com/esri/samples/simple_line_symbol/SimpleLineSymbolSample.java
@@ -30,12 +30,13 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.PointCollection;
 import com.esri.arcgisruntime.geometry.Polyline;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
@@ -64,6 +65,10 @@ public class SimpleLineSymbolSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a control panel
       VBox controlsVBox = new VBox(6);
       controlsVBox.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(0,0,0,0.3)"), CornerRadii.EMPTY,
@@ -74,7 +79,8 @@ public class SimpleLineSymbolSample extends Application {
 
       createSymbolFunctionality(controlsVBox);
 
-      final ArcGISMap map = new ArcGISMap(Basemap.createImagery());
+      // create a map with the imagery basemap style
+      final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
       // set initial map view point
       Point point = new Point(-226773, 6550477, SpatialReferences.getWebMercator());

--- a/symbology/simple-line-symbol/src/main/java/com/esri/samples/simple_line_symbol/SimpleLineSymbolSample.java
+++ b/symbology/simple-line-symbol/src/main/java/com/esri/samples/simple_line_symbol/SimpleLineSymbolSample.java
@@ -78,10 +78,10 @@ public class SimpleLineSymbolSample extends Application {
 
       createSymbolFunctionality(controlsVBox);
 
-      // create a map with the imagery basemap style
+      // create a map with the standard imagery basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/symbology/simple-line-symbol/src/main/java/com/esri/samples/simple_line_symbol/SimpleLineSymbolSample.java
+++ b/symbology/simple-line-symbol/src/main/java/com/esri/samples/simple_line_symbol/SimpleLineSymbolSample.java
@@ -31,7 +31,6 @@ import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
-import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.PointCollection;
 import com.esri.arcgisruntime.geometry.Polyline;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
@@ -87,9 +86,7 @@ public class SimpleLineSymbolSample extends Application {
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      Point point = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
-      Viewpoint viewpoint = new Viewpoint(point, 7200); // point, scale
-      mapView.setViewpoint(viewpoint);
+      mapView.setViewpoint(new Viewpoint(50.59778, -2.03718, 7200));
 
       // creates a line from two points
       PointCollection points = new PointCollection(SpatialReferences.getWebMercator());

--- a/symbology/simple-line-symbol/src/main/java/com/esri/samples/simple_line_symbol/SimpleLineSymbolSample.java
+++ b/symbology/simple-line-symbol/src/main/java/com/esri/samples/simple_line_symbol/SimpleLineSymbolSample.java
@@ -82,14 +82,14 @@ public class SimpleLineSymbolSample extends Application {
       // create a map with the imagery basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // set initial map view point
-      Point point = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
-      Viewpoint viewpoint = new Viewpoint(point, 7200); // point, scale
-      map.setInitialViewpoint(viewpoint);
-
-      // create a view for this ArcGISMap and set ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      Point point = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
+      Viewpoint viewpoint = new Viewpoint(point, 7200); // point, scale
+      mapView.setViewpoint(viewpoint);
 
       // creates a line from two points
       PointCollection points = new PointCollection(SpatialReferences.getWebMercator());

--- a/symbology/simple-marker-symbol/build.gradle
+++ b/symbology/simple-marker-symbol/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/symbology/simple-marker-symbol/src/main/java/com/esri/samples/simple_marker_symbol/SimpleMarkerSymbolSample.java
+++ b/symbology/simple-marker-symbol/src/main/java/com/esri/samples/simple_marker_symbol/SimpleMarkerSymbolSample.java
@@ -21,11 +21,12 @@ import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.SpatialReference;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
@@ -51,8 +52,12 @@ public class SimpleMarkerSymbolSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create ArcGISMap with imagery basemap
-      final ArcGISMap map = new ArcGISMap(Basemap.createImagery());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create ArcGISMap with imagery basemap style
+      final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
       // create spatial reference for WGS 1948
       final SpatialReference webMercator = SpatialReferences.getWebMercator();

--- a/symbology/simple-marker-symbol/src/main/java/com/esri/samples/simple_marker_symbol/SimpleMarkerSymbolSample.java
+++ b/symbology/simple-marker-symbol/src/main/java/com/esri/samples/simple_marker_symbol/SimpleMarkerSymbolSample.java
@@ -23,7 +23,6 @@ import javafx.stage.Stage;
 
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Point;
-import com.esri.arcgisruntime.geometry.SpatialReference;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.BasemapStyle;
@@ -56,22 +55,16 @@ public class SimpleMarkerSymbolSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create ArcGISMap with imagery basemap style
+      // create a map with a basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // create spatial reference for WGS 1948
-      final SpatialReference webMercator = SpatialReferences.getWebMercator();
-
-      // create a initial viewpoint with a center point and scale
-      Point point = new Point(-226773, 6550477, webMercator);
-      Viewpoint viewpoint = new Viewpoint(point, 7500);
-
-      // set initial view point to the ArcGISMap
-      map.setInitialViewpoint(viewpoint);
-
-      // create a view and set ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint to the map view centered on a point
+      Point point = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
+      mapView.setViewpoint(new Viewpoint(point, 7200));
 
       // create new graphics overlay and add it to the map view
       GraphicsOverlay graphicsOverlay = new GraphicsOverlay();

--- a/symbology/simple-marker-symbol/src/main/java/com/esri/samples/simple_marker_symbol/SimpleMarkerSymbolSample.java
+++ b/symbology/simple-marker-symbol/src/main/java/com/esri/samples/simple_marker_symbol/SimpleMarkerSymbolSample.java
@@ -55,10 +55,10 @@ public class SimpleMarkerSymbolSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the standard imagery basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/symbology/simple-renderer/build.gradle
+++ b/symbology/simple-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/symbology/simple-renderer/src/main/java/com/esri/samples/simple_renderer/SimpleRendererSample.java
+++ b/symbology/simple-renderer/src/main/java/com/esri/samples/simple_renderer/SimpleRendererSample.java
@@ -60,7 +60,7 @@ public class SimpleRendererSample extends Application {
       // create a map with the imagery basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 

--- a/symbology/simple-renderer/src/main/java/com/esri/samples/simple_renderer/SimpleRendererSample.java
+++ b/symbology/simple-renderer/src/main/java/com/esri/samples/simple_renderer/SimpleRendererSample.java
@@ -21,12 +21,13 @@ import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.SpatialReference;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -52,8 +53,12 @@ public class SimpleRendererSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a ArcGISMap with the imagery basemap
-      final ArcGISMap map = new ArcGISMap(Basemap.createImageryWithLabels());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a ArcGISMap with the imagery basemap style
+      final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY);
 
       // create a view and set ArcGISMap to it
       mapView = new MapView();

--- a/symbology/simple-renderer/src/main/java/com/esri/samples/simple_renderer/SimpleRendererSample.java
+++ b/symbology/simple-renderer/src/main/java/com/esri/samples/simple_renderer/SimpleRendererSample.java
@@ -57,14 +57,14 @@ public class SimpleRendererSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a ArcGISMap with the imagery basemap style
+      // create a map with the imagery basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY);
 
-      // create a view and set ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
 
-      // create SpatialReference for points
+      // create a spatial reference for the points
       final SpatialReference spatialReference = SpatialReferences.getWgs84();
 
       // create points for displaying graphics

--- a/symbology/symbolize-shapefile/build.gradle
+++ b/symbology/symbolize-shapefile/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/symbology/symbolize-shapefile/src/main/java/com/esri/samples/symbolize_shapefile/SymbolizeShapefileSample.java
+++ b/symbology/symbolize-shapefile/src/main/java/com/esri/samples/symbolize_shapefile/SymbolizeShapefileSample.java
@@ -27,11 +27,12 @@ import javafx.scene.control.ToggleButton;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ShapefileFeatureTable;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.SimpleFillSymbol;
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol;
@@ -57,8 +58,12 @@ public class SymbolizeShapefileSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create a map with a basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create a map with a basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // set the map to the map view
       mapView = new MapView();

--- a/symbology/symbolize-shapefile/src/main/java/com/esri/samples/symbolize_shapefile/SymbolizeShapefileSample.java
+++ b/symbology/symbolize-shapefile/src/main/java/com/esri/samples/symbolize_shapefile/SymbolizeShapefileSample.java
@@ -62,10 +62,10 @@ public class SymbolizeShapefileSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a map with a basemap style
+      // create a map with the topographic basemap style
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // set the map to the map view
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
@@ -85,7 +85,7 @@ public class SymbolizeShapefileSample extends Application {
         }
       });
 
-      // add the feature layer to the map
+      // add the feature layer to the map's operational layers
       map.getOperationalLayers().add(featureLayer);
 
       // create the symbols and renderer

--- a/symbology/unique-value-renderer/build.gradle
+++ b/symbology/unique-value-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/symbology/unique-value-renderer/src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java
+++ b/symbology/unique-value-renderer/src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java
@@ -26,6 +26,8 @@ import javafx.stage.Stage;
 
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
+import com.esri.arcgisruntime.geometry.Envelope;
+import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.BasemapStyle;
@@ -68,12 +70,13 @@ public class UniqueValueRendererSample extends Application {
       // create a map with the topographic basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a map view and set its map
+      // create a map view and set the map to it
       mapView = new MapView();
       mapView.setMap(map);
 
       // set a viewpoint on the map view
-      mapView.setViewpoint(new Viewpoint(36.74938, -118.64617, 15000000));
+      mapView.setViewpoint(new Viewpoint(new Envelope(-13893029.0, 3573174.0, -12038972.0, 5309823.0,
+        SpatialReferences.getWebMercator())));
 
       // create service feature table
       String sampleServiceUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3";

--- a/symbology/unique-value-renderer/src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java
+++ b/symbology/unique-value-renderer/src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java
@@ -24,12 +24,13 @@ import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.SimpleFillSymbol;
@@ -62,8 +63,12 @@ public class UniqueValueRendererSample extends Application {
       stage.setScene(scene);
       stage.show();
 
-      // create ArcGISMap with topographic basemap
-      final ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
+      // create ArcGISMap with topographic basemap style
+      final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
       // create a view and set ArcGISMap to it
       mapView = new MapView();

--- a/symbology/unique-value-renderer/src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java
+++ b/symbology/unique-value-renderer/src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java
@@ -26,8 +26,6 @@ import javafx.stage.Stage;
 
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
-import com.esri.arcgisruntime.geometry.Envelope;
-import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.BasemapStyle;
@@ -67,12 +65,15 @@ public class UniqueValueRendererSample extends Application {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create ArcGISMap with topographic basemap style
+      // create a map with the topographic basemap style
       final ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
 
-      // create a view and set ArcGISMap to it
+      // create a map view and set its map
       mapView = new MapView();
       mapView.setMap(map);
+
+      // set a viewpoint on the map view
+      mapView.setViewpoint(new Viewpoint(36.74938, -118.64617, 15000000));
 
       // create service feature table
       String sampleServiceUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3";
@@ -120,16 +121,8 @@ public class UniqueValueRendererSample extends Application {
       // set the renderer on the feature layer
       featureLayer.setRenderer(uniqueValueRenderer);
 
-      // add the layer to the ArcGISMap
+      // add the feature layer to the map
       map.getOperationalLayers().add(featureLayer);
-
-      // create initial viewpoint using a envelope
-      Envelope envelope = new Envelope(-13893029.0, 3573174.0, -12038972.0, 5309823.0, SpatialReferences
-          .getWebMercator());
-
-      // set viewpoint on ArcGISMap
-      Viewpoint viewpoint = new Viewpoint(envelope);
-      map.setInitialViewpoint(viewpoint);
 
       // add the map view and control panel to stack pane
       stackPane.getChildren().add(mapView);

--- a/symbology/unique-value-renderer/src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java
+++ b/symbology/unique-value-renderer/src/main/java/com/esri/samples/unique_value_renderer/UniqueValueRendererSample.java
@@ -124,7 +124,7 @@ public class UniqueValueRendererSample extends Application {
       // set the renderer on the feature layer
       featureLayer.setRenderer(uniqueValueRenderer);
 
-      // add the feature layer to the map
+      // add the feature layer to the map's operational layers
       map.getOperationalLayers().add(featureLayer);
 
       // add the map view and control panel to stack pane


### PR DESCRIPTION
### Description

This PR is for the following sample categories:
- Search
- Symbology

Notes specific to this PR: 
- Find Address, Find Place, Reverse Geocode Online - also had geocode service URLs updated.
Note: It's been previously raised in a Review by Rachael that the About the Data section in Find Place could be in the other 2 samples too - this was added to the designs in Common Samples with some other tweaks, but for now I've just updated the existing URL so that it is 'correct' as there will need to be a little more discussion on this again in the Samples team since this has changed again since then.

### General comments on Basemap updates:

It updates `Map` and/or `Basemap` Constructors as per the new design. This may include the following changes depending on the sample:
- Replace `Basemap.Type` with `BasemapStyle`
- If a lat/long/zoom was being set in the `Map` constructor, this is replaced with a `Viewpoint` being set on the `MapView`.
- Any Readme Updates identified

In addition, the samples that include the above changes, or other services requiring an API Key going forward, have the API Key  set within the sample. This will then work in conjunction with the Gradle Task being added in PR 593.

Once 593 is approved and merged into `dev` we will merge those changes into these PRs and then update all the Samples to `100.10.0-xxxx` and do a round of testing of the Samples with all the API Key / Basemap changes at that time. (We have left them as 100.9.0 (in most cases) for now to minimize merge conflicts in the `build.gradle` file).

In the meantime, the updates listed above can be reviewed. Thanks!