### PR TITLE
New Basemaps: Utility Network Category

### DIFF
--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/utility_network/display-utility-associations/src/main/java/com/esri/samples/display_utility_associations/DisplayUtilityAssociationsSample.java
+++ b/utility_network/display-utility-associations/src/main/java/com/esri/samples/display_utility_associations/DisplayUtilityAssociationsSample.java
@@ -33,11 +33,12 @@ import javafx.scene.layout.*;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
@@ -69,9 +70,13 @@ public class DisplayUtilityAssociationsSample extends Application {
       stage.setHeight(700);
       stage.setScene(scene);
       stage.show();
+
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
       
-      // create a map with the topographic vector basemap
-      ArcGISMap map = new ArcGISMap(Basemap.createTopographicVector());
+      // create a map with the topographic basemap style
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
       
       // create a viewpoint to focus on the utility networks' extent
       Viewpoint viewPoint = new Viewpoint(41.8057655, -88.1489692, 23);

--- a/utility_network/perform-valve-isolation-trace/build.gradle
+++ b/utility_network/perform-valve-isolation-trace/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/utility_network/perform-valve-isolation-trace/src/main/java/com/esri/samples/perform_valve_isolation_trace/PerformValveIsolationTraceController.java
+++ b/utility_network/perform-valve-isolation-trace/src/main/java/com/esri/samples/perform_valve_isolation_trace/PerformValveIsolationTraceController.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.ArcGISFeature;
 import com.esri.arcgisruntime.data.FeatureQueryResult;
@@ -40,7 +41,7 @@ import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
@@ -82,8 +83,12 @@ public class PerformValveIsolationTraceController {
   public void initialize() {
     try {
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a basemap and set it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.createStreetsNightVector());
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS_NIGHT);
       mapView.setMap(map);
 
       // load the utility network data from the feature service and create feature layers

--- a/utility_network/perform-valve-isolation-trace/src/main/java/com/esri/samples/perform_valve_isolation_trace/PerformValveIsolationTraceController.java
+++ b/utility_network/perform-valve-isolation-trace/src/main/java/com/esri/samples/perform_valve_isolation_trace/PerformValveIsolationTraceController.java
@@ -87,7 +87,7 @@ public class PerformValveIsolationTraceController {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a basemap and set it to the map view
+      // create a map with the streets night basemap style and set it to the map view
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS_NIGHT);
       mapView.setMap(map);
 

--- a/utility_network/trace-a-utility-network/README.md
+++ b/utility_network/trace-a-utility-network/README.md
@@ -14,7 +14,7 @@ Click on one or more features while 'Add starting locations' or 'Add barriers' i
 
 ## How it works
 
-1. Create a `Map` and add it to a `MapView`.
+1. Create an `ArcGISMap` and add it to a `MapView`.
 2. Using the URL to a utility network's feature service, create `FeatureLayer`s that contain the utility network's features, and add them to the operational layers of the map.
 3. Create and load a `UtilityNetwork` with the same feature service URL and map.
 4. Add a `GraphicsOverlay` with symbology that distinguishes starting points from barriers.

--- a/utility_network/trace-a-utility-network/README.md
+++ b/utility_network/trace-a-utility-network/README.md
@@ -14,7 +14,7 @@ Click on one or more features while 'Add starting locations' or 'Add barriers' i
 
 ## How it works
 
-1. Create an `ArcGISMap` and add it to a `MapView`.
+1. Create an `ArcGISMap` and set it on a `MapView`.
 2. Using the URL to a utility network's feature service, create `FeatureLayer`s that contain the utility network's features, and add them to the operational layers of the map.
 3. Create and load a `UtilityNetwork` with the same feature service URL and map.
 4. Add a `GraphicsOverlay` with symbology that distinguishes starting points from barriers.

--- a/utility_network/trace-a-utility-network/build.gradle
+++ b/utility_network/trace-a-utility-network/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.9.0'
+    arcgisVersion = '100.10.0-2992'
 }
 
 javafx {

--- a/utility_network/trace-a-utility-network/src/main/java/com/esri/samples/trace_a_utility_network/TraceAUtilityNetworkController.java
+++ b/utility_network/trace-a-utility-network/src/main/java/com/esri/samples/trace_a_utility_network/TraceAUtilityNetworkController.java
@@ -108,9 +108,10 @@ public class TraceAUtilityNetworkController {
       String yourAPIKey = System.getProperty("apiKey");
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
-      // create a basemap and set it to the map view
+      // create a map with the streets night basemap style and set it to the map view
       ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS_NIGHT);
       mapView.setMap(map);
+
       // set the viewpoint to a subsection of the utility network
       mapView.setViewpointAsync(new Viewpoint(
           new Envelope(-9813547.35557238, 5129980.36635111, -9813185.0602376, 5130215.41254146,

--- a/utility_network/trace-a-utility-network/src/main/java/com/esri/samples/trace_a_utility_network/TraceAUtilityNetworkController.java
+++ b/utility_network/trace-a-utility-network/src/main/java/com/esri/samples/trace_a_utility_network/TraceAUtilityNetworkController.java
@@ -37,6 +37,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.GridPane;
 import javafx.scene.paint.Color;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.ArcGISFeature;
 import com.esri.arcgisruntime.data.FeatureQueryResult;
@@ -44,7 +45,6 @@ import com.esri.arcgisruntime.data.QueryParameters;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.GeometryEngine;
-import com.esri.arcgisruntime.geometry.GeometryType;
 import com.esri.arcgisruntime.geometry.Point;
 import com.esri.arcgisruntime.geometry.Polyline;
 import com.esri.arcgisruntime.geometry.ProximityResult;
@@ -53,7 +53,7 @@ import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.layers.LayerContent;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
-import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.GeoElement;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.Graphic;
@@ -104,8 +104,12 @@ public class TraceAUtilityNetworkController {
 
   public void initialize() {
     try {
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a basemap and set it to the map view
-      ArcGISMap map = new ArcGISMap(Basemap.createStreetsNightVector());
+      ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_STREETS_NIGHT);
       mapView.setMap(map);
       // set the viewpoint to a subsection of the utility network
       mapView.setViewpointAsync(new Viewpoint(


### PR DESCRIPTION
### Description

This PR is for the following sample categories:
- Utility Network

### General comments on Basemap updates:

It updates `Map` and/or `Basemap` Constructors as per the new design. This may include the following changes depending on the sample:
- Replace `Basemap.Type` with `BasemapStyle`
- If a lat/long/zoom was being set in the `Map` constructor, this is replaced with a `Viewpoint` being set on the `MapView`.
- Any Readme Updates identified

In addition, the samples that include the above changes, or other services requiring an API Key going forward, have the API Key  set within the sample. This will then work in conjunction with the Gradle Task being added in PR 593.

Once 593 is approved and merged into `dev` we will merge those changes into these PRs and then update all the Samples to `100.10.0-xxxx` and do a round of testing of the Samples with all the API Key / Basemap changes at that time. (We have left them as 100.9.0 (in most cases) for now to minimize merge conflicts in the `build.gradle` file).

In the meantime, the updates listed above can be reviewed. Thanks!