### PR TITLE
Use api key authentication workflow for generate offline map samples

### DIFF
--- a/map/generate-offline-map-overrides/README.md
+++ b/map/generate-offline-map-overrides/README.md
@@ -10,7 +10,7 @@ When taking a web map offline, you may adjust the data (such as layers or tiles)
 
 ## How to use the sample
 
-Sign in with an ArcGIS Online account when prompted for credentials (taking web maps offline requires an account) and modify the overrides parameters:
+Modify the overrides parameters:
 
 * Use the min/max scale input fields to adjust the level IDs to be taken offline for the streets basemap.
 * Use the "Extent Buffer Distance" input field to set the buffer radius for the streets basemap.
@@ -18,7 +18,7 @@ Sign in with an ArcGIS Online account when prompted for credentials (taking web 
 * Use the "Min Hydrant Flow Rate" input field to only download features with a flow rate higher than this value.
 * Select the "Water Pipes" checkbox if you want to crop the water pipe features to the extent of the map.
 
-After you have set up the overrides to your liking, click the "Generate offline map" button to start the download. A progress bar will display. Click the "Cancel" button if you want to stop the download. When the download is complete, the view will display the offline map. Pan around to see that the map is cropped to the download area's extent.
+Set up the overrides to your liking, click the "Generate offline map" button to start the download. A progress bar will display. Click the "Cancel" button if you want to stop the download. When the download is complete, the view will display the offline map. Pan around to see that the map is cropped to the download area's extent.
 
 ## How it works
 

--- a/map/generate-offline-map-overrides/README.metadata.json
+++ b/map/generate-offline-map-overrides/README.metadata.json
@@ -6,7 +6,6 @@
         "GenerateOfflineMapOverrides.png"
     ],
     "keywords": [
-        "LOD",
         "adjust",
         "download",
         "extent",
@@ -24,6 +23,7 @@
         "GenerateOfflineMapParameterOverrides",
         "GenerateOfflineMapParameters",
         "GenerateOfflineMapResult",
+        "LOD",
         "OfflineMapParametersKey",
         "OfflineMapTask"
     ],

--- a/map/generate-offline-map-overrides/README.metadata.json
+++ b/map/generate-offline-map-overrides/README.metadata.json
@@ -10,6 +10,7 @@
         "download",
         "extent",
         "filter",
+        "LOD",
         "offline",
         "override",
         "parameters",
@@ -23,7 +24,6 @@
         "GenerateOfflineMapParameterOverrides",
         "GenerateOfflineMapParameters",
         "GenerateOfflineMapResult",
-        "LOD",
         "OfflineMapParametersKey",
         "OfflineMapTask"
     ],

--- a/map/generate-offline-map-overrides/build.gradle
+++ b/map/generate-offline-map-overrides/build.gradle
@@ -38,6 +38,17 @@ dependencies {
     runtimeOnly 'org.slf4j:slf4j-nop:1.7.32'
 }
 
+task createGradlePropertiesAndWriteApiKey {
+    description = "Creates a new gradle.properties file with an empty API key variable in the user home ./gradle folder, if the file doesn't already exist."
+    group = "build"
+    def propertiesFile = new File("${System.properties.getProperty("user.home")}/.gradle/gradle.properties")
+    if (!propertiesFile.exists()) {
+        print("Go to " + new URL("https://developers.arcgis.com/dashboard") + " to get an API key.")
+        print(" Add your API key to ${System.properties.getProperty("user.home")}\\.gradle\\gradle.properties.")
+        propertiesFile.write("apiKey = ")
+    }
+}
+
 task copyNatives(type: Copy) {
     description = "Copies the arcgis native libraries into the project build directory for development."
     group = "build"
@@ -49,6 +60,10 @@ task copyNatives(type: Copy) {
 }
 
 run {
+    doFirst {
+        // sets the API key from the gradle.properties file as a Java system property
+        systemProperty 'apiKey', apiKey
+    }
     dependsOn copyNatives
     mainClassName = 'com.esri.samples.generate_offline_map_overrides.GenerateOfflineMapOverridesLauncher'
 }

--- a/map/generate-offline-map-overrides/src/main/java/com/esri/samples/generate_offline_map_overrides/GenerateOfflineMapOverridesController.java
+++ b/map/generate-offline-map-overrides/src/main/java/com/esri/samples/generate_offline_map_overrides/GenerateOfflineMapOverridesController.java
@@ -35,6 +35,7 @@ import javafx.scene.control.Spinner;
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
+import com.esri.arcgisruntime.tasks.geodatabase.GenerateGeodatabaseParameters;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.GeometryEngine;
 import com.esri.arcgisruntime.geometry.Point;
@@ -55,6 +56,7 @@ import com.esri.arcgisruntime.tasks.offlinemap.GenerateOfflineMapParameters;
 import com.esri.arcgisruntime.tasks.offlinemap.GenerateOfflineMapResult;
 import com.esri.arcgisruntime.tasks.offlinemap.OfflineMapParametersKey;
 import com.esri.arcgisruntime.tasks.offlinemap.OfflineMapTask;
+import com.esri.arcgisruntime.tasks.tilecache.ExportTileCacheParameters;
 
 public class GenerateOfflineMapOverridesController {
 
@@ -147,7 +149,7 @@ public class GenerateOfflineMapOverridesController {
               // get the export tile cache parameters for the base layer
               OfflineMapParametersKey basemapParamKey = new OfflineMapParametersKey(
                   mapView.getMap().getBasemap().getBaseLayers().get(0));
-              var exportTileCacheParameters =
+              ExportTileCacheParameters exportTileCacheParameters =
                   overrides.getExportTileCacheParameters().get(basemapParamKey);
 
               // create a new sublist of level IDs in the range requested by the user
@@ -167,7 +169,7 @@ public class GenerateOfflineMapOverridesController {
                   long layerId = featureTable.getLayerInfo().getServiceLayerId();
                   // get the layer option parameters specifically for this layer
                   OfflineMapParametersKey key = new OfflineMapParametersKey(layer);
-                  var generateGeodatabaseParameters = overrides.getGenerateGeodatabaseParameters().get(key);
+                  GenerateGeodatabaseParameters generateGeodatabaseParameters = overrides.getGenerateGeodatabaseParameters().get(key);
                   List<GenerateLayerOption> layerOptions = generateGeodatabaseParameters.getLayerOptions();
                   // use an iterator so we can remove layer options while looping over them
                   Iterator<GenerateLayerOption> layerOptionsIterator = layerOptions.iterator();

--- a/map/generate-offline-map-overrides/src/main/java/com/esri/samples/generate_offline_map_overrides/GenerateOfflineMapOverridesController.java
+++ b/map/generate-offline-map-overrides/src/main/java/com/esri/samples/generate_offline_map_overrides/GenerateOfflineMapOverridesController.java
@@ -83,8 +83,8 @@ public class GenerateOfflineMapOverridesController {
     ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
     // create a portal item with the itemId of the web map
-    Portal portal = new Portal("https://www.arcgis.com");
-    PortalItem portalItem = new PortalItem(portal, "acc027394bc84c2fb04d1ed317aac674");
+    var portal = new Portal("https://www.arcgis.com");
+    var portalItem = new PortalItem(portal, "acc027394bc84c2fb04d1ed317aac674");
 
     // create a map with the portal item
     map = new ArcGISMap(portalItem);

--- a/map/generate-offline-map-overrides/src/main/java/com/esri/samples/generate_offline_map_overrides/GenerateOfflineMapOverridesController.java
+++ b/map/generate-offline-map-overrides/src/main/java/com/esri/samples/generate_offline_map_overrides/GenerateOfflineMapOverridesController.java
@@ -32,6 +32,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.ProgressBar;
 import javafx.scene.control.Spinner;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Envelope;
@@ -46,10 +47,7 @@ import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.portal.Portal;
 import com.esri.arcgisruntime.portal.PortalItem;
-import com.esri.arcgisruntime.security.AuthenticationManager;
-import com.esri.arcgisruntime.security.DefaultAuthenticationChallengeHandler;
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol;
-import com.esri.arcgisruntime.tasks.geodatabase.GenerateGeodatabaseParameters;
 import com.esri.arcgisruntime.tasks.geodatabase.GenerateLayerOption;
 import com.esri.arcgisruntime.tasks.offlinemap.GenerateOfflineMapJob;
 import com.esri.arcgisruntime.tasks.offlinemap.GenerateOfflineMapParameterOverrides;
@@ -57,7 +55,6 @@ import com.esri.arcgisruntime.tasks.offlinemap.GenerateOfflineMapParameters;
 import com.esri.arcgisruntime.tasks.offlinemap.GenerateOfflineMapResult;
 import com.esri.arcgisruntime.tasks.offlinemap.OfflineMapParametersKey;
 import com.esri.arcgisruntime.tasks.offlinemap.OfflineMapTask;
-import com.esri.arcgisruntime.tasks.tilecache.ExportTileCacheParameters;
 
 public class GenerateOfflineMapOverridesController {
 
@@ -80,15 +77,19 @@ public class GenerateOfflineMapOverridesController {
 
   @FXML
   private void initialize() {
-    // handle authentication with the portal
-    AuthenticationManager.setAuthenticationChallengeHandler(new DefaultAuthenticationChallengeHandler());
+
+    // authentication with an API key or named user is required to access basemaps and other location services
+    String yourAPIKey = System.getProperty("apiKey");
+    ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
     // create a portal item with the itemId of the web map
-    Portal portal = new Portal("https://www.arcgis.com", true);
+    Portal portal = new Portal("https://www.arcgis.com");
     PortalItem portalItem = new PortalItem(portal, "acc027394bc84c2fb04d1ed317aac674");
 
     // create a map with the portal item
     map = new ArcGISMap(portalItem);
+    // display the generate offline map area as a red box on the map
+    updateDownloadArea();
     map.addDoneLoadingListener(() -> {
       // enable the generate offline map button when the map is loaded
       if (map.getLoadStatus() == LoadStatus.LOADED) {
@@ -101,10 +102,9 @@ public class GenerateOfflineMapOverridesController {
         // show a red border around the download area
         downloadArea = new Graphic();
         graphicsOverlay.getGraphics().add(downloadArea);
-        SimpleLineSymbol simpleLineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, 0xFFFF0000, 2);
+        var simpleLineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, 0xFFFF0000, 2);
         downloadArea.setSymbol(simpleLineSymbol);
 
-        updateDownloadArea();
       }
     });
 
@@ -126,7 +126,7 @@ public class GenerateOfflineMapOverridesController {
       progressBar.setVisible(true);
 
       // create an offline map task with the map
-      OfflineMapTask offlineMapTask = new OfflineMapTask(map);
+      var offlineMapTask = new OfflineMapTask(map);
 
       // get default offline map parameters for this task given the download area
       ListenableFuture<GenerateOfflineMapParameters> generateOfflineMapParametersFuture = offlineMapTask
@@ -147,7 +147,7 @@ public class GenerateOfflineMapOverridesController {
               // get the export tile cache parameters for the base layer
               OfflineMapParametersKey basemapParamKey = new OfflineMapParametersKey(
                   mapView.getMap().getBasemap().getBaseLayers().get(0));
-              ExportTileCacheParameters exportTileCacheParameters =
+              var exportTileCacheParameters =
                   overrides.getExportTileCacheParameters().get(basemapParamKey);
 
               // create a new sublist of level IDs in the range requested by the user
@@ -162,13 +162,12 @@ public class GenerateOfflineMapOverridesController {
               // configure layer option parameters for each layer depending on the options selected in the UI
               for (Layer layer : map.getOperationalLayers()) {
                 if (layer instanceof FeatureLayer) {
-                  FeatureLayer featureLayer = (FeatureLayer) layer;
+                  var featureLayer = (FeatureLayer) layer;
                   ServiceFeatureTable featureTable = (ServiceFeatureTable) featureLayer.getFeatureTable();
                   long layerId = featureTable.getLayerInfo().getServiceLayerId();
                   // get the layer option parameters specifically for this layer
                   OfflineMapParametersKey key = new OfflineMapParametersKey(layer);
-                  GenerateGeodatabaseParameters generateGeodatabaseParameters =
-                      overrides.getGenerateGeodatabaseParameters().get(key);
+                  var generateGeodatabaseParameters = overrides.getGenerateGeodatabaseParameters().get(key);
                   List<GenerateLayerOption> layerOptions = generateGeodatabaseParameters.getLayerOptions();
                   // use an iterator so we can remove layer options while looping over them
                   Iterator<GenerateLayerOption> layerOptionsIterator = layerOptions.iterator();
@@ -194,7 +193,7 @@ public class GenerateOfflineMapOverridesController {
                             layerOption.setWhereClause("FLOW >= " + minHydrantFlowRateSpinner.getValue());
                             layerOption.setQueryOption(GenerateLayerOption.QueryOption.USE_FILTER);
                             break;
-                          //clip water main feature geometries to the extent if the checkbox is selected
+                          // clip water main feature geometries to the extent if the checkbox is selected
                           case "Main":
                             layerOption.setUseGeometry(waterPipesCheckBox.isSelected());
                         }
@@ -263,7 +262,7 @@ public class GenerateOfflineMapOverridesController {
 
   /**
    * Cancels the current offline map job.
-      */
+   */
   @FXML
   private void cancelJob() {
     if (job != null) {
@@ -272,7 +271,7 @@ public class GenerateOfflineMapOverridesController {
   }
 
   /**
-   * Stops the animation and disposes of application resources.
+   * Stops and releases all resources used in the application.
    */
   void terminate() {
 

--- a/map/generate-offline-map-overrides/src/main/resources/generate_offline_map_overrides/main.fxml
+++ b/map/generate-offline-map-overrides/src/main/resources/generate_offline_map_overrides/main.fxml
@@ -29,7 +29,7 @@
     <!--SDK MapView-->
     <MapView fx:id="mapView"/>
     <!--Offline Map Override Parameters-->
-    <VBox StackPane.alignment="TOP_LEFT" maxWidth="350" prefWidth="300" maxHeight="300" spacing="6"
+    <VBox StackPane.alignment="TOP_LEFT" maxWidth="360" prefWidth="300" maxHeight="300" spacing="6"
           styleClass="panel-region" alignment="CENTER">
         <padding>
             <Insets topRightBottomLeft="10"/>

--- a/map/generate-offline-map-overrides/src/main/resources/generate_offline_map_overrides/style.css
+++ b/map/generate-offline-map-overrides/src/main/resources/generate_offline_map_overrides/style.css
@@ -1,6 +1,5 @@
 .panel-region .label {
   -fx-text-fill: white;
-  -fx-font-weight: bold;
 }
 
 .panel-region .check-box {

--- a/map/generate-offline-map-overrides/src/main/resources/generate_offline_map_overrides/style.css
+++ b/map/generate-offline-map-overrides/src/main/resources/generate_offline_map_overrides/style.css
@@ -1,27 +1,8 @@
 .panel-region .label {
   -fx-text-fill: white;
-}
-
-.label {
-  -fx-text-fill: black;
-}
-
-.slider .axis {
-    -fx-tick-label-fill: white;
-}
-
-.range-slider .axis {
-    -fx-tick-label-fill: white;
+  -fx-font-weight: bold;
 }
 
 .panel-region .check-box {
    -fx-text-fill: white;
-}
-
-.panel-region .radio-button {
-   -fx-text-fill: white;
-}
-
-.color-picker .color-picker-label {
-   -fx-text-fill: black;
 }

--- a/map/generate-offline-map-with-local-basemap/README.md
+++ b/map/generate-offline-map-with-local-basemap/README.md
@@ -22,9 +22,9 @@ The author of a web map can support the use of basemaps which are already on a d
 
 Click on the "Take Map Offline" button. You will be prompted to choose whether you wish to download a basemap or use the local basemap (which is already saved in the samples-data directory as "naperville_imagery.tpkx").
 
-If you choose to download the online basemap, the offline map will be generated with the same (topographic) basemap as the online web map. To download the Esri basemap, you may be prompted to sign in to ArcGIS.com.
+If you choose to download the online basemap, the offline map will be generated with the same (topographic) basemap as the online web map.
 
-If you choose to use the local basemap from the device, the offline map will be generated with the local imagery basemap. The download will be quicker since no tiles are exported or downloaded. Since the application is not exporting online ArcGIS Online basemaps you will not need to log-in.
+If you choose to use the local basemap from the device, the offline map will be generated with the local imagery basemap. The download will be quicker since no tiles are exported or downloaded.
 
 ## How it works
 

--- a/map/generate-offline-map-with-local-basemap/build.gradle
+++ b/map/generate-offline-map-with-local-basemap/build.gradle
@@ -38,6 +38,17 @@ dependencies {
     runtimeOnly 'org.slf4j:slf4j-nop:1.7.32'
 }
 
+task createGradlePropertiesAndWriteApiKey {
+    description = "Creates a new gradle.properties file with an empty API key variable in the user home ./gradle folder, if the file doesn't already exist."
+    group = "build"
+    def propertiesFile = new File("${System.properties.getProperty("user.home")}/.gradle/gradle.properties")
+    if (!propertiesFile.exists()) {
+        print("Go to " + new URL("https://developers.arcgis.com/dashboard") + " to get an API key.")
+        print(" Add your API key to ${System.properties.getProperty("user.home")}\\.gradle\\gradle.properties.")
+        propertiesFile.write("apiKey = ")
+    }
+}
+
 task copyNatives(type: Copy) {
     description = "Copies the arcgis native libraries into the project build directory for development."
     group = "build"
@@ -49,6 +60,10 @@ task copyNatives(type: Copy) {
 }
 
 run {
+    doFirst {
+        // sets the API key from the gradle.properties file as a Java system property
+        systemProperty 'apiKey', apiKey
+    }
     dependsOn copyNatives
     mainClassName = 'com.esri.samples.generate_offline_map_with_local_basemap.GenerateOfflineMapWithLocalBasemapLauncher'
 }

--- a/map/generate-offline-map/README.md
+++ b/map/generate-offline-map/README.md
@@ -10,7 +10,7 @@ Taking a web map offline allows users continued productivity when their network 
 
 ## How to use the sample
 
-When the app starts, you will be prompted to sign in using an ArcGIS Online account. Once the map loads, zoom to the extent you want to take offline. The red border shows the extent that will be downloaded. Click the "Take Map Offline" button to start the offline map job. The progress bar will show the job's progress. When complete, the offline map will replace the online map in the map view.
+Once the map loads, zoom to the extent you want to take offline. The red border shows the extent that will be downloaded. Click the "Take Map Offline" button to start the offline map job. The progress bar will show the job's progress. When complete, the offline map will replace the online map in the map view.
 
 ## How it works
 

--- a/map/generate-offline-map/build.gradle
+++ b/map/generate-offline-map/build.gradle
@@ -38,6 +38,17 @@ dependencies {
     runtimeOnly 'org.slf4j:slf4j-nop:1.7.32'
 }
 
+task createGradlePropertiesAndWriteApiKey {
+    description = "Creates a new gradle.properties file with an empty API key variable in the user home ./gradle folder, if the file doesn't already exist."
+    group = "build"
+    def propertiesFile = new File("${System.properties.getProperty("user.home")}/.gradle/gradle.properties")
+    if (!propertiesFile.exists()) {
+        print("Go to " + new URL("https://developers.arcgis.com/dashboard") + " to get an API key.")
+        print(" Add your API key to ${System.properties.getProperty("user.home")}\\.gradle\\gradle.properties.")
+        propertiesFile.write("apiKey = ")
+    }
+}
+
 task copyNatives(type: Copy) {
     description = "Copies the arcgis native libraries into the project build directory for development."
     group = "build"
@@ -49,6 +60,10 @@ task copyNatives(type: Copy) {
 }
 
 run {
+    doFirst {
+        // sets the API key from the gradle.properties file as a Java system property
+        systemProperty 'apiKey', apiKey
+    }
     dependsOn copyNatives
     mainClassName = 'com.esri.samples.generate_offline_map.GenerateOfflineMapLauncher'
 }

--- a/map/generate-offline-map/src/main/java/com/esri/samples/generate_offline_map/GenerateOfflineMapSample.java
+++ b/map/generate-offline-map/src/main/java/com/esri/samples/generate_offline_map/GenerateOfflineMapSample.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Point2D;
@@ -69,15 +70,16 @@ public class GenerateOfflineMapSample extends Application {
       stage.setScene(scene);
       stage.show();
 
+      // authentication with an API key or named user is required to access basemaps and other location services
+      String yourAPIKey = System.getProperty("apiKey");
+      ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
+
       // create a button to take the map offline
       Button offlineMapButton = new Button("Take Map Offline");
       offlineMapButton.setDisable(true);
 
-      // handle authentication with the portal
-      AuthenticationManager.setAuthenticationChallengeHandler(new DefaultAuthenticationChallengeHandler());
-
       // create a portal item with the itemId of the web map
-      Portal portal = new Portal("https://www.arcgis.com", true);
+      Portal portal = new Portal("https://www.arcgis.com");
       PortalItem portalItem = new PortalItem(portal, "acc027394bc84c2fb04d1ed317aac674");
 
       // create a map with the portal item
@@ -122,8 +124,7 @@ public class GenerateOfflineMapSample extends Application {
       });
 
       // create progress bar to show download progress
-      ProgressBar progressBar = new ProgressBar();
-      progressBar.setProgress(0.0);
+      ProgressBar progressBar = new ProgressBar(0.0);
       progressBar.setVisible(false);
 
       // when the button is clicked, start the offline map task job

--- a/map/generate-offline-map/src/main/java/com/esri/samples/generate_offline_map/GenerateOfflineMapSample.java
+++ b/map/generate-offline-map/src/main/java/com/esri/samples/generate_offline_map/GenerateOfflineMapSample.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Point2D;
@@ -32,6 +31,7 @@ import javafx.scene.control.ProgressBar;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
+import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.Job;
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.Point;
@@ -42,8 +42,6 @@ import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.portal.Portal;
 import com.esri.arcgisruntime.portal.PortalItem;
-import com.esri.arcgisruntime.security.AuthenticationManager;
-import com.esri.arcgisruntime.security.DefaultAuthenticationChallengeHandler;
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol;
 import com.esri.arcgisruntime.tasks.offlinemap.GenerateOfflineMapJob;
 import com.esri.arcgisruntime.tasks.offlinemap.GenerateOfflineMapParameters;
@@ -79,8 +77,8 @@ public class GenerateOfflineMapSample extends Application {
       offlineMapButton.setDisable(true);
 
       // create a portal item with the itemId of the web map
-      Portal portal = new Portal("https://www.arcgis.com");
-      PortalItem portalItem = new PortalItem(portal, "acc027394bc84c2fb04d1ed317aac674");
+      var portal = new Portal("https://www.arcgis.com");
+      var portalItem = new PortalItem(portal, "acc027394bc84c2fb04d1ed317aac674");
 
       // create a map with the portal item
       map = new ArcGISMap(portalItem);
@@ -96,7 +94,7 @@ public class GenerateOfflineMapSample extends Application {
       mapView.setMap(map);
 
       // create a graphics overlay for the map view
-      GraphicsOverlay graphicsOverlay = new GraphicsOverlay();
+      var graphicsOverlay = new GraphicsOverlay();
       mapView.getGraphicsOverlays().add(graphicsOverlay);
 
       // create a graphic to show a box around the extent we want to download
@@ -124,7 +122,7 @@ public class GenerateOfflineMapSample extends Application {
       });
 
       // create progress bar to show download progress
-      ProgressBar progressBar = new ProgressBar(0.0);
+      var progressBar = new ProgressBar(0.0);
       progressBar.setVisible(false);
 
       // when the button is clicked, start the offline map task job
@@ -179,7 +177,7 @@ public class GenerateOfflineMapSample extends Application {
   }
 
   /**
-   * Stops and releases all resources used in application.
+   * Stops and releases all resources used in the application.
    */
   @Override
   public void stop() {


### PR DESCRIPTION
This PR updates the Generate Offline Map, Generate Offline Map with Local Basemap and Generate Offline Map Overrides samples to remove the named user authentication workflow and replace with the preferred API key authentication workflow instead. It also updates existing sample code where appropriate and readmes. 

@jenmerritt could you take a look please? 