### PR TITLE
More sample updates

### DIFF
--- a/display_information/show-callout/src/main/java/com/esri/samples/show_callout/ShowCalloutSample.java
+++ b/display_information/show-callout/src/main/java/com/esri/samples/show_callout/ShowCalloutSample.java
@@ -24,7 +24,9 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
+import com.esri.arcgisruntime.geometry.GeometryEngine;
 import com.esri.arcgisruntime.geometry.Point;
+import com.esri.arcgisruntime.geometry.SpatialReferences;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.Callout;
@@ -75,9 +77,12 @@ public class ShowCalloutSample extends Application {
           // create a map point from a point
           Point mapPoint = mapView.screenToLocation(point);
 
+          // project user-tapped map point location
+          Point projectedPoint = (Point)GeometryEngine.project(mapPoint, SpatialReferences.getWgs84());
+
           // set the callout's details
           callout.setTitle("Location");
-          callout.setDetail(String.format("x: %.2f, y: %.2f", mapPoint.getX(), mapPoint.getY()));
+          callout.setDetail(String.format("Lat: %.3f, Long: %.3f", projectedPoint.getY(), projectedPoint.getX()));
 
           // show the callout where the user clicked
           callout.showCalloutAt(mapPoint);

--- a/feature_layers/display-subtype-feature-layer/src/main/resources/display_subtype_feature_layer/main.fxml
+++ b/feature_layers/display-subtype-feature-layer/src/main/resources/display_subtype_feature_layer/main.fxml
@@ -33,7 +33,7 @@
            stylesheets="/display_subtype_feature_layer/style.css">
     <!--SDK MapView-->
     <MapView fx:id="mapView"/>
-    <VBox StackPane.alignment="TOP_RIGHT" maxWidth="190" maxHeight="200" spacing="6" styleClass="panel-region" alignment="CENTER_LEFT" visible="false" fx:id="vBox">
+    <VBox StackPane.alignment="TOP_RIGHT" maxWidth="215" maxHeight="200" spacing="6" styleClass="panel-region" alignment="CENTER_LEFT" visible="false" fx:id="vBox">
         <StackPane.margin>
             <Insets top="60" right="10"/>
         </StackPane.margin>

--- a/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
+++ b/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
@@ -16,6 +16,7 @@
 
 package com.esri.samples.change_basemap;
 
+import com.esri.arcgisruntime.mapping.Basemap;
 import javafx.application.Application;
 import javafx.collections.FXCollections;
 import javafx.geometry.Insets;
@@ -57,8 +58,11 @@ public class ChangeBasemapSample extends Application {
 
       // create a map view
       mapView = new MapView();
+      // create a new map and set it to the map view: a basemap style will be added to the map once the sample loads
+      map = new ArcGISMap();
+      mapView.setMap(map);
       // create a new view point centered on Scotland, UK
-      var viewpoint = new Viewpoint(57.5000, -5.0000, 9244648);
+      mapView.setViewpoint(new Viewpoint(57.5000, -5.0000, 9244648));
 
       // setup a list view of basemap styles
       ListView<BasemapStyle> basemapStyleListView = new ListView<>(FXCollections.observableArrayList(BasemapStyle.values()));
@@ -67,9 +71,8 @@ public class ChangeBasemapSample extends Application {
       // change the basemap when a list option is selected
       basemapStyleListView.getSelectionModel().selectedItemProperty().addListener(o -> {
         BasemapStyle selectedBasemapStyle = basemapStyleListView.getSelectionModel().getSelectedItem();
-        map = new ArcGISMap(selectedBasemapStyle);
-        mapView.setMap(map);
-        mapView.setViewpoint(viewpoint);
+        Basemap basemap = new Basemap(selectedBasemapStyle);
+        map.setBasemap(basemap);
       });
 
       // select the first basemap style

--- a/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
+++ b/map/change-basemap/src/main/java/com/esri/samples/change_basemap/ChangeBasemapSample.java
@@ -16,7 +16,6 @@
 
 package com.esri.samples.change_basemap;
 
-import com.esri.arcgisruntime.mapping.Basemap;
 import javafx.application.Application;
 import javafx.collections.FXCollections;
 import javafx.geometry.Insets;
@@ -28,6 +27,7 @@ import javafx.stage.Stage;
 
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
+import com.esri.arcgisruntime.mapping.Basemap;
 import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;


### PR DESCRIPTION
### Description

This PR contains 3 small updates:

- Show callout: update to display lat/long rather than x and y co-ordinates
- Display subtype feature layer: increase vbox width to account for truncated text on linux
- Change basemap: use the `setBasemap` method to set the basemap rather than creating a new map everytime and cleaned up the viewpoint code slightly so that the viewpoint is only set when the app launches. That way if a user navigates the map and then changes the basemap, they'll remain in the same place to compare the new basemap.
@jenmerritt could you take a look please? thanks! 
