### PR TITLE
Apply Unique Values sample patch

### DIFF
--- a/raster/apply-mosaic-rule-to-rasters/src/main/java/com/esri/samples/apply_mosaic_rule_to_rasters/ApplyMosaicRuleToRastersSample.java
+++ b/raster/apply-mosaic-rule-to-rasters/src/main/java/com/esri/samples/apply_mosaic_rule_to_rasters/ApplyMosaicRuleToRastersSample.java
@@ -168,7 +168,7 @@ public class ApplyMosaicRuleToRastersSample extends Application {
   private void setupUI() {
     // create a label
     Label mosaicRuleLabel = new Label("Choose a mosaic rule: ");
-    mosaicRuleLabel.setTextFill(Color.WHITE);
+    mosaicRuleLabel.setStyle("-fx-text-fill: white");
 
     // create a combo box
     mosaicRuleComboBox = new ComboBox<>(

--- a/symbology/apply-unique-values-with-alternate-symbols/src/main/java/com/esri/samples/apply_unique_values_with_alternate_symbols/ApplyUniqueValuesWithAlternateSymbolsSample.java
+++ b/symbology/apply-unique-values-with-alternate-symbols/src/main/java/com/esri/samples/apply_unique_values_with_alternate_symbols/ApplyUniqueValuesWithAlternateSymbolsSample.java
@@ -53,7 +53,7 @@ import com.esri.arcgisruntime.symbology.UniqueValueRenderer;
 public class ApplyUniqueValuesWithAlternateSymbolsSample extends Application {
 
   private MapView mapView;
-  private FeatureLayer featureLayer; // keep loadable in scope to avoid garbage collection
+  private ServiceFeatureTable serviceFeatureTable; // keep loadable in scope to avoid garbage collection
   private final static String FEATURE_SERVICE_URL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0";
   private Button button;
   private Label label;
@@ -134,17 +134,15 @@ public class ApplyUniqueValuesWithAlternateSymbolsSample extends Application {
       uniqueValRenderer.setDefaultSymbol(multilayerPurpleDiamondSymbol);
 
       // create a service feature table using the feature service url
-      final var serviceFeatureTable = new ServiceFeatureTable(FEATURE_SERVICE_URL);
-
-      // create a feature layer from the service feature table
-      featureLayer = new FeatureLayer(serviceFeatureTable);
-
-      // set the unique value renderer on the feature layer
-      featureLayer.setRenderer(uniqueValRenderer);
-
+      serviceFeatureTable = new ServiceFeatureTable(FEATURE_SERVICE_URL);
+      
       // check the service feature table has loaded before adding the feature layer to the map
       serviceFeatureTable.addDoneLoadingListener( () -> {
         if (serviceFeatureTable.getLoadStatus() == LoadStatus.LOADED) {
+          // create a feature layer from the service feature table
+          var featureLayer = new FeatureLayer(serviceFeatureTable);
+          // set the unique value renderer on the feature layer
+          featureLayer.setRenderer(uniqueValRenderer);
           map.getOperationalLayers().add(featureLayer);
           vBox.setDisable(false);
         } else {
@@ -173,7 +171,7 @@ public class ApplyUniqueValuesWithAlternateSymbolsSample extends Application {
 
     // create label to show scale values and button to reset viewpoint
     label = new Label("Current scale: 1:25000");
-    label .setTextFill(Color.WHITE);
+    label.setStyle("-fx-text-fill: white");
     button = new Button("Reset Viewpoint");
 
     // create and configure a VBox


### PR DESCRIPTION
This PR addresses a bug which was causing garbage collection of the service feature table before it could render on the map. The service feature table is now set as a member variable to keep it in scope, and the creation of the feature layer from the service feature table has been moved into the done loading listener of the table.

This PR also makes use of the CSS style of setting the label colour in this sample and another sample: when using COLOR.WHITE the sample viewer build will not recognise that and will default to original css behaviour (black label). Using CSS styling gets over this issue.

@Luiy0 could you review please? thanks! tagging @01smito01 for info with garbage collection practice :D 