### PR TITLE
Upgrade to Gradle 7.3

### DIFF
--- a/analysis/analyze-hotspots/build.gradle
+++ b/analysis/analyze-hotspots/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/analysis/analyze-hotspots/gradle/wrapper/gradle-wrapper.properties
+++ b/analysis/analyze-hotspots/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/analysis/distance-measurement-analysis/build.gradle
+++ b/analysis/distance-measurement-analysis/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/analysis/distance-measurement-analysis/gradle/wrapper/gradle-wrapper.properties
+++ b/analysis/distance-measurement-analysis/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/analysis/line-of-sight-geoelement/build.gradle
+++ b/analysis/line-of-sight-geoelement/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/analysis/line-of-sight-geoelement/gradle/wrapper/gradle-wrapper.properties
+++ b/analysis/line-of-sight-geoelement/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/analysis/line-of-sight-location/build.gradle
+++ b/analysis/line-of-sight-location/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/analysis/line-of-sight-location/gradle/wrapper/gradle-wrapper.properties
+++ b/analysis/line-of-sight-location/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/analysis/viewshed-camera/build.gradle
+++ b/analysis/viewshed-camera/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/analysis/viewshed-camera/gradle/wrapper/gradle-wrapper.properties
+++ b/analysis/viewshed-camera/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/analysis/viewshed-geoelement/build.gradle
+++ b/analysis/viewshed-geoelement/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/analysis/viewshed-geoelement/gradle/wrapper/gradle-wrapper.properties
+++ b/analysis/viewshed-geoelement/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/analysis/viewshed-geoprocessing/build.gradle
+++ b/analysis/viewshed-geoprocessing/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/analysis/viewshed-geoprocessing/gradle/wrapper/gradle-wrapper.properties
+++ b/analysis/viewshed-geoprocessing/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/analysis/viewshed-location/build.gradle
+++ b/analysis/viewshed-location/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/analysis/viewshed-location/gradle/wrapper/gradle-wrapper.properties
+++ b/analysis/viewshed-location/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,3 @@
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/add-graphics-with-renderer/build.gradle
+++ b/display_information/add-graphics-with-renderer/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/add-graphics-with-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/add-graphics-with-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display_information/add-graphics-with-symbols/build.gradle
+++ b/display_information/add-graphics-with-symbols/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/add-graphics-with-symbols/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/add-graphics-with-symbols/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display_information/control-annotation-sublayer-visibility/build.gradle
+++ b/display_information/control-annotation-sublayer-visibility/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
     }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/control-annotation-sublayer-visibility/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/control-annotation-sublayer-visibility/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display_information/dictionary-renderer-graphics-overlay/build.gradle
+++ b/display_information/dictionary-renderer-graphics-overlay/build.gradle
@@ -96,5 +96,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/dictionary-renderer-graphics-overlay/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/dictionary-renderer-graphics-overlay/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display_information/display-annotation/build.gradle
+++ b/display_information/display-annotation/build.gradle
@@ -96,5 +96,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/display-grid/build.gradle
+++ b/display_information/display-grid/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/display-grid/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/display-grid/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display_information/format-coordinates/build.gradle
+++ b/display_information/format-coordinates/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/format-coordinates/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/format-coordinates/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display_information/identify-graphics/build.gradle
+++ b/display_information/identify-graphics/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/identify-graphics/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/identify-graphics/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display_information/show-callout/build.gradle
+++ b/display_information/show-callout/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/show-callout/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/show-callout/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display_information/show-labels-on-layer/build.gradle
+++ b/display_information/show-labels-on-layer/build.gradle
@@ -93,5 +93,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/show-labels-on-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/show-labels-on-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display_information/sketch-on-map/build.gradle
+++ b/display_information/sketch-on-map/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/sketch-on-map/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/sketch-on-map/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display_information/update-graphics/build.gradle
+++ b/display_information/update-graphics/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/display_information/update-graphics/gradle/wrapper/gradle-wrapper.properties
+++ b/display_information/update-graphics/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/editing/add-features/build.gradle
+++ b/editing/add-features/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/editing/add-features/gradle/wrapper/gradle-wrapper.properties
+++ b/editing/add-features/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/editing/delete-features/build.gradle
+++ b/editing/delete-features/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/editing/delete-features/gradle/wrapper/gradle-wrapper.properties
+++ b/editing/delete-features/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/editing/edit-and-sync-features/build.gradle
+++ b/editing/edit-and-sync-features/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/editing/edit-and-sync-features/gradle/wrapper/gradle-wrapper.properties
+++ b/editing/edit-and-sync-features/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -93,5 +93,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/editing/edit-feature-attachments/gradle/wrapper/gradle-wrapper.properties
+++ b/editing/edit-feature-attachments/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/editing/edit-features-with-feature-linked-annotation/build.gradle
+++ b/editing/edit-features-with-feature-linked-annotation/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/editing/edit-features-with-feature-linked-annotation/gradle/wrapper/gradle-wrapper.properties
+++ b/editing/edit-features-with-feature-linked-annotation/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/editing/edit-with-branch-versioning/build.gradle
+++ b/editing/edit-with-branch-versioning/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/editing/edit-with-branch-versioning/gradle/wrapper/gradle-wrapper.properties
+++ b/editing/edit-with-branch-versioning/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/editing/update-attributes/build.gradle
+++ b/editing/update-attributes/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/editing/update-attributes/gradle/wrapper/gradle-wrapper.properties
+++ b/editing/update-attributes/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/editing/update-geometries/build.gradle
+++ b/editing/update-geometries/build.gradle
@@ -91,5 +91,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/editing/update-geometries/gradle/wrapper/gradle-wrapper.properties
+++ b/editing/update-geometries/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/change-feature-layer-renderer/build.gradle
+++ b/feature_layers/change-feature-layer-renderer/build.gradle
@@ -91,5 +91,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/change-feature-layer-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/change-feature-layer-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -93,5 +93,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/display-subtype-feature-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/display-subtype-feature-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-collection-layer-from-portal/build.gradle
+++ b/feature_layers/feature-collection-layer-from-portal/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-collection-layer-from-portal/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-collection-layer-from-portal/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-collection-layer-query/build.gradle
+++ b/feature_layers/feature-collection-layer-query/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-collection-layer-query/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-collection-layer-query/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-collection-layer/build.gradle
+++ b/feature_layers/feature-collection-layer/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-collection-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-collection-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-layer-definition-expression/build.gradle
+++ b/feature_layers/feature-layer-definition-expression/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-layer-definition-expression/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-layer-definition-expression/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-layer-dictionary-renderer/build.gradle
+++ b/feature_layers/feature-layer-dictionary-renderer/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-layer-dictionary-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-layer-dictionary-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-layer-extrusion/build.gradle
+++ b/feature_layers/feature-layer-extrusion/build.gradle
@@ -76,5 +76,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-layer-extrusion/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-layer-extrusion/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-layer-feature-service/build.gradle
+++ b/feature_layers/feature-layer-feature-service/build.gradle
@@ -91,5 +91,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-layer-feature-service/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-layer-feature-service/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-layer-geodatabase/build.gradle
+++ b/feature_layers/feature-layer-geodatabase/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-layer-geodatabase/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-layer-geodatabase/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-layer-geopackage/build.gradle
+++ b/feature_layers/feature-layer-geopackage/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-layer-geopackage/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-layer-geopackage/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-layer-query/build.gradle
+++ b/feature_layers/feature-layer-query/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-layer-query/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-layer-query/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-layer-rendering-mode-map/build.gradle
+++ b/feature_layers/feature-layer-rendering-mode-map/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-layer-rendering-mode-map/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-layer-rendering-mode-map/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-layer-selection/build.gradle
+++ b/feature_layers/feature-layer-selection/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-layer-selection/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-layer-selection/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/feature-layer-shapefile/build.gradle
+++ b/feature_layers/feature-layer-shapefile/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/feature-layer-shapefile/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/feature-layer-shapefile/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/generate-geodatabase/build.gradle
+++ b/feature_layers/generate-geodatabase/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/generate-geodatabase/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/generate-geodatabase/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/list-related-features/build.gradle
+++ b/feature_layers/list-related-features/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/list-related-features/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/list-related-features/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/statistical-query-group-and-sort/build.gradle
+++ b/feature_layers/statistical-query-group-and-sort/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/statistical-query-group-and-sort/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/statistical-query-group-and-sort/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/statistical-query/build.gradle
+++ b/feature_layers/statistical-query/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/statistical-query/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/statistical-query/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/time-based-query/build.gradle
+++ b/feature_layers/time-based-query/build.gradle
@@ -91,5 +91,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/time-based-query/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/time-based-query/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/feature_layers/toggle-between-feature-request-modes/build.gradle
+++ b/feature_layers/toggle-between-feature-request-modes/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/feature_layers/toggle-between-feature-request-modes/gradle/wrapper/gradle-wrapper.properties
+++ b/feature_layers/toggle-between-feature-request-modes/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/buffer-list/build.gradle
+++ b/geometry/buffer-list/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/buffer-list/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/buffer-list/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/buffer/build.gradle
+++ b/geometry/buffer/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/buffer/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/buffer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/clip-geometry/build.gradle
+++ b/geometry/clip-geometry/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/clip-geometry/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/clip-geometry/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/convex-hull-list/build.gradle
+++ b/geometry/convex-hull-list/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/convex-hull-list/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/convex-hull-list/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/convex-hull/build.gradle
+++ b/geometry/convex-hull/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/convex-hull/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/convex-hull/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/create-geometries/build.gradle
+++ b/geometry/create-geometries/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/create-geometries/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/create-geometries/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/cut-geometry/build.gradle
+++ b/geometry/cut-geometry/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/cut-geometry/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/cut-geometry/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/densify-and-generalize/build.gradle
+++ b/geometry/densify-and-generalize/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/densify-and-generalize/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/densify-and-generalize/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/geodesic-operations/build.gradle
+++ b/geometry/geodesic-operations/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/geodesic-operations/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/geodesic-operations/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/geodesic-sector-and-ellipse/build.gradle
+++ b/geometry/geodesic-sector-and-ellipse/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/geodesic-sector-and-ellipse/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/geodesic-sector-and-ellipse/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/geometry-engine-simplify/build.gradle
+++ b/geometry/geometry-engine-simplify/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/geometry-engine-simplify/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/geometry-engine-simplify/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/list-transformations-by-suitability/build.gradle
+++ b/geometry/list-transformations-by-suitability/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/list-transformations-by-suitability/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/list-transformations-by-suitability/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/nearest-vertex/build.gradle
+++ b/geometry/nearest-vertex/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/nearest-vertex/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/nearest-vertex/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/project/build.gradle
+++ b/geometry/project/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/project/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/spatial-operations/build.gradle
+++ b/geometry/spatial-operations/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/spatial-operations/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/spatial-operations/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/geometry/spatial-relationships/build.gradle
+++ b/geometry/spatial-relationships/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/geometry/spatial-relationships/gradle/wrapper/gradle-wrapper.properties
+++ b/geometry/spatial-relationships/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip

--- a/group_layers/group-layers/build.gradle
+++ b/group_layers/group-layers/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/group_layers/group-layers/gradle/wrapper/gradle-wrapper.properties
+++ b/group_layers/group-layers/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hydrography/add-enc-exchange-set/build.gradle
+++ b/hydrography/add-enc-exchange-set/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/hydrography/add-enc-exchange-set/gradle/wrapper/gradle-wrapper.properties
+++ b/hydrography/add-enc-exchange-set/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/image_layers/change-sublayer-renderer/build.gradle
+++ b/image_layers/change-sublayer-renderer/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/image_layers/change-sublayer-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/image_layers/change-sublayer-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/image_layers/map-image-layer-sublayer-visibility/build.gradle
+++ b/image_layers/map-image-layer-sublayer-visibility/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/image_layers/map-image-layer-sublayer-visibility/gradle/wrapper/gradle-wrapper.properties
+++ b/image_layers/map-image-layer-sublayer-visibility/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/image_layers/map-image-layer-tables/build.gradle
+++ b/image_layers/map-image-layer-tables/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/image_layers/map-image-layer-tables/gradle/wrapper/gradle-wrapper.properties
+++ b/image_layers/map-image-layer-tables/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/image_layers/map-image-layer/build.gradle
+++ b/image_layers/map-image-layer/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/image_layers/map-image-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/image_layers/map-image-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/image_layers/query-map-image-sublayer/build.gradle
+++ b/image_layers/query-map-image-sublayer/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/image_layers/query-map-image-sublayer/gradle/wrapper/gradle-wrapper.properties
+++ b/image_layers/query-map-image-sublayer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kml/create-and-save-kml-file/build.gradle
+++ b/kml/create-and-save-kml-file/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/kml/create-and-save-kml-file/gradle/wrapper/gradle-wrapper.properties
+++ b/kml/create-and-save-kml-file/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kml/display-kml-network-links/build.gradle
+++ b/kml/display-kml-network-links/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/kml/display-kml-network-links/gradle/wrapper/gradle-wrapper.properties
+++ b/kml/display-kml-network-links/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kml/display-kml/build.gradle
+++ b/kml/display-kml/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/kml/display-kml/gradle/wrapper/gradle-wrapper.properties
+++ b/kml/display-kml/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kml/edit-kml-ground-overlay/build.gradle
+++ b/kml/edit-kml-ground-overlay/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/kml/edit-kml-ground-overlay/gradle/wrapper/gradle-wrapper.properties
+++ b/kml/edit-kml-ground-overlay/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kml/identify-kml-features/build.gradle
+++ b/kml/identify-kml-features/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/kml/identify-kml-features/gradle/wrapper/gradle-wrapper.properties
+++ b/kml/identify-kml-features/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kml/list-kml-contents/build.gradle
+++ b/kml/list-kml-contents/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/kml/list-kml-contents/gradle/wrapper/gradle-wrapper.properties
+++ b/kml/list-kml-contents/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kml/play-a-kml-tour/build.gradle
+++ b/kml/play-a-kml-tour/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/kml/play-a-kml-tour/gradle/wrapper/gradle-wrapper.properties
+++ b/kml/play-a-kml-tour/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/local_server/local-server-feature-layer/build.gradle
+++ b/local_server/local-server-feature-layer/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/local_server/local-server-feature-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/local_server/local-server-feature-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/local_server/local-server-geoprocessing/build.gradle
+++ b/local_server/local-server-geoprocessing/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/local_server/local-server-geoprocessing/gradle/wrapper/gradle-wrapper.properties
+++ b/local_server/local-server-geoprocessing/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/local_server/local-server-map-image-layer/build.gradle
+++ b/local_server/local-server-map-image-layer/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/local_server/local-server-map-image-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/local_server/local-server-map-image-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/local_server/local-server-services/build.gradle
+++ b/local_server/local-server-services/build.gradle
@@ -81,5 +81,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/local_server/local-server-services/gradle/wrapper/gradle-wrapper.properties
+++ b/local_server/local-server-services/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/access-load-status/gradle/wrapper/gradle-wrapper.properties
+++ b/map/access-load-status/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
@@ -81,5 +81,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/change-basemap/gradle/wrapper/gradle-wrapper.properties
+++ b/map/change-basemap/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -78,5 +78,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/create-and-save-map/gradle/wrapper/gradle-wrapper.properties
+++ b/map/create-and-save-map/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/display-map/gradle/wrapper/gradle-wrapper.properties
+++ b/map/display-map/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/download-preplanned-map/build.gradle
+++ b/map/download-preplanned-map/build.gradle
@@ -78,5 +78,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/download-preplanned-map/gradle/wrapper/gradle-wrapper.properties
+++ b/map/download-preplanned-map/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/generate-offline-map-overrides/build.gradle
+++ b/map/generate-offline-map-overrides/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/generate-offline-map-overrides/gradle/wrapper/gradle-wrapper.properties
+++ b/map/generate-offline-map-overrides/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/generate-offline-map-with-local-basemap/build.gradle
+++ b/map/generate-offline-map-with-local-basemap/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/generate-offline-map-with-local-basemap/gradle/wrapper/gradle-wrapper.properties
+++ b/map/generate-offline-map-with-local-basemap/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/generate-offline-map/build.gradle
+++ b/map/generate-offline-map/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/generate-offline-map/gradle/wrapper/gradle-wrapper.properties
+++ b/map/generate-offline-map/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/honor-mobile-map-package-expiration-date/build.gradle
+++ b/map/honor-mobile-map-package-expiration-date/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
     }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/honor-mobile-map-package-expiration-date/gradle/wrapper/gradle-wrapper.properties
+++ b/map/honor-mobile-map-package-expiration-date/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/manage-bookmarks/build.gradle
+++ b/map/manage-bookmarks/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/manage-bookmarks/gradle/wrapper/gradle-wrapper.properties
+++ b/map/manage-bookmarks/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/manage-operational-layers/build.gradle
+++ b/map/manage-operational-layers/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/manage-operational-layers/gradle/wrapper/gradle-wrapper.properties
+++ b/map/manage-operational-layers/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/map-initial-extent/build.gradle
+++ b/map/map-initial-extent/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/map-initial-extent/gradle/wrapper/gradle-wrapper.properties
+++ b/map/map-initial-extent/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/map-reference-scale/build.gradle
+++ b/map/map-reference-scale/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/map-reference-scale/gradle/wrapper/gradle-wrapper.properties
+++ b/map/map-reference-scale/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/map-spatial-reference/build.gradle
+++ b/map/map-spatial-reference/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/map-spatial-reference/gradle/wrapper/gradle-wrapper.properties
+++ b/map/map-spatial-reference/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/min-max-scale/build.gradle
+++ b/map/min-max-scale/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/min-max-scale/gradle/wrapper/gradle-wrapper.properties
+++ b/map/min-max-scale/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/mobile-map-search-and-route/build.gradle
+++ b/map/mobile-map-search-and-route/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/mobile-map-search-and-route/gradle/wrapper/gradle-wrapper.properties
+++ b/map/mobile-map-search-and-route/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/open-map-url/build.gradle
+++ b/map/open-map-url/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/open-map-url/gradle/wrapper/gradle-wrapper.properties
+++ b/map/open-map-url/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/open-mobile-map-package/build.gradle
+++ b/map/open-mobile-map-package/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/open-mobile-map-package/gradle/wrapper/gradle-wrapper.properties
+++ b/map/open-mobile-map-package/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/read-geopackage/build.gradle
+++ b/map/read-geopackage/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/read-geopackage/gradle/wrapper/gradle-wrapper.properties
+++ b/map/read-geopackage/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map/set-initial-map-location/build.gradle
+++ b/map/set-initial-map-location/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map/set-initial-map-location/gradle/wrapper/gradle-wrapper.properties
+++ b/map/set-initial-map-location/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/change-viewpoint/build.gradle
+++ b/map_view/change-viewpoint/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/change-viewpoint/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/change-viewpoint/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/display-device-location-with-autopan-modes/build.gradle
+++ b/map_view/display-device-location-with-autopan-modes/build.gradle
@@ -93,5 +93,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/display-device-location-with-autopan-modes/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/display-device-location-with-autopan-modes/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/display-device-location-with-nmea-data-sources/build.gradle
+++ b/map_view/display-device-location-with-nmea-data-sources/build.gradle
@@ -93,5 +93,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/display-device-location-with-nmea-data-sources/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/display-device-location-with-nmea-data-sources/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/display-drawing-status/build.gradle
+++ b/map_view/display-drawing-status/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/display-drawing-status/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/display-drawing-status/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/display-layer-view-state/build.gradle
+++ b/map_view/display-layer-view-state/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/display-layer-view-state/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/display-layer-view-state/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/identify-layers/build.gradle
+++ b/map_view/identify-layers/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/identify-layers/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/identify-layers/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -93,5 +93,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/map-rotation/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/map-rotation/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -93,5 +93,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/scale-bar/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/scale-bar/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/set-up-location-driven-geotriggers/build.gradle
+++ b/map_view/set-up-location-driven-geotriggers/build.gradle
@@ -93,5 +93,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/set-up-location-driven-geotriggers/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/set-up-location-driven-geotriggers/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/show-location-history/build.gradle
+++ b/map_view/show-location-history/build.gradle
@@ -93,5 +93,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/show-location-history/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/show-location-history/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/map_view/take-screenshot/gradle/wrapper/gradle-wrapper.properties
+++ b/map_view/take-screenshot/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/network_analysis/closest-facility-static/build.gradle
+++ b/network_analysis/closest-facility-static/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/network_analysis/closest-facility-static/gradle/wrapper/gradle-wrapper.properties
+++ b/network_analysis/closest-facility-static/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/network_analysis/closest-facility/build.gradle
+++ b/network_analysis/closest-facility/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/network_analysis/closest-facility/gradle/wrapper/gradle-wrapper.properties
+++ b/network_analysis/closest-facility/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/network_analysis/find-route/build.gradle
+++ b/network_analysis/find-route/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/network_analysis/find-route/gradle/wrapper/gradle-wrapper.properties
+++ b/network_analysis/find-route/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
+++ b/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/network_analysis/find-service-areas-for-multiple-facilities/gradle/wrapper/gradle-wrapper.properties
+++ b/network_analysis/find-service-areas-for-multiple-facilities/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/network_analysis/offline-routing/build.gradle
+++ b/network_analysis/offline-routing/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/network_analysis/offline-routing/gradle/wrapper/gradle-wrapper.properties
+++ b/network_analysis/offline-routing/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/network_analysis/routing-around-barriers/build.gradle
+++ b/network_analysis/routing-around-barriers/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/network_analysis/routing-around-barriers/gradle/wrapper/gradle-wrapper.properties
+++ b/network_analysis/routing-around-barriers/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/network_analysis/service-area-task/build.gradle
+++ b/network_analysis/service-area-task/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/network_analysis/service-area-task/gradle/wrapper/gradle-wrapper.properties
+++ b/network_analysis/service-area-task/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ogc/browse-ogc-api-feature-service/build.gradle
+++ b/ogc/browse-ogc-api-feature-service/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/ogc/browse-ogc-api-feature-service/gradle/wrapper/gradle-wrapper.properties
+++ b/ogc/browse-ogc-api-feature-service/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ogc/browse-wfs-layers/build.gradle
+++ b/ogc/browse-wfs-layers/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/ogc/browse-wfs-layers/gradle/wrapper/gradle-wrapper.properties
+++ b/ogc/browse-wfs-layers/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ogc/display-ogc-api-collection/build.gradle
+++ b/ogc/display-ogc-api-collection/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/ogc/display-ogc-api-collection/gradle/wrapper/gradle-wrapper.properties
+++ b/ogc/display-ogc-api-collection/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ogc/display-wfs-layer/build.gradle
+++ b/ogc/display-wfs-layer/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/ogc/display-wfs-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/ogc/display-wfs-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ogc/open-street-map-layer/build.gradle
+++ b/ogc/open-street-map-layer/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/ogc/open-street-map-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/ogc/open-street-map-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ogc/query-with-cql-filters/build.gradle
+++ b/ogc/query-with-cql-filters/build.gradle
@@ -87,5 +87,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/ogc/query-with-cql-filters/gradle/wrapper/gradle-wrapper.properties
+++ b/ogc/query-with-cql-filters/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ogc/style-wms-layer/build.gradle
+++ b/ogc/style-wms-layer/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/ogc/style-wms-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/ogc/style-wms-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ogc/wfs-xml-query/build.gradle
+++ b/ogc/wfs-xml-query/build.gradle
@@ -93,5 +93,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/ogc/wfs-xml-query/gradle/wrapper/gradle-wrapper.properties
+++ b/ogc/wfs-xml-query/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ogc/wms-layer-url/build.gradle
+++ b/ogc/wms-layer-url/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/ogc/wms-layer-url/gradle/wrapper/gradle-wrapper.properties
+++ b/ogc/wms-layer-url/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ogc/wmts-layer/build.gradle
+++ b/ogc/wmts-layer/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/ogc/wmts-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/ogc/wmts-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/portal/integrated-windows-authentication/build.gradle
+++ b/portal/integrated-windows-authentication/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/portal/integrated-windows-authentication/gradle/wrapper/gradle-wrapper.properties
+++ b/portal/integrated-windows-authentication/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/portal/oauth/build.gradle
+++ b/portal/oauth/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/portal/oauth/gradle/wrapper/gradle-wrapper.properties
+++ b/portal/oauth/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/portal/token-authentication/build.gradle
+++ b/portal/token-authentication/build.gradle
@@ -76,5 +76,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/portal/token-authentication/gradle/wrapper/gradle-wrapper.properties
+++ b/portal/token-authentication/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/portal/webmap-keyword-search/build.gradle
+++ b/portal/webmap-keyword-search/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/portal/webmap-keyword-search/gradle/wrapper/gradle-wrapper.properties
+++ b/portal/webmap-keyword-search/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/apply-mosaic-rule-to-rasters/build.gradle
+++ b/raster/apply-mosaic-rule-to-rasters/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/apply-mosaic-rule-to-rasters/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/apply-mosaic-rule-to-rasters/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/blend-renderer/build.gradle
+++ b/raster/blend-renderer/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/blend-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/blend-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/colormap-renderer/build.gradle
+++ b/raster/colormap-renderer/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/colormap-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/colormap-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/hillshade-renderer/build.gradle
+++ b/raster/hillshade-renderer/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/hillshade-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/hillshade-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/identify-raster-cell/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/identify-raster-cell/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/raster-function/build.gradle
+++ b/raster/raster-function/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/raster-function/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/raster-function/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/raster-layer-file/build.gradle
+++ b/raster/raster-layer-file/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/raster-layer-file/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/raster-layer-file/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/raster-layer-geopackage/build.gradle
+++ b/raster/raster-layer-geopackage/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/raster-layer-geopackage/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/raster-layer-geopackage/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/raster-layer-url/build.gradle
+++ b/raster/raster-layer-url/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/raster-layer-url/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/raster-layer-url/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/raster-rendering-rule/build.gradle
+++ b/raster/raster-rendering-rule/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/raster-rendering-rule/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/raster-rendering-rule/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/rgb-renderer/build.gradle
+++ b/raster/rgb-renderer/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/rgb-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/rgb-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/raster/stretch-renderer/build.gradle
+++ b/raster/stretch-renderer/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/raster/stretch-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/raster/stretch-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/add-a-point-scene-layer/build.gradle
+++ b/scene/add-a-point-scene-layer/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/add-a-point-scene-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/add-a-point-scene-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/add-an-integrated-mesh-layer/build.gradle
+++ b/scene/add-an-integrated-mesh-layer/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/add-an-integrated-mesh-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/add-an-integrated-mesh-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/animate-3d-graphic/build.gradle
+++ b/scene/animate-3d-graphic/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/animate-3d-graphic/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/animate-3d-graphic/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/animate-images-with-image-overlay/build.gradle
+++ b/scene/animate-images-with-image-overlay/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/animate-images-with-image-overlay/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/animate-images-with-image-overlay/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/change-atmosphere-effect/build.gradle
+++ b/scene/change-atmosphere-effect/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/change-atmosphere-effect/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/change-atmosphere-effect/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/choose-camera-controller/build.gradle
+++ b/scene/choose-camera-controller/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/choose-camera-controller/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/choose-camera-controller/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/create-terrain-surface-from-local-raster/build.gradle
+++ b/scene/create-terrain-surface-from-local-raster/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/create-terrain-surface-from-local-raster/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/create-terrain-surface-from-local-raster/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/create-terrain-surface-from-local-tile-package/build.gradle
+++ b/scene/create-terrain-surface-from-local-tile-package/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/create-terrain-surface-from-local-tile-package/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/create-terrain-surface-from-local-tile-package/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/display-scene/build.gradle
+++ b/scene/display-scene/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/display-scene/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/display-scene/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/distance-composite-symbol/build.gradle
+++ b/scene/distance-composite-symbol/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/distance-composite-symbol/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/distance-composite-symbol/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/extrude-graphics/build.gradle
+++ b/scene/extrude-graphics/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/extrude-graphics/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/extrude-graphics/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/feature-layer-rendering-mode-scene/build.gradle
+++ b/scene/feature-layer-rendering-mode-scene/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/feature-layer-rendering-mode-scene/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/feature-layer-rendering-mode-scene/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/get-elevation-at-a-point/build.gradle
+++ b/scene/get-elevation-at-a-point/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/get-elevation-at-a-point/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/get-elevation-at-a-point/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/open-mobile-scene-package/build.gradle
+++ b/scene/open-mobile-scene-package/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/open-mobile-scene-package/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/open-mobile-scene-package/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/open-scene-portal-item/build.gradle
+++ b/scene/open-scene-portal-item/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/open-scene-portal-item/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/open-scene-portal-item/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/orbit-the-camera-around-an-object/build.gradle
+++ b/scene/orbit-the-camera-around-an-object/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/orbit-the-camera-around-an-object/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/orbit-the-camera-around-an-object/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/realistic-lighting-and-shadows/build.gradle
+++ b/scene/realistic-lighting-and-shadows/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/realistic-lighting-and-shadows/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/realistic-lighting-and-shadows/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/scene-layer-selection/build.gradle
+++ b/scene/scene-layer-selection/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/scene-layer-selection/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/scene-layer-selection/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/scene-layer/build.gradle
+++ b/scene/scene-layer/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/scene-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/scene-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/scene-properties-expressions/build.gradle
+++ b/scene/scene-properties-expressions/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/scene-properties-expressions/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/scene-properties-expressions/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/show-labels-on-layer-in-3d/build.gradle
+++ b/scene/show-labels-on-layer-in-3d/build.gradle
@@ -78,5 +78,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/show-labels-on-layer-in-3d/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/show-labels-on-layer-in-3d/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/surface-placement/build.gradle
+++ b/scene/surface-placement/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/surface-placement/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/surface-placement/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/symbols/build.gradle
+++ b/scene/symbols/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/symbols/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/symbols/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/sync-map-and-scene-viewpoints/build.gradle
+++ b/scene/sync-map-and-scene-viewpoints/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/sync-map-and-scene-viewpoints/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/sync-map-and-scene-viewpoints/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/terrain-exaggeration/build.gradle
+++ b/scene/terrain-exaggeration/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/terrain-exaggeration/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/terrain-exaggeration/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/view-content-beneath-terrain-surface/build.gradle
+++ b/scene/view-content-beneath-terrain-surface/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/view-content-beneath-terrain-surface/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/view-content-beneath-terrain-surface/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scene/view-point-cloud-data-offline/build.gradle
+++ b/scene/view-point-cloud-data-offline/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/scene/view-point-cloud-data-offline/gradle/wrapper/gradle-wrapper.properties
+++ b/scene/view-point-cloud-data-offline/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/search/find-address/build.gradle
+++ b/search/find-address/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/search/find-address/gradle/wrapper/gradle-wrapper.properties
+++ b/search/find-address/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/search/find-place/build.gradle
+++ b/search/find-place/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/search/find-place/gradle/wrapper/gradle-wrapper.properties
+++ b/search/find-place/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/search/offline-geocode/build.gradle
+++ b/search/offline-geocode/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/search/offline-geocode/gradle/wrapper/gradle-wrapper.properties
+++ b/search/offline-geocode/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/search/reverse-geocode-online/build.gradle
+++ b/search/reverse-geocode-online/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/search/reverse-geocode-online/gradle/wrapper/gradle-wrapper.properties
+++ b/search/reverse-geocode-online/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/create-symbol-styles-from-web-styles/build.gradle
+++ b/symbology/create-symbol-styles-from-web-styles/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/create-symbol-styles-from-web-styles/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/create-symbol-styles-from-web-styles/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/custom-dictionary-style/build.gradle
+++ b/symbology/custom-dictionary-style/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/custom-dictionary-style/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/custom-dictionary-style/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
@@ -81,5 +81,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/graphics-overlay-dictionary-renderer-3D/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/picture-marker-symbol/build.gradle
+++ b/symbology/picture-marker-symbol/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/picture-marker-symbol/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/picture-marker-symbol/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/read-symbols-from-mobile-style-file/build.gradle
+++ b/symbology/read-symbols-from-mobile-style-file/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/read-symbols-from-mobile-style-file/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/read-symbols-from-mobile-style-file/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/simple-fill-symbol/build.gradle
+++ b/symbology/simple-fill-symbol/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/simple-fill-symbol/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/simple-fill-symbol/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/simple-line-symbol/build.gradle
+++ b/symbology/simple-line-symbol/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/simple-line-symbol/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/simple-line-symbol/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/simple-marker-symbol/build.gradle
+++ b/symbology/simple-marker-symbol/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/simple-marker-symbol/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/simple-marker-symbol/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/simple-renderer/build.gradle
+++ b/symbology/simple-renderer/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/simple-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/simple-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/symbol-dictionary/build.gradle
+++ b/symbology/symbol-dictionary/build.gradle
@@ -81,5 +81,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/symbol-dictionary/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/symbol-dictionary/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/symbolize-shapefile/build.gradle
+++ b/symbology/symbolize-shapefile/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/symbolize-shapefile/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/symbolize-shapefile/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/symbology/unique-value-renderer/build.gradle
+++ b/symbology/unique-value-renderer/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/symbology/unique-value-renderer/gradle/wrapper/gradle-wrapper.properties
+++ b/symbology/unique-value-renderer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tiled_layers/export-tiles/build.gradle
+++ b/tiled_layers/export-tiles/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/tiled_layers/export-tiles/gradle/wrapper/gradle-wrapper.properties
+++ b/tiled_layers/export-tiles/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tiled_layers/export-vector-tiles/build.gradle
+++ b/tiled_layers/export-vector-tiles/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/tiled_layers/export-vector-tiles/gradle/wrapper/gradle-wrapper.properties
+++ b/tiled_layers/export-vector-tiles/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tiled_layers/tile-cache/build.gradle
+++ b/tiled_layers/tile-cache/build.gradle
@@ -80,5 +80,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/tiled_layers/tile-cache/gradle/wrapper/gradle-wrapper.properties
+++ b/tiled_layers/tile-cache/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tiled_layers/tiled-layer/build.gradle
+++ b/tiled_layers/tiled-layer/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/tiled_layers/tiled-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/tiled_layers/tiled-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tiled_layers/vector-tiled-layer-url/build.gradle
+++ b/tiled_layers/vector-tiled-layer-url/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/tiled_layers/vector-tiled-layer-url/gradle/wrapper/gradle-wrapper.properties
+++ b/tiled_layers/vector-tiled-layer-url/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tiled_layers/web-tiled-layer/build.gradle
+++ b/tiled_layers/web-tiled-layer/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/tiled_layers/web-tiled-layer/gradle/wrapper/gradle-wrapper.properties
+++ b/tiled_layers/web-tiled-layer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/utility_network/configure-subnetwork-trace/build.gradle
+++ b/utility_network/configure-subnetwork-trace/build.gradle
@@ -77,5 +77,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/utility_network/configure-subnetwork-trace/gradle/wrapper/gradle-wrapper.properties
+++ b/utility_network/configure-subnetwork-trace/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Dec 18 12:49:56 GMT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/utility_network/display-content-of-utility-network-container/build.gradle
+++ b/utility_network/display-content-of-utility-network-container/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/utility_network/display-content-of-utility-network-container/gradle/wrapper/gradle-wrapper.properties
+++ b/utility_network/display-content-of-utility-network-container/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue Sep 14 14:29:56 GMT 2021
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -92,5 +92,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/utility_network/display-utility-associations/gradle/wrapper/gradle-wrapper.properties
+++ b/utility_network/display-utility-associations/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/utility_network/perform-valve-isolation-trace/build.gradle
+++ b/utility_network/perform-valve-isolation-trace/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/utility_network/perform-valve-isolation-trace/gradle/wrapper/gradle-wrapper.properties
+++ b/utility_network/perform-valve-isolation-trace/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/utility_network/trace-a-utility-network/build.gradle
+++ b/utility_network/trace-a-utility-network/build.gradle
@@ -95,5 +95,5 @@ task productionZip(type: Zip) {
 }
 
 wrapper {
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.3'
 }

--- a/utility_network/trace-a-utility-network/gradle/wrapper/gradle-wrapper.properties
+++ b/utility_network/trace-a-utility-network/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates all samples to Gradle 7.3, in support of users who want to run samples using Java 17. @mbcoder @jenmerritt could you take a look please?