### PR TITLE
Add dispose method to preview map view

### DIFF
--- a/tiled_layers/export-tiles/src/main/java/com/esri/samples/export_tiles/ExportTilesSample.java
+++ b/tiled_layers/export-tiles/src/main/java/com/esri/samples/export_tiles/ExportTilesSample.java
@@ -54,6 +54,7 @@ import com.esri.arcgisruntime.tasks.tilecache.ExportTileCacheTask;
 public class ExportTilesSample extends Application {
 
   private MapView mapView;
+  private MapView previewMapView;
 
   @Override
   public void start(Stage stage) {
@@ -119,7 +120,6 @@ public class ExportTilesSample extends Application {
           Layer layer = map.getBasemap().getBaseLayers().get(0);
           if (layer instanceof ArcGISTiledLayer) {
             ArcGISTiledLayer tiledLayer = (ArcGISTiledLayer) layer;
-
             // create progress bar to show task progress
             var progressBar = new ProgressBar(0.0);
             progressBar.setVisible(false);
@@ -166,13 +166,15 @@ public class ExportTilesSample extends Application {
                         preview.initOwner(mapView.getScene().getWindow());
                         preview.setTitle("Preview");
                         preview.setHeaderText("Exported to " + tileCache.getPath());
-                        MapView mapPreview = new MapView();
-                        mapPreview.setMinSize(400, 400);
+                        previewMapView = new MapView();
+                        previewMapView.setMinSize(400, 400);
                         ArcGISTiledLayer tiledLayerPreview = new ArcGISTiledLayer(tileCache);
                         ArcGISMap previewMap = new ArcGISMap(new Basemap(tiledLayerPreview));
-                        mapPreview.setMap(previewMap);
-                        preview.getDialogPane().setContent(mapPreview);
+                        previewMapView.setMap(previewMap);
+                        preview.getDialogPane().setContent(previewMapView);
                         preview.show();
+                        // dispose of the preview mapview's resources
+                        preview.setOnCloseRequest(event -> previewMapView.dispose());
 
                       } else {
                         new Alert(Alert.AlertType.ERROR, exportTileCacheJob.getError().getAdditionalMessage()).show();

--- a/tiled_layers/export-tiles/src/main/java/com/esri/samples/export_tiles/ExportTilesSample.java
+++ b/tiled_layers/export-tiles/src/main/java/com/esri/samples/export_tiles/ExportTilesSample.java
@@ -54,7 +54,6 @@ import com.esri.arcgisruntime.tasks.tilecache.ExportTileCacheTask;
 public class ExportTilesSample extends Application {
 
   private MapView mapView;
-  private MapView previewMapView;
 
   @Override
   public void start(Stage stage) {
@@ -166,7 +165,7 @@ public class ExportTilesSample extends Application {
                         preview.initOwner(mapView.getScene().getWindow());
                         preview.setTitle("Preview");
                         preview.setHeaderText("Exported to " + tileCache.getPath());
-                        previewMapView = new MapView();
+                        MapView previewMapView = new MapView();
                         previewMapView.setMinSize(400, 400);
                         ArcGISTiledLayer tiledLayerPreview = new ArcGISTiledLayer(tileCache);
                         ArcGISMap previewMap = new ArcGISMap(new Basemap(tiledLayerPreview));

--- a/tiled_layers/export-vector-tiles/src/main/java/com/esri/samples/export_vector_tiles/ExportVectorTilesSample.java
+++ b/tiled_layers/export-vector-tiles/src/main/java/com/esri/samples/export_vector_tiles/ExportVectorTilesSample.java
@@ -56,7 +56,6 @@ import com.esri.arcgisruntime.tasks.vectortilecache.ExportVectorTilesTask;
 public class ExportVectorTilesSample extends Application {
 
   private MapView mapView;
-  private MapView previewMapView;
 
   @Override
   public void start(Stage stage) {
@@ -181,7 +180,7 @@ public class ExportVectorTilesSample extends Application {
                         preview.setTitle("Preview");
                         preview.setHeaderText("Exported tiles to " + tileCache.getPath() + "\nExported resources to " +
                           resourceCache.getPath());
-                        previewMapView = new MapView();
+                        MapView previewMapView = new MapView();
                         previewMapView.setMinSize(400, 400);
                         ArcGISVectorTiledLayer vectorTiledLayerPreview = new ArcGISVectorTiledLayer(tileCache, resourceCache);
                         ArcGISMap previewMap = new ArcGISMap(new Basemap(vectorTiledLayerPreview));


### PR DESCRIPTION
The sample viewer was occasionally crashing due to the second map view in the export tiles and export vector tiles samples not being disposed of. This PR addresses this. @colinanderson could you have a look please? 