### PR TITLE
Add redirect urls to Toggle between feature modes sample

### DIFF
--- a/feature_layers/toggle-between-feature-request-modes/README.metadata.json
+++ b/feature_layers/toggle-between-feature-request-modes/README.metadata.json
@@ -15,7 +15,11 @@
     "ServiceFeatureTable",
     "ServiceFeatureTable.FeatureRequestMode"
   ],
-  "redirect_from": "",
+  "redirect_from": [
+    "/java/sample-code/service-feature-table-cache/",
+    "/java/sample-code/service-feature-table-manual-cache/",
+    "/java/sample-code/service-feature-table-no-cache/"
+  ],
   "relevant_apis": [
     "FeatureLayer",
     "ServiceFeatureTable",


### PR DESCRIPTION
This PR adds redirects to the newer Toggle between feature modes sample. This newer sample combined the original three individual samples, and as such requires a redirect url so that if a user has bookmarked an earlier version of the sample, they will be redirected to this one. @jenmerritt please could you take a look? thanks! 