### PR TITLE
Update to JavaFX 17 and 100.14.0 Toolkit

### DIFF
--- a/analysis/analyze-hotspots/build.gradle
+++ b/analysis/analyze-hotspots/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/analysis/analyze-hotspots/build.gradle
+++ b/analysis/analyze-hotspots/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/analysis/distance-measurement-analysis/build.gradle
+++ b/analysis/distance-measurement-analysis/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/analysis/distance-measurement-analysis/build.gradle
+++ b/analysis/distance-measurement-analysis/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/analysis/line-of-sight-geoelement/build.gradle
+++ b/analysis/line-of-sight-geoelement/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/analysis/line-of-sight-geoelement/build.gradle
+++ b/analysis/line-of-sight-geoelement/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/analysis/line-of-sight-location/build.gradle
+++ b/analysis/line-of-sight-location/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/analysis/line-of-sight-location/build.gradle
+++ b/analysis/line-of-sight-location/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/analysis/viewshed-camera/build.gradle
+++ b/analysis/viewshed-camera/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/analysis/viewshed-camera/build.gradle
+++ b/analysis/viewshed-camera/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/analysis/viewshed-geoelement/build.gradle
+++ b/analysis/viewshed-geoelement/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/analysis/viewshed-geoelement/build.gradle
+++ b/analysis/viewshed-geoelement/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/analysis/viewshed-geoprocessing/build.gradle
+++ b/analysis/viewshed-geoprocessing/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/analysis/viewshed-geoprocessing/build.gradle
+++ b/analysis/viewshed-geoprocessing/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/analysis/viewshed-location/build.gradle
+++ b/analysis/viewshed-location/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/analysis/viewshed-location/build.gradle
+++ b/analysis/viewshed-location/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/add-graphics-with-renderer/build.gradle
+++ b/display_information/add-graphics-with-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/add-graphics-with-renderer/build.gradle
+++ b/display_information/add-graphics-with-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/display_information/add-graphics-with-symbols/build.gradle
+++ b/display_information/add-graphics-with-symbols/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/add-graphics-with-symbols/build.gradle
+++ b/display_information/add-graphics-with-symbols/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/display_information/control-annotation-sublayer-visibility/build.gradle
+++ b/display_information/control-annotation-sublayer-visibility/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/control-annotation-sublayer-visibility/build.gradle
+++ b/display_information/control-annotation-sublayer-visibility/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/display_information/dictionary-renderer-graphics-overlay/build.gradle
+++ b/display_information/dictionary-renderer-graphics-overlay/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/dictionary-renderer-graphics-overlay/build.gradle
+++ b/display_information/dictionary-renderer-graphics-overlay/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/display_information/display-annotation/build.gradle
+++ b/display_information/display-annotation/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/display-annotation/build.gradle
+++ b/display_information/display-annotation/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/display_information/display-dimensions/build.gradle
+++ b/display_information/display-dimensions/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/display-dimensions/build.gradle
+++ b/display_information/display-dimensions/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/display_information/display-grid/build.gradle
+++ b/display_information/display-grid/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/display_information/display-grid/build.gradle
+++ b/display_information/display-grid/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/format-coordinates/build.gradle
+++ b/display_information/format-coordinates/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/format-coordinates/build.gradle
+++ b/display_information/format-coordinates/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/display_information/identify-graphics/build.gradle
+++ b/display_information/identify-graphics/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/identify-graphics/build.gradle
+++ b/display_information/identify-graphics/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/display_information/show-callout/build.gradle
+++ b/display_information/show-callout/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/show-callout/build.gradle
+++ b/display_information/show-callout/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/display_information/show-labels-on-layer/build.gradle
+++ b/display_information/show-labels-on-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/show-labels-on-layer/build.gradle
+++ b/display_information/show-labels-on-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/display_information/sketch-on-map/build.gradle
+++ b/display_information/sketch-on-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/display_information/sketch-on-map/build.gradle
+++ b/display_information/sketch-on-map/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/update-graphics/build.gradle
+++ b/display_information/update-graphics/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/display_information/update-graphics/build.gradle
+++ b/display_information/update-graphics/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/editing/add-features/build.gradle
+++ b/editing/add-features/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/editing/add-features/build.gradle
+++ b/editing/add-features/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/editing/delete-features/build.gradle
+++ b/editing/delete-features/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/editing/delete-features/build.gradle
+++ b/editing/delete-features/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/editing/edit-and-sync-features/build.gradle
+++ b/editing/edit-and-sync-features/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/editing/edit-and-sync-features/build.gradle
+++ b/editing/edit-and-sync-features/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/editing/edit-feature-attachments/build.gradle
+++ b/editing/edit-feature-attachments/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/editing/edit-features-with-feature-linked-annotation/build.gradle
+++ b/editing/edit-features-with-feature-linked-annotation/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/editing/edit-features-with-feature-linked-annotation/build.gradle
+++ b/editing/edit-features-with-feature-linked-annotation/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/editing/edit-with-branch-versioning/build.gradle
+++ b/editing/edit-with-branch-versioning/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/editing/edit-with-branch-versioning/build.gradle
+++ b/editing/edit-with-branch-versioning/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/editing/update-attributes/build.gradle
+++ b/editing/update-attributes/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/editing/update-attributes/build.gradle
+++ b/editing/update-attributes/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/editing/update-geometries/build.gradle
+++ b/editing/update-geometries/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 javafx {
     version = "17.0.2"

--- a/editing/update-geometries/build.gradle
+++ b/editing/update-geometries/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -9,7 +9,7 @@ ext {
     arcgisVersion = '100.14.0'
 }
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/change-feature-layer-renderer/build.gradle
+++ b/feature_layers/change-feature-layer-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 javafx {
     version = "17.0.2"

--- a/feature_layers/change-feature-layer-renderer/build.gradle
+++ b/feature_layers/change-feature-layer-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -9,7 +9,7 @@ ext {
     arcgisVersion = '100.14.0'
 }
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/feature_layers/display-subtype-feature-layer/build.gradle
+++ b/feature_layers/display-subtype-feature-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/feature-collection-layer-from-portal/build.gradle
+++ b/feature_layers/feature-collection-layer-from-portal/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.web' ]
 }
 

--- a/feature_layers/feature-collection-layer-from-portal/build.gradle
+++ b/feature_layers/feature-collection-layer-from-portal/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/feature-collection-layer-query/build.gradle
+++ b/feature_layers/feature-collection-layer-query/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/feature-collection-layer-query/build.gradle
+++ b/feature_layers/feature-collection-layer-query/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/feature-collection-layer/build.gradle
+++ b/feature_layers/feature-collection-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/feature-collection-layer/build.gradle
+++ b/feature_layers/feature-collection-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/feature-layer-dictionary-renderer/build.gradle
+++ b/feature_layers/feature-layer-dictionary-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/feature_layers/feature-layer-dictionary-renderer/build.gradle
+++ b/feature_layers/feature-layer-dictionary-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/feature-layer-extrusion/build.gradle
+++ b/feature_layers/feature-layer-extrusion/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 javafx {
     version = "17.0.2"

--- a/feature_layers/feature-layer-extrusion/build.gradle
+++ b/feature_layers/feature-layer-extrusion/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -9,7 +9,7 @@ ext {
     arcgisVersion = '100.14.0'
 }
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/feature-layer-feature-service/build.gradle
+++ b/feature_layers/feature-layer-feature-service/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 javafx {
     version = "17.0.2"

--- a/feature_layers/feature-layer-feature-service/build.gradle
+++ b/feature_layers/feature-layer-feature-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -9,7 +9,7 @@ ext {
     arcgisVersion = '100.14.0'
 }
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/feature-layer-geodatabase/build.gradle
+++ b/feature_layers/feature-layer-geodatabase/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/feature_layers/feature-layer-geodatabase/build.gradle
+++ b/feature_layers/feature-layer-geodatabase/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/feature-layer-geopackage/build.gradle
+++ b/feature_layers/feature-layer-geopackage/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/feature_layers/feature-layer-geopackage/build.gradle
+++ b/feature_layers/feature-layer-geopackage/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/feature-layer-query/build.gradle
+++ b/feature_layers/feature-layer-query/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/feature-layer-query/build.gradle
+++ b/feature_layers/feature-layer-query/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/feature-layer-rendering-mode-map/build.gradle
+++ b/feature_layers/feature-layer-rendering-mode-map/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/feature-layer-rendering-mode-map/build.gradle
+++ b/feature_layers/feature-layer-rendering-mode-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/feature-layer-selection/build.gradle
+++ b/feature_layers/feature-layer-selection/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/feature-layer-selection/build.gradle
+++ b/feature_layers/feature-layer-selection/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/feature-layer-shapefile/build.gradle
+++ b/feature_layers/feature-layer-shapefile/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/feature_layers/feature-layer-shapefile/build.gradle
+++ b/feature_layers/feature-layer-shapefile/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/filter-by-definition-expression-or-display-filter/build.gradle
+++ b/feature_layers/filter-by-definition-expression-or-display-filter/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/filter-by-definition-expression-or-display-filter/build.gradle
+++ b/feature_layers/filter-by-definition-expression-or-display-filter/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/generate-geodatabase/build.gradle
+++ b/feature_layers/generate-geodatabase/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/generate-geodatabase/build.gradle
+++ b/feature_layers/generate-geodatabase/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/list-related-features/build.gradle
+++ b/feature_layers/list-related-features/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/list-related-features/build.gradle
+++ b/feature_layers/list-related-features/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/statistical-query-group-and-sort/build.gradle
+++ b/feature_layers/statistical-query-group-and-sort/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/feature_layers/statistical-query-group-and-sort/build.gradle
+++ b/feature_layers/statistical-query-group-and-sort/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/statistical-query/build.gradle
+++ b/feature_layers/statistical-query/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/statistical-query/build.gradle
+++ b/feature_layers/statistical-query/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/time-based-query/build.gradle
+++ b/feature_layers/time-based-query/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 javafx {
     version = "17.0.2"

--- a/feature_layers/time-based-query/build.gradle
+++ b/feature_layers/time-based-query/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -9,7 +9,7 @@ ext {
     arcgisVersion = '100.14.0'
 }
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/feature_layers/toggle-between-feature-request-modes/build.gradle
+++ b/feature_layers/toggle-between-feature-request-modes/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/feature_layers/toggle-between-feature-request-modes/build.gradle
+++ b/feature_layers/toggle-between-feature-request-modes/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/buffer-list/build.gradle
+++ b/geometry/buffer-list/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/buffer-list/build.gradle
+++ b/geometry/buffer-list/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/buffer/build.gradle
+++ b/geometry/buffer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/buffer/build.gradle
+++ b/geometry/buffer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/clip-geometry/build.gradle
+++ b/geometry/clip-geometry/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/clip-geometry/build.gradle
+++ b/geometry/clip-geometry/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/convex-hull-list/build.gradle
+++ b/geometry/convex-hull-list/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/convex-hull-list/build.gradle
+++ b/geometry/convex-hull-list/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/convex-hull/build.gradle
+++ b/geometry/convex-hull/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/convex-hull/build.gradle
+++ b/geometry/convex-hull/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/create-geometries/build.gradle
+++ b/geometry/create-geometries/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/create-geometries/build.gradle
+++ b/geometry/create-geometries/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/cut-geometry/build.gradle
+++ b/geometry/cut-geometry/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/cut-geometry/build.gradle
+++ b/geometry/cut-geometry/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/densify-and-generalize/build.gradle
+++ b/geometry/densify-and-generalize/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/geometry/densify-and-generalize/build.gradle
+++ b/geometry/densify-and-generalize/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/geodesic-operations/build.gradle
+++ b/geometry/geodesic-operations/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/geodesic-operations/build.gradle
+++ b/geometry/geodesic-operations/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/geodesic-sector-and-ellipse/build.gradle
+++ b/geometry/geodesic-sector-and-ellipse/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/geometry/geodesic-sector-and-ellipse/build.gradle
+++ b/geometry/geodesic-sector-and-ellipse/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/geometry-engine-simplify/build.gradle
+++ b/geometry/geometry-engine-simplify/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/geometry-engine-simplify/build.gradle
+++ b/geometry/geometry-engine-simplify/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/list-transformations-by-suitability/build.gradle
+++ b/geometry/list-transformations-by-suitability/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/list-transformations-by-suitability/build.gradle
+++ b/geometry/list-transformations-by-suitability/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/nearest-vertex/build.gradle
+++ b/geometry/nearest-vertex/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/nearest-vertex/build.gradle
+++ b/geometry/nearest-vertex/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/project/build.gradle
+++ b/geometry/project/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/project/build.gradle
+++ b/geometry/project/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/spatial-operations/build.gradle
+++ b/geometry/spatial-operations/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/spatial-operations/build.gradle
+++ b/geometry/spatial-operations/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/geometry/spatial-relationships/build.gradle
+++ b/geometry/spatial-relationships/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/geometry/spatial-relationships/build.gradle
+++ b/geometry/spatial-relationships/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/group_layers/group-layers/build.gradle
+++ b/group_layers/group-layers/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/group_layers/group-layers/build.gradle
+++ b/group_layers/group-layers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/hydrography/add-enc-exchange-set/build.gradle
+++ b/hydrography/add-enc-exchange-set/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/hydrography/add-enc-exchange-set/build.gradle
+++ b/hydrography/add-enc-exchange-set/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/image_layers/change-sublayer-renderer/build.gradle
+++ b/image_layers/change-sublayer-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/image_layers/change-sublayer-renderer/build.gradle
+++ b/image_layers/change-sublayer-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/image_layers/map-image-layer-sublayer-visibility/build.gradle
+++ b/image_layers/map-image-layer-sublayer-visibility/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/image_layers/map-image-layer-sublayer-visibility/build.gradle
+++ b/image_layers/map-image-layer-sublayer-visibility/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/image_layers/map-image-layer-tables/build.gradle
+++ b/image_layers/map-image-layer-tables/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/image_layers/map-image-layer-tables/build.gradle
+++ b/image_layers/map-image-layer-tables/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/image_layers/map-image-layer/build.gradle
+++ b/image_layers/map-image-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/image_layers/map-image-layer/build.gradle
+++ b/image_layers/map-image-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/image_layers/query-map-image-sublayer/build.gradle
+++ b/image_layers/query-map-image-sublayer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/image_layers/query-map-image-sublayer/build.gradle
+++ b/image_layers/query-map-image-sublayer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/kml/create-and-save-kml-file/build.gradle
+++ b/kml/create-and-save-kml-file/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/kml/create-and-save-kml-file/build.gradle
+++ b/kml/create-and-save-kml-file/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/kml/display-kml-network-links/build.gradle
+++ b/kml/display-kml-network-links/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/kml/display-kml-network-links/build.gradle
+++ b/kml/display-kml-network-links/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/kml/display-kml/build.gradle
+++ b/kml/display-kml/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/kml/display-kml/build.gradle
+++ b/kml/display-kml/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/kml/edit-kml-ground-overlay/build.gradle
+++ b/kml/edit-kml-ground-overlay/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/kml/edit-kml-ground-overlay/build.gradle
+++ b/kml/edit-kml-ground-overlay/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/kml/identify-kml-features/build.gradle
+++ b/kml/identify-kml-features/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.web' ]
 }
 

--- a/kml/identify-kml-features/build.gradle
+++ b/kml/identify-kml-features/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/kml/list-kml-contents/build.gradle
+++ b/kml/list-kml-contents/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/kml/list-kml-contents/build.gradle
+++ b/kml/list-kml-contents/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/kml/play-a-kml-tour/build.gradle
+++ b/kml/play-a-kml-tour/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.media' ]
 }
 

--- a/kml/play-a-kml-tour/build.gradle
+++ b/kml/play-a-kml-tour/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/local_server/local-server-feature-layer/build.gradle
+++ b/local_server/local-server-feature-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/local_server/local-server-feature-layer/build.gradle
+++ b/local_server/local-server-feature-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/local_server/local-server-geoprocessing/build.gradle
+++ b/local_server/local-server-geoprocessing/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/local_server/local-server-geoprocessing/build.gradle
+++ b/local_server/local-server-geoprocessing/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/local_server/local-server-map-image-layer/build.gradle
+++ b/local_server/local-server-map-image-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/local_server/local-server-map-image-layer/build.gradle
+++ b/local_server/local-server-map-image-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/local_server/local-server-services/build.gradle
+++ b/local_server/local-server-services/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/local_server/local-server-services/build.gradle
+++ b/local_server/local-server-services/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/access-load-status/build.gradle
+++ b/map/access-load-status/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
+++ b/map/apply-scheduled-updates-to-preplanned-map-area/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/browse-building-floors/build.gradle
+++ b/map/browse-building-floors/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/browse-building-floors/build.gradle
+++ b/map/browse-building-floors/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/change-basemap/build.gradle
+++ b/map/change-basemap/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.web' ]
 }
 

--- a/map/create-and-save-map/build.gradle
+++ b/map/create-and-save-map/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/display-map/build.gradle
+++ b/map/display-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/download-preplanned-map/build.gradle
+++ b/map/download-preplanned-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/map/download-preplanned-map/build.gradle
+++ b/map/download-preplanned-map/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/generate-offline-map-overrides/build.gradle
+++ b/map/generate-offline-map-overrides/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/map/generate-offline-map-overrides/build.gradle
+++ b/map/generate-offline-map-overrides/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/generate-offline-map-with-local-basemap/build.gradle
+++ b/map/generate-offline-map-with-local-basemap/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/map/generate-offline-map-with-local-basemap/build.gradle
+++ b/map/generate-offline-map-with-local-basemap/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/generate-offline-map/build.gradle
+++ b/map/generate-offline-map/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/map/generate-offline-map/build.gradle
+++ b/map/generate-offline-map/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/honor-mobile-map-package-expiration-date/build.gradle
+++ b/map/honor-mobile-map-package-expiration-date/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/honor-mobile-map-package-expiration-date/build.gradle
+++ b/map/honor-mobile-map-package-expiration-date/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/manage-bookmarks/build.gradle
+++ b/map/manage-bookmarks/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/manage-bookmarks/build.gradle
+++ b/map/manage-bookmarks/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/manage-operational-layers/build.gradle
+++ b/map/manage-operational-layers/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/manage-operational-layers/build.gradle
+++ b/map/manage-operational-layers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/map-initial-extent/build.gradle
+++ b/map/map-initial-extent/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/map-initial-extent/build.gradle
+++ b/map/map-initial-extent/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/map-reference-scale/build.gradle
+++ b/map/map-reference-scale/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/map/map-reference-scale/build.gradle
+++ b/map/map-reference-scale/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/map-spatial-reference/build.gradle
+++ b/map/map-spatial-reference/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/map-spatial-reference/build.gradle
+++ b/map/map-spatial-reference/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/min-max-scale/build.gradle
+++ b/map/min-max-scale/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/min-max-scale/build.gradle
+++ b/map/min-max-scale/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/mobile-map-search-and-route/build.gradle
+++ b/map/mobile-map-search-and-route/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/mobile-map-search-and-route/build.gradle
+++ b/map/mobile-map-search-and-route/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/open-map-url/build.gradle
+++ b/map/open-map-url/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/open-map-url/build.gradle
+++ b/map/open-map-url/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/open-mobile-map-package/build.gradle
+++ b/map/open-mobile-map-package/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/open-mobile-map-package/build.gradle
+++ b/map/open-mobile-map-package/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/read-geopackage/build.gradle
+++ b/map/read-geopackage/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/read-geopackage/build.gradle
+++ b/map/read-geopackage/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map/set-initial-map-location/build.gradle
+++ b/map/set-initial-map-location/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map/set-initial-map-location/build.gradle
+++ b/map/set-initial-map-location/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map_view/change-viewpoint/build.gradle
+++ b/map_view/change-viewpoint/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/change-viewpoint/build.gradle
+++ b/map_view/change-viewpoint/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map_view/display-device-location-with-autopan-modes/build.gradle
+++ b/map_view/display-device-location-with-autopan-modes/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/display-device-location-with-autopan-modes/build.gradle
+++ b/map_view/display-device-location-with-autopan-modes/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map_view/display-device-location-with-nmea-data-sources/build.gradle
+++ b/map_view/display-device-location-with-nmea-data-sources/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/map_view/display-device-location-with-nmea-data-sources/build.gradle
+++ b/map_view/display-device-location-with-nmea-data-sources/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/display-drawing-status/build.gradle
+++ b/map_view/display-drawing-status/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/display-drawing-status/build.gradle
+++ b/map_view/display-drawing-status/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map_view/display-layer-view-state/build.gradle
+++ b/map_view/display-layer-view-state/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/display-layer-view-state/build.gradle
+++ b/map_view/display-layer-view-state/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map_view/identify-layers/build.gradle
+++ b/map_view/identify-layers/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/identify-layers/build.gradle
+++ b/map_view/identify-layers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 
@@ -36,7 +36,7 @@ dependencies {
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     // handle SLF4J http://www.slf4j.org/codes.html#StaticLoggerBinder
     runtimeOnly 'org.slf4j:slf4j-nop:1.7.32'
-    implementation 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'
+    implementation 'com.esri.arcgisruntime:arcgis-java-toolkit:100.14.0'
 }
 
 task createGradlePropertiesAndWriteApiKey {

--- a/map_view/map-rotation/build.gradle
+++ b/map_view/map-rotation/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 
@@ -36,7 +36,7 @@ dependencies {
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
     // handle SLF4J http://www.slf4j.org/codes.html#StaticLoggerBinder
     runtimeOnly 'org.slf4j:slf4j-nop:1.7.32'
-    implementation 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'
+    implementation 'com.esri.arcgisruntime:arcgis-java-toolkit:100.14.0'
 }
 
 task createGradlePropertiesAndWriteApiKey {

--- a/map_view/scale-bar/build.gradle
+++ b/map_view/scale-bar/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/set-up-location-driven-geotriggers/build.gradle
+++ b/map_view/set-up-location-driven-geotriggers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/map_view/set-up-location-driven-geotriggers/build.gradle
+++ b/map_view/set-up-location-driven-geotriggers/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/show-location-history/build.gradle
+++ b/map_view/show-location-history/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/show-location-history/build.gradle
+++ b/map_view/show-location-history/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/map_view/take-screenshot/build.gradle
+++ b/map_view/take-screenshot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.swing' ]
 }
 

--- a/network_analysis/closest-facility-static/build.gradle
+++ b/network_analysis/closest-facility-static/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/network_analysis/closest-facility-static/build.gradle
+++ b/network_analysis/closest-facility-static/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/network_analysis/closest-facility/build.gradle
+++ b/network_analysis/closest-facility/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/network_analysis/closest-facility/build.gradle
+++ b/network_analysis/closest-facility/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/network_analysis/find-route/build.gradle
+++ b/network_analysis/find-route/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/network_analysis/find-route/build.gradle
+++ b/network_analysis/find-route/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
+++ b/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
+++ b/network_analysis/find-service-areas-for-multiple-facilities/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/network_analysis/offline-routing/build.gradle
+++ b/network_analysis/offline-routing/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/network_analysis/offline-routing/build.gradle
+++ b/network_analysis/offline-routing/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/network_analysis/routing-around-barriers/build.gradle
+++ b/network_analysis/routing-around-barriers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/network_analysis/routing-around-barriers/build.gradle
+++ b/network_analysis/routing-around-barriers/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/network_analysis/service-area-task/build.gradle
+++ b/network_analysis/service-area-task/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/network_analysis/service-area-task/build.gradle
+++ b/network_analysis/service-area-task/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/browse-ogc-api-feature-service/build.gradle
+++ b/ogc/browse-ogc-api-feature-service/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/browse-ogc-api-feature-service/build.gradle
+++ b/ogc/browse-ogc-api-feature-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/ogc/browse-wfs-layers/build.gradle
+++ b/ogc/browse-wfs-layers/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/browse-wfs-layers/build.gradle
+++ b/ogc/browse-wfs-layers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/ogc/display-ogc-api-collection/build.gradle
+++ b/ogc/display-ogc-api-collection/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/display-ogc-api-collection/build.gradle
+++ b/ogc/display-ogc-api-collection/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/ogc/display-wfs-layer/build.gradle
+++ b/ogc/display-wfs-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/display-wfs-layer/build.gradle
+++ b/ogc/display-wfs-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/ogc/open-street-map-layer/build.gradle
+++ b/ogc/open-street-map-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/open-street-map-layer/build.gradle
+++ b/ogc/open-street-map-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/ogc/query-with-cql-filters/build.gradle
+++ b/ogc/query-with-cql-filters/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/ogc/query-with-cql-filters/build.gradle
+++ b/ogc/query-with-cql-filters/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/style-wms-layer/build.gradle
+++ b/ogc/style-wms-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/style-wms-layer/build.gradle
+++ b/ogc/style-wms-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/ogc/wfs-xml-query/build.gradle
+++ b/ogc/wfs-xml-query/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/wfs-xml-query/build.gradle
+++ b/ogc/wfs-xml-query/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/ogc/wms-layer-url/build.gradle
+++ b/ogc/wms-layer-url/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/wms-layer-url/build.gradle
+++ b/ogc/wms-layer-url/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/ogc/wmts-layer/build.gradle
+++ b/ogc/wmts-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/ogc/wmts-layer/build.gradle
+++ b/ogc/wmts-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/portal/integrated-windows-authentication/build.gradle
+++ b/portal/integrated-windows-authentication/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.web' ]
 }
 

--- a/portal/integrated-windows-authentication/build.gradle
+++ b/portal/integrated-windows-authentication/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/portal/oauth/build.gradle
+++ b/portal/oauth/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.web' ]
 }
 

--- a/portal/oauth/build.gradle
+++ b/portal/oauth/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/portal/token-authentication/build.gradle
+++ b/portal/token-authentication/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 javafx {
     version = "17.0.2"

--- a/portal/token-authentication/build.gradle
+++ b/portal/token-authentication/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -9,7 +9,7 @@ ext {
     arcgisVersion = '100.14.0'
 }
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/portal/webmap-keyword-search/build.gradle
+++ b/portal/webmap-keyword-search/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/portal/webmap-keyword-search/build.gradle
+++ b/portal/webmap-keyword-search/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/apply-mosaic-rule-to-rasters/build.gradle
+++ b/raster/apply-mosaic-rule-to-rasters/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml']
 }
 

--- a/raster/apply-mosaic-rule-to-rasters/build.gradle
+++ b/raster/apply-mosaic-rule-to-rasters/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/blend-renderer/build.gradle
+++ b/raster/blend-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/raster/blend-renderer/build.gradle
+++ b/raster/blend-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/colormap-renderer/build.gradle
+++ b/raster/colormap-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/colormap-renderer/build.gradle
+++ b/raster/colormap-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/raster/hillshade-renderer/build.gradle
+++ b/raster/hillshade-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/raster/hillshade-renderer/build.gradle
+++ b/raster/hillshade-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/identify-raster-cell/build.gradle
+++ b/raster/identify-raster-cell/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/raster/raster-function/build.gradle
+++ b/raster/raster-function/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/raster-function/build.gradle
+++ b/raster/raster-function/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/raster/raster-layer-file/build.gradle
+++ b/raster/raster-layer-file/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/raster-layer-file/build.gradle
+++ b/raster/raster-layer-file/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/raster/raster-layer-geopackage/build.gradle
+++ b/raster/raster-layer-geopackage/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/raster-layer-geopackage/build.gradle
+++ b/raster/raster-layer-geopackage/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/raster/raster-layer-url/build.gradle
+++ b/raster/raster-layer-url/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/raster-layer-url/build.gradle
+++ b/raster/raster-layer-url/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/raster/raster-rendering-rule/build.gradle
+++ b/raster/raster-rendering-rule/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/raster-rendering-rule/build.gradle
+++ b/raster/raster-rendering-rule/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/raster/rgb-renderer/build.gradle
+++ b/raster/rgb-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/raster/rgb-renderer/build.gradle
+++ b/raster/rgb-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/raster/stretch-renderer/build.gradle
+++ b/raster/stretch-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/raster/stretch-renderer/build.gradle
+++ b/raster/stretch-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/add-a-point-scene-layer/build.gradle
+++ b/scene/add-a-point-scene-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/add-a-point-scene-layer/build.gradle
+++ b/scene/add-a-point-scene-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/add-an-integrated-mesh-layer/build.gradle
+++ b/scene/add-an-integrated-mesh-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/add-an-integrated-mesh-layer/build.gradle
+++ b/scene/add-an-integrated-mesh-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/animate-3d-graphic/build.gradle
+++ b/scene/animate-3d-graphic/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/scene/animate-3d-graphic/build.gradle
+++ b/scene/animate-3d-graphic/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/animate-images-with-image-overlay/build.gradle
+++ b/scene/animate-images-with-image-overlay/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/scene/animate-images-with-image-overlay/build.gradle
+++ b/scene/animate-images-with-image-overlay/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/change-atmosphere-effect/build.gradle
+++ b/scene/change-atmosphere-effect/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/change-atmosphere-effect/build.gradle
+++ b/scene/change-atmosphere-effect/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/choose-camera-controller/build.gradle
+++ b/scene/choose-camera-controller/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/choose-camera-controller/build.gradle
+++ b/scene/choose-camera-controller/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/create-terrain-surface-from-local-raster/build.gradle
+++ b/scene/create-terrain-surface-from-local-raster/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/create-terrain-surface-from-local-raster/build.gradle
+++ b/scene/create-terrain-surface-from-local-raster/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/create-terrain-surface-from-local-tile-package/build.gradle
+++ b/scene/create-terrain-surface-from-local-tile-package/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/create-terrain-surface-from-local-tile-package/build.gradle
+++ b/scene/create-terrain-surface-from-local-tile-package/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/display-scene/build.gradle
+++ b/scene/display-scene/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/display-scene/build.gradle
+++ b/scene/display-scene/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/distance-composite-symbol/build.gradle
+++ b/scene/distance-composite-symbol/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/scene/distance-composite-symbol/build.gradle
+++ b/scene/distance-composite-symbol/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/extrude-graphics/build.gradle
+++ b/scene/extrude-graphics/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/extrude-graphics/build.gradle
+++ b/scene/extrude-graphics/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/feature-layer-rendering-mode-scene/build.gradle
+++ b/scene/feature-layer-rendering-mode-scene/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/feature-layer-rendering-mode-scene/build.gradle
+++ b/scene/feature-layer-rendering-mode-scene/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/get-elevation-at-a-point/build.gradle
+++ b/scene/get-elevation-at-a-point/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/get-elevation-at-a-point/build.gradle
+++ b/scene/get-elevation-at-a-point/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/open-mobile-scene-package/build.gradle
+++ b/scene/open-mobile-scene-package/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/open-mobile-scene-package/build.gradle
+++ b/scene/open-mobile-scene-package/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/open-scene-portal-item/build.gradle
+++ b/scene/open-scene-portal-item/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/open-scene-portal-item/build.gradle
+++ b/scene/open-scene-portal-item/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/orbit-the-camera-around-an-object/build.gradle
+++ b/scene/orbit-the-camera-around-an-object/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/scene/orbit-the-camera-around-an-object/build.gradle
+++ b/scene/orbit-the-camera-around-an-object/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/realistic-lighting-and-shadows/build.gradle
+++ b/scene/realistic-lighting-and-shadows/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = ['javafx.controls','javafx.fxml']
 }
 

--- a/scene/realistic-lighting-and-shadows/build.gradle
+++ b/scene/realistic-lighting-and-shadows/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/scene-layer-selection/build.gradle
+++ b/scene/scene-layer-selection/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/scene-layer-selection/build.gradle
+++ b/scene/scene-layer-selection/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/scene-layer/build.gradle
+++ b/scene/scene-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/scene-layer/build.gradle
+++ b/scene/scene-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/scene-properties-expressions/build.gradle
+++ b/scene/scene-properties-expressions/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/scene/scene-properties-expressions/build.gradle
+++ b/scene/scene-properties-expressions/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/show-labels-on-layer-in-3d/build.gradle
+++ b/scene/show-labels-on-layer-in-3d/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/show-labels-on-layer-in-3d/build.gradle
+++ b/scene/show-labels-on-layer-in-3d/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/surface-placement/build.gradle
+++ b/scene/surface-placement/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/scene/surface-placement/build.gradle
+++ b/scene/surface-placement/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/symbols/build.gradle
+++ b/scene/symbols/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/symbols/build.gradle
+++ b/scene/symbols/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/sync-map-and-scene-viewpoints/build.gradle
+++ b/scene/sync-map-and-scene-viewpoints/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/sync-map-and-scene-viewpoints/build.gradle
+++ b/scene/sync-map-and-scene-viewpoints/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/terrain-exaggeration/build.gradle
+++ b/scene/terrain-exaggeration/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/scene/terrain-exaggeration/build.gradle
+++ b/scene/terrain-exaggeration/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/view-content-beneath-terrain-surface/build.gradle
+++ b/scene/view-content-beneath-terrain-surface/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/view-content-beneath-terrain-surface/build.gradle
+++ b/scene/view-content-beneath-terrain-surface/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/scene/view-point-cloud-data-offline/build.gradle
+++ b/scene/view-point-cloud-data-offline/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/scene/view-point-cloud-data-offline/build.gradle
+++ b/scene/view-point-cloud-data-offline/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/search/find-address/build.gradle
+++ b/search/find-address/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/search/find-address/build.gradle
+++ b/search/find-address/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/search/find-place/build.gradle
+++ b/search/find-place/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/search/find-place/build.gradle
+++ b/search/find-place/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/search/offline-geocode/build.gradle
+++ b/search/offline-geocode/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/search/offline-geocode/build.gradle
+++ b/search/offline-geocode/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/search/reverse-geocode-online/build.gradle
+++ b/search/reverse-geocode-online/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/search/reverse-geocode-online/build.gradle
+++ b/search/reverse-geocode-online/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/symbology/create-symbol-styles-from-web-styles/build.gradle
+++ b/symbology/create-symbol-styles-from-web-styles/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/create-symbol-styles-from-web-styles/build.gradle
+++ b/symbology/create-symbol-styles-from-web-styles/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/symbology/custom-dictionary-style/build.gradle
+++ b/symbology/custom-dictionary-style/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/symbology/custom-dictionary-style/build.gradle
+++ b/symbology/custom-dictionary-style/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
+++ b/symbology/graphics-overlay-dictionary-renderer-3D/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/symbology/picture-marker-symbol/build.gradle
+++ b/symbology/picture-marker-symbol/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/picture-marker-symbol/build.gradle
+++ b/symbology/picture-marker-symbol/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.swing' ]
 }
 

--- a/symbology/read-symbols-from-mobile-style-file/build.gradle
+++ b/symbology/read-symbols-from-mobile-style-file/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/symbology/read-symbols-from-mobile-style-file/build.gradle
+++ b/symbology/read-symbols-from-mobile-style-file/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/simple-fill-symbol/build.gradle
+++ b/symbology/simple-fill-symbol/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/simple-fill-symbol/build.gradle
+++ b/symbology/simple-fill-symbol/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/symbology/simple-line-symbol/build.gradle
+++ b/symbology/simple-line-symbol/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/simple-line-symbol/build.gradle
+++ b/symbology/simple-line-symbol/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/symbology/simple-marker-symbol/build.gradle
+++ b/symbology/simple-marker-symbol/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/simple-marker-symbol/build.gradle
+++ b/symbology/simple-marker-symbol/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/symbology/simple-renderer/build.gradle
+++ b/symbology/simple-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/simple-renderer/build.gradle
+++ b/symbology/simple-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/symbology/symbol-dictionary/build.gradle
+++ b/symbology/symbol-dictionary/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/symbology/symbol-dictionary/build.gradle
+++ b/symbology/symbol-dictionary/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/symbolize-shapefile/build.gradle
+++ b/symbology/symbolize-shapefile/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/symbolize-shapefile/build.gradle
+++ b/symbology/symbolize-shapefile/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/symbology/unique-value-renderer/build.gradle
+++ b/symbology/unique-value-renderer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/symbology/unique-value-renderer/build.gradle
+++ b/symbology/unique-value-renderer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/tiled_layers/export-tiles/build.gradle
+++ b/tiled_layers/export-tiles/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/tiled_layers/export-tiles/build.gradle
+++ b/tiled_layers/export-tiles/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/tiled_layers/export-vector-tiles/build.gradle
+++ b/tiled_layers/export-vector-tiles/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/tiled_layers/export-vector-tiles/build.gradle
+++ b/tiled_layers/export-vector-tiles/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/tiled_layers/tile-cache/build.gradle
+++ b/tiled_layers/tile-cache/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/tiled_layers/tile-cache/build.gradle
+++ b/tiled_layers/tile-cache/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/tiled_layers/tiled-layer/build.gradle
+++ b/tiled_layers/tiled-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/tiled_layers/tiled-layer/build.gradle
+++ b/tiled_layers/tiled-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/tiled_layers/vector-tiled-layer-url/build.gradle
+++ b/tiled_layers/vector-tiled-layer-url/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/tiled_layers/vector-tiled-layer-url/build.gradle
+++ b/tiled_layers/vector-tiled-layer-url/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/tiled_layers/web-tiled-layer/build.gradle
+++ b/tiled_layers/web-tiled-layer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/tiled_layers/web-tiled-layer/build.gradle
+++ b/tiled_layers/web-tiled-layer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/utility_network/configure-subnetwork-trace/build.gradle
+++ b/utility_network/configure-subnetwork-trace/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/utility_network/configure-subnetwork-trace/build.gradle
+++ b/utility_network/configure-subnetwork-trace/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/utility_network/display-content-of-utility-network-container/build.gradle
+++ b/utility_network/display-content-of-utility-network-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/utility_network/display-content-of-utility-network-container/build.gradle
+++ b/utility_network/display-content-of-utility-network-container/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/utility_network/display-utility-associations/build.gradle
+++ b/utility_network/display-utility-associations/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls' ]
 }
 

--- a/utility_network/perform-valve-isolation-trace/build.gradle
+++ b/utility_network/perform-valve-isolation-trace/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/utility_network/perform-valve-isolation-trace/build.gradle
+++ b/utility_network/perform-valve-isolation-trace/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {

--- a/utility_network/trace-a-utility-network/build.gradle
+++ b/utility_network/trace-a-utility-network/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
 group = 'com.esri.samples'
@@ -10,7 +10,7 @@ ext {
 }
 
 javafx {
-    version = "11.0.2"
+    version = "17.0.2"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/utility_network/trace-a-utility-network/build.gradle
+++ b/utility_network/trace-a-utility-network/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.14.0'
+    arcgisVersion = '100.14.1'
 }
 
 javafx {


### PR DESCRIPTION
This PR updates JavaFX 11 to 17, in support of Java JDK 17. It also updates our samples to point to the latest version of our Java SDK Toolkit, 100.14.0. 

@mbcoder could you review please? 