### PR TITLE
Export tiles update

### DIFF
--- a/raster/rgb-renderer/src/main/resources/rgb_renderer/main.fxml
+++ b/raster/rgb-renderer/src/main/resources/rgb_renderer/main.fxml
@@ -24,7 +24,7 @@
 <?import javafx.scene.paint.Color?>
 <?import javafx.geometry.Insets?>
 <StackPane fx:controller="com.esri.samples.rgb_renderer.RgbRendererController" xmlns:fx="http://javafx.com/fxml"
-           stylesheets="/rgb_renderer/style.cssrer/style.css">
+           stylesheets="/rgb_renderer/style.css">
     <MapView fx:id="mapView"/>
     <VBox StackPane.alignment="TOP_LEFT" maxWidth="320" maxHeight="50" styleClass="panel-region" spacing="10">
         <padding>

--- a/raster/stretch-renderer/src/main/resources/stretch_renderer/main.fxml
+++ b/raster/stretch-renderer/src/main/resources/stretch_renderer/main.fxml
@@ -29,7 +29,7 @@
 <?import javafx.scene.paint.Color?>
 <?import javafx.geometry.Insets?>
 <StackPane fx:controller="com.esri.samples.stretch_renderer.StretchRendererController" xmlns:fx="http://javafx.com/fxml"
-           stylesheets="/stretch_renderer/style.cssenderer/style.css">
+           stylesheets="/stretch_renderer/style.css">
     <MapView fx:id="mapView"/>
     <VBox StackPane.alignment="TOP_LEFT" maxWidth="300" maxHeight="50" styleClass="panel-region" spacing="10">
         <padding>

--- a/tiled_layers/export-tiles/build.gradle
+++ b/tiled_layers/export-tiles/build.gradle
@@ -36,6 +36,17 @@ dependencies {
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }
 
+task createGradlePropertiesAndWriteApiKey {
+    description = "Creates a new gradle.properties file with an empty API key variable in the user home ./gradle folder, if the file doesn't already exist."
+    group = "build"
+    def propertiesFile = new File("${System.properties.getProperty("user.home")}/.gradle/gradle.properties")
+    if (!propertiesFile.exists()) {
+        print("Go to " + new URL("https://developers.arcgis.com/dashboard") + " to get an API key.")
+        print(" Add your API key to ${System.properties.getProperty("user.home")}\\.gradle\\gradle.properties.")
+        propertiesFile.write("apiKey = ")
+    }
+}
+
 task copyNatives(type: Copy) {
     description = "Copies the arcgis native libraries into the project build directory for development."
     group = "build"
@@ -47,6 +58,10 @@ task copyNatives(type: Copy) {
 }
 
 run {
+    doFirst {
+        // sets the API key from the gradle.properties file as a Java system property
+        systemProperty 'apiKey', apiKey
+    }
     dependsOn copyNatives
     mainClassName = 'com.esri.samples.export_tiles.ExportTilesLauncher'
 }

--- a/tiled_layers/export-tiles/src/main/java/com/esri/samples/export_tiles/ExportTilesSample.java
+++ b/tiled_layers/export-tiles/src/main/java/com/esri/samples/export_tiles/ExportTilesSample.java
@@ -20,11 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
-import com.esri.arcgisruntime.mapping.BasemapStyle;
-import com.esri.arcgisruntime.mapping.Viewpoint;
 import javafx.application.Application;
-import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
@@ -35,6 +31,7 @@ import javafx.scene.control.ProgressBar;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.Job;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.TileCache;
@@ -44,11 +41,12 @@ import com.esri.arcgisruntime.layers.ArcGISTiledLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
 import com.esri.arcgisruntime.mapping.view.MapView;
+import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol;
-import com.esri.arcgisruntime.tasks.tilecache.ExportTileCacheJob;
 import com.esri.arcgisruntime.tasks.tilecache.ExportTileCacheParameters;
 import com.esri.arcgisruntime.tasks.tilecache.ExportTileCacheTask;
 

--- a/tiled_layers/export-tiles/src/main/java/com/esri/samples/export_tiles/ExportTilesSample.java
+++ b/tiled_layers/export-tiles/src/main/java/com/esri/samples/export_tiles/ExportTilesSample.java
@@ -119,14 +119,13 @@ public class ExportTilesSample extends Application {
           // create a tiled layer from the basemap
           ArcGISTiledLayer tiledLayer = (ArcGISTiledLayer) map.getBasemap().getBaseLayers().get(0);
 
-          // create button to export tiles
-          Button exportTilesButton = new Button("Export Tiles");
-
           // create progress bar to show task progress
           var progressBar = new ProgressBar();
           progressBar.setProgress(0.0);
           progressBar.setVisible(false);
 
+          // create button to export tiles
+          Button exportTilesButton = new Button("Export Tiles");
           // when the button is clicked, export the tiles to a temporary file
           exportTilesButton.setOnAction(e -> {
             try {
@@ -138,11 +137,13 @@ public class ExportTilesSample extends Application {
               File tempFile = File.createTempFile("tiles", ".tpkx");
               tempFile.deleteOnExit();
 
-              // create a task
+              // create a new export tile cache task
               var exportTileCacheTask = new ExportTileCacheTask(tiledLayer.getUri());
 
               // create parameters for the export tiles job
               double mapScale = mapView.getMapScale();
+              // the max scale is parameter is set to 10% of the map's scale to limit the
+              // number of tiles exported to within the tiled layer's max tile export limit
               ListenableFuture<ExportTileCacheParameters> exportTileCacheParametersListenableFuture =
                 exportTileCacheTask.createDefaultExportTileCacheParametersAsync(downloadArea.getGeometry(), mapScale, mapScale * 0.1);
 


### PR DESCRIPTION
This PR updates the service from which to export tiles from. It now uses tiles from the Esri imagery basemap and requires an API key. It also updates the export type to a .tpkx file, along with some other minor sample improvements including the use of `var` to modernise the Java code in the sample. This PR also fixes up bad paths to CSS in two Raster samples. 

@jenmerritt could you take a look please? thanks! 