### PR TITLE
[Update] Added reset to Cut/Clip Geometry samples

### DIFF
--- a/geometry/clip-geometry/README.md
+++ b/geometry/clip-geometry/README.md
@@ -15,8 +15,8 @@ Click the "Reset" button to remove the clipped graphics and restore the original
 
 ## How it works
 
-1.  Use the static method `GeometryEngine.clip()` to generate a clipped `Geometry`, passing in an existing `Geometry` and an `Envelope` as parameters.  The existing geometry will be clipped where it intersects an envelope.
-2.  Create a new `Graphic` from the clipped geometry and add it to a `GraphicsOverlay` on the `MapView`.
+1. Use the static method `GeometryEngine.clip()` to generate a clipped `Geometry`, passing in an existing `Geometry` and an `Envelope` as parameters.  The existing geometry will be clipped where it intersects an envelope.
+2. Create a new `Graphic` from the clipped geometry and add it to a `GraphicsOverlay` on the `MapView`.
 
 ## Relevant API
 

--- a/geometry/clip-geometry/README.md
+++ b/geometry/clip-geometry/README.md
@@ -11,6 +11,8 @@ Create a new set of geometries for analysis (e.g. displaying buffer zones around
 ## How to use the sample
 
 Click the "Clip" button to clip the blue graphic with the red dashed envelopes.
+Click the "Reset" button to remove the clipped graphics and restore the original blue graphic.
+
 
 ## How it works
 

--- a/geometry/clip-geometry/README.md
+++ b/geometry/clip-geometry/README.md
@@ -13,7 +13,6 @@ Create a new set of geometries for analysis (e.g. displaying buffer zones around
 Click the "Clip" button to clip the blue graphic with the red dashed envelopes.
 Click the "Reset" button to remove the clipped graphics and restore the original blue graphic.
 
-
 ## How it works
 
 1.  Use the static method `GeometryEngine.clip()` to generate a clipped `Geometry`, passing in an existing `Geometry` and an `Envelope` as parameters.  The existing geometry will be clipped where it intersects an envelope.

--- a/geometry/clip-geometry/src/main/java/com/esri/samples/clip_geometry/ClipGeometrySample.java
+++ b/geometry/clip-geometry/src/main/java/com/esri/samples/clip_geometry/ClipGeometrySample.java
@@ -116,18 +116,28 @@ public class ClipGeometrySample extends Application {
       // create a button to perform the clip operation
       Button clipButton = new Button("Clip");
       clipButton.setOnAction(e -> {
-        // for each envelope, clip the Colorado geometry and show the result, replacing the original Colorado graphic
-        coloradoGraphic.setVisible(false);
-        envelopesOverlay.getGraphics().forEach(graphic -> {
-          Geometry geometry = GeometryEngine.clip(coloradoGraphic.getGeometry(), (Envelope) graphic.getGeometry());
-          if (geometry != null) {
-            Graphic clippedGraphic = new Graphic(geometry, fillSymbol);
-            clipAreasOverlay.getGraphics().add(clippedGraphic);
-          }
-        });
-        // only clip once
-        clipButton.setDisable(true);
-      });
+        if (clipButton.getText().equals("Clip")){
+
+          // for each envelope, clip the Colorado geometry and show the result, replacing the original Colorado graphic
+          coloradoGraphic.setVisible(false);
+          envelopesOverlay.getGraphics().forEach(graphic -> {
+            Geometry geometry = GeometryEngine.clip(coloradoGraphic.getGeometry(), (Envelope) graphic.getGeometry());
+            if (geometry != null) {
+              Graphic clippedGraphic = new Graphic(geometry, fillSymbol);
+              clipAreasOverlay.getGraphics().add(clippedGraphic);}
+          });
+
+          // convert the clip button into a reset button
+          clipButton.setText("Reset");
+        } else if (clipButton.getText().equals("Reset")){
+
+          // remove clipped graphics and re-enable the original Colorado graphic
+          clipAreasOverlay.getGraphics().clear();
+          coloradoGraphic.setVisible(true);
+
+          // convert the reset button back to a clip button
+          clipButton.setText("Clip");
+        }});
 
       // add the map view to the stack pane
       stackPane.getChildren().addAll(mapView, clipButton);

--- a/geometry/clip-geometry/src/main/java/com/esri/samples/clip_geometry/ClipGeometrySample.java
+++ b/geometry/clip-geometry/src/main/java/com/esri/samples/clip_geometry/ClipGeometrySample.java
@@ -113,11 +113,10 @@ public class ClipGeometrySample extends Application {
       GraphicsOverlay clipAreasOverlay = new GraphicsOverlay();
       mapView.getGraphicsOverlays().add(clipAreasOverlay);
 
-      // create a button to perform the clip operation
-      Button clipButton = new Button("Clip");
-      clipButton.setOnAction(e -> {
-        if (clipButton.getText().equals("Clip")){
-
+      // create a button to perform the clip and reset operation
+      var button = new Button("Clip");
+      button.setOnAction(e -> {
+        if (clipAreasOverlay.getGraphics().isEmpty()){
           // for each envelope, clip the Colorado geometry and show the result, replacing the original Colorado graphic
           coloradoGraphic.setVisible(false);
           envelopesOverlay.getGraphics().forEach(graphic -> {
@@ -127,22 +126,21 @@ public class ClipGeometrySample extends Application {
               clipAreasOverlay.getGraphics().add(clippedGraphic);}
           });
 
-          // convert the clip button into a reset button
-          clipButton.setText("Reset");
-        } else if (clipButton.getText().equals("Reset")){
-
+          // update the button text
+          button.setText("Reset");
+        } else {
           // remove clipped graphics and re-enable the original Colorado graphic
           clipAreasOverlay.getGraphics().clear();
           coloradoGraphic.setVisible(true);
 
-          // convert the reset button back to a clip button
-          clipButton.setText("Clip");
+          // update the button text
+          button.setText("Clip");
         }});
 
       // add the map view to the stack pane
-      stackPane.getChildren().addAll(mapView, clipButton);
-      StackPane.setAlignment(clipButton, Pos.TOP_LEFT);
-      StackPane.setMargin(clipButton, new Insets(10, 0, 0, 10));
+      stackPane.getChildren().addAll(mapView, button);
+      StackPane.setAlignment(button, Pos.TOP_LEFT);
+      StackPane.setMargin(button, new Insets(10, 0, 0, 10));
     } catch (Exception e) {
       // on any error, display the stack trace.
       e.printStackTrace();

--- a/geometry/cut-geometry/README.md
+++ b/geometry/cut-geometry/README.md
@@ -11,6 +11,7 @@ You might cut a polygon representing a large parcel to subdivide it into smaller
 ## How to use the sample
 
 Click the "Cut" button to cut the polygon with the polyline and see the resulting parts (shaded in different colors).
+Click the "Reset" button to remove the separate parts.
 
 ## How it works
 

--- a/geometry/cut-geometry/src/main/java/com/esri/samples/cut_geometry/CutGeometrySample.java
+++ b/geometry/cut-geometry/src/main/java/com/esri/samples/cut_geometry/CutGeometrySample.java
@@ -90,19 +90,30 @@ public class CutGeometrySample extends Application {
       // zoom to show the polygon graphic
       mapView.setViewpointGeometryAsync(polygonGraphic.getGeometry());
 
+      // create a graphics overlay to contain the cut areas
+      GraphicsOverlay cutAreasOverlay = new GraphicsOverlay();
+      mapView.getGraphicsOverlays().add(cutAreasOverlay);
+
       // create a button to perform the cut operation
       Button cutButton = new Button("Cut");
       cutButton.setOnAction(e -> {
-        // cut the polygon geometry with the polyline, expect two geometries
-        List<Geometry> parts = GeometryEngine.cut(polygonGraphic.getGeometry(), (Polyline) polylineGraphic.getGeometry());
-        // create graphics for the US and Canada sides
-        Graphic canadaSide = new Graphic(parts.get(0), new SimpleFillSymbol(SimpleFillSymbol.Style.FORWARD_DIAGONAL,
+        if (cutButton.getText().equals("Cut")){
+          // cut the polygon geometry with the polyline, expect two geometries
+          List<Geometry> parts = GeometryEngine.cut(polygonGraphic.getGeometry(), (Polyline) polylineGraphic.getGeometry());
+          // create graphics for the US and Canada sides
+          Graphic canadaSide = new Graphic(parts.get(0), new SimpleFillSymbol(SimpleFillSymbol.Style.FORWARD_DIAGONAL,
             0xFF00FF00, new SimpleLineSymbol(SimpleLineSymbol.Style.NULL, 0xFFFFFFFF, 0)));
-        Graphic usSide = new Graphic(parts.get(1), new SimpleFillSymbol(SimpleFillSymbol.Style.FORWARD_DIAGONAL,
+          Graphic usSide = new Graphic(parts.get(1), new SimpleFillSymbol(SimpleFillSymbol.Style.FORWARD_DIAGONAL,
             0xFFFFFF00, new SimpleLineSymbol(SimpleLineSymbol.Style.NULL, 0xFFFFFFFF, 0)));
-        graphicsOverlay.getGraphics().addAll(Arrays.asList(canadaSide, usSide));
-        // only cut once
-        cutButton.setDisable(true);
+          cutAreasOverlay.getGraphics().addAll(Arrays.asList(canadaSide, usSide));
+          // convert the cut button into a reset button
+          cutButton.setText("Reset");
+        } else if (cutButton.getText().equals("Reset")) {
+          // remove cut graphics
+          cutAreasOverlay.getGraphics().clear();
+          // convert the reset button back to a cut button
+          cutButton.setText("Cut");
+        }
       });
 
       // add the map view to the stack pane

--- a/geometry/cut-geometry/src/main/java/com/esri/samples/cut_geometry/CutGeometrySample.java
+++ b/geometry/cut-geometry/src/main/java/com/esri/samples/cut_geometry/CutGeometrySample.java
@@ -94,32 +94,35 @@ public class CutGeometrySample extends Application {
       GraphicsOverlay cutAreasOverlay = new GraphicsOverlay();
       mapView.getGraphicsOverlays().add(cutAreasOverlay);
 
-      // create a button to perform the cut operation
-      Button cutButton = new Button("Cut");
-      cutButton.setOnAction(e -> {
-        if (cutButton.getText().equals("Cut")){
+      // create a button to perform the cut and reset operation
+      var button = new Button("Cut");
+      button.setOnAction(e -> {
+        if (cutAreasOverlay.getGraphics().isEmpty()){
           // cut the polygon geometry with the polyline, expect two geometries
           List<Geometry> parts = GeometryEngine.cut(polygonGraphic.getGeometry(), (Polyline) polylineGraphic.getGeometry());
+
           // create graphics for the US and Canada sides
           Graphic canadaSide = new Graphic(parts.get(0), new SimpleFillSymbol(SimpleFillSymbol.Style.FORWARD_DIAGONAL,
             0xFF00FF00, new SimpleLineSymbol(SimpleLineSymbol.Style.NULL, 0xFFFFFFFF, 0)));
           Graphic usSide = new Graphic(parts.get(1), new SimpleFillSymbol(SimpleFillSymbol.Style.FORWARD_DIAGONAL,
             0xFFFFFF00, new SimpleLineSymbol(SimpleLineSymbol.Style.NULL, 0xFFFFFFFF, 0)));
           cutAreasOverlay.getGraphics().addAll(Arrays.asList(canadaSide, usSide));
-          // convert the cut button into a reset button
-          cutButton.setText("Reset");
-        } else if (cutButton.getText().equals("Reset")) {
+
+          // update the button text
+          button.setText("Reset");
+        } else {
           // remove cut graphics
           cutAreasOverlay.getGraphics().clear();
-          // convert the reset button back to a cut button
-          cutButton.setText("Cut");
+
+          // update the button text
+          button.setText("Cut");
         }
       });
 
       // add the map view to the stack pane
-      stackPane.getChildren().addAll(mapView, cutButton);
-      StackPane.setAlignment(cutButton, Pos.TOP_LEFT);
-      StackPane.setMargin(cutButton, new Insets(10, 0, 0, 10));
+      stackPane.getChildren().addAll(mapView, button);
+      StackPane.setAlignment(button, Pos.TOP_LEFT);
+      StackPane.setMargin(button, new Insets(10, 0, 0, 10));
     } catch (Exception e) {
       // on any error, display the stack trace.
       e.printStackTrace();


### PR DESCRIPTION
<!-- Give the PR a meaningful title that makes for a concise description of the content within the PR. For example, the title of a PR for a new sample should be "New sample: xxx" or for a bug fix, "Patch: fix (description of bug) in sample x". -->

<!-- If you are merging a sample for the current release, ensure the target branch is `master`. If merging a sample for the next release, ensure the target branch is `dev`. -->

### Description

<!-- Give a brief summary description (one or two sentences) of the work done within the PR, and also write any particular points on which you'd like specific feedback/advice on. Ensure to both request a review and also assign that reviewee, as well as tag them in this PR description. -->

Added the ability to reset the `Clip Geometry` and  `Cut Geometry` samples to their initial states. Not very much to talk about here except:
- The related issue in common-samples implements reset functionality as a separate button which is enabled/disabled in opposition to the cut/clip button. I've not created any new buttons but instead chosen to change the label text of the existing button, and change its functionality based on its label. Notwithstanding the slightly hackish implementation, is it fine to have just the one button rather than two, even if that's not what common-samples is doing?

@Rachael-E apologies for giving you more work; hopefully this one won't take very long.

Checklist:
- [x] Set target branch to master (current release) or dev (next release)
- [x] Request a reviewer
- [x] Assign a reviewer
- [x] Tag reviewer in comment
