### PR TITLE
[Sample Update] Feature Layer Dictionary Renderer sample

### DIFF
--- a/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
+++ b/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
@@ -120,7 +120,6 @@ public class FeatureLayerDictionaryRendererSample extends Application {
     
     // load the geodatabase
     geodatabase.loadAsync();
-    
   }
 
   /**

--- a/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
+++ b/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
@@ -108,7 +108,6 @@ public class FeatureLayerDictionaryRendererSample extends Application {
               }
             })
           );
-          
         } else {
           new Alert(Alert.AlertType.ERROR, "Error: Map operational list size does not match geodatabase feature table list size").show();
         }

--- a/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
+++ b/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
@@ -37,9 +37,7 @@ import java.io.File;
 public class FeatureLayerDictionaryRendererSample extends Application {
 
   private MapView mapView;
-  // keep loadables in scope to avoid garbage collection
-  private Geodatabase geodatabase;
-  private FeatureLayer featureLayer;
+  private Geodatabase geodatabase;   // keep loadable in scope to avoid garbage collection
 
   @Override
   public void start(Stage stage) {
@@ -63,46 +61,66 @@ public class FeatureLayerDictionaryRendererSample extends Application {
     ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
     mapView.setMap(map);
 
-    // load geo-database from local location
-    File geodatabaseFile = new File(System.getProperty("data.dir"), "./samples-data/dictionary/militaryoverlay" +
-            ".geodatabase");
-    geodatabase = new Geodatabase(geodatabaseFile.getAbsolutePath());
-    geodatabase.loadAsync();
-
     // render tells layer what symbols to apply to what features
     File stylxFile = new File(System.getProperty("data.dir"), "./samples-data/stylx/mil2525d.stylx");
-    DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle.createFromFile(stylxFile.getAbsolutePath());
-    symbolDictionary.loadAsync();
+    var dictionarySymbolStyle = DictionarySymbolStyle.createFromFile(stylxFile.getAbsolutePath());
+    dictionarySymbolStyle.loadAsync();
 
+    // create a new geodatabase instance from the geodatabase stored at the local location
+    File geodatabaseFile = new File(System.getProperty("data.dir"), "./samples-data/dictionary/militaryoverlay" +
+      ".geodatabase");
+    geodatabase = new Geodatabase(geodatabaseFile.getAbsolutePath());
+
+    // check the geodatabase has loaded successfully
     geodatabase.addDoneLoadingListener(() -> {
       if (geodatabase.getLoadStatus() == LoadStatus.LOADED) {
-        geodatabase.getGeodatabaseFeatureTables().forEach(table -> {
-          // add each layer to map
-          featureLayer = new FeatureLayer(table);
-          featureLayer.loadAsync();
-          // Features no longer show after this scale
-          featureLayer.setMinScale(1000000);
-          map.getOperationalLayers().add(featureLayer);
+        var mapOperationalLayersList = map.getOperationalLayers();
+        var geodatabaseFeatureTablesList = geodatabase.getGeodatabaseFeatureTables();
 
-          // displays features from layer using mil2525d symbols
-          DictionaryRenderer dictionaryRenderer = new DictionaryRenderer(symbolDictionary);
-          featureLayer.setRenderer(dictionaryRenderer);
-
-          featureLayer.addDoneLoadingListener(() -> {
-            if (featureLayer.getLoadStatus() == LoadStatus.LOADED) {
-              // initial viewpoint to encompass all graphics displayed on the map view 
-              mapView.setViewpointGeometryAsync(featureLayer.getFullExtent());
-            } else {
-              Alert alert = new Alert(Alert.AlertType.ERROR, "Feature Layer Failed to Load!");
-              alert.show();
-            }
-          });
+        geodatabaseFeatureTablesList.forEach(table -> {
+          // create a new feature layer from each geodatabase feature table and
+          // add it to the map's list of operational layers
+          mapOperationalLayersList.add(new FeatureLayer(table));
         });
+
+        // check the map operational layers size matches that of the geodatabase's feature tables size
+        if (!mapOperationalLayersList.isEmpty() && mapOperationalLayersList.size() == geodatabaseFeatureTablesList.size()) {
+
+          // check that each layer has loaded correctly and if not display an error message
+          mapOperationalLayersList.forEach(layer ->
+            layer.addDoneLoadingListener(() -> {
+              if (layer.getLoadStatus() == LoadStatus.LOADED) {
+                
+                // set the feature layer's minimum scale so that features no longer show after this scale
+                layer.setMinScale(1000000);
+                
+                // set the dictionary renderer as the feature layer's renderer
+                if (layer instanceof FeatureLayer) {
+                  ((FeatureLayer) layer).setRenderer(new DictionaryRenderer(dictionarySymbolStyle));
+                }
+                
+                // set the map view viewpoint
+                mapView.setViewpointGeometryAsync(layer.getFullExtent());
+
+              } else {
+                new Alert(Alert.AlertType.ERROR,
+                  "Feature layer failed to load: " + layer.getLoadError().getCause().getMessage()).show();
+              }
+            })
+          );
+          
+        } else {
+          new Alert(Alert.AlertType.ERROR, "Error: Map operational list size does not match geodatabase feature table list size").show();
+        }
+        
       } else {
-        Alert alert = new Alert(Alert.AlertType.ERROR, "Geodatabase Failed to Load!");
-        alert.show();
+        new Alert(Alert.AlertType.ERROR, "Geodatabase Failed to Load!").show();
       }
     });
+    
+    // load the geodatabase
+    geodatabase.loadAsync();
+    
   }
 
   /**

--- a/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
+++ b/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
@@ -71,8 +71,8 @@ public class FeatureLayerDictionaryRendererSample extends Application {
       ".geodatabase");
     geodatabase = new Geodatabase(geodatabaseFile.getAbsolutePath());
 
-    // check the geodatabase has loaded successfully
     geodatabase.addDoneLoadingListener(() -> {
+    // check if the geodatabase has loaded successfully
       if (geodatabase.getLoadStatus() == LoadStatus.LOADED) {
         var mapOperationalLayersList = map.getOperationalLayers();
         var geodatabaseFeatureTablesList = geodatabase.getGeodatabaseFeatureTables();

--- a/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
+++ b/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
@@ -112,7 +112,6 @@ public class FeatureLayerDictionaryRendererSample extends Application {
         } else {
           new Alert(Alert.AlertType.ERROR, "Error: Map operational list size does not match geodatabase feature table list size").show();
         }
-        
       } else {
         new Alert(Alert.AlertType.ERROR, "Geodatabase Failed to Load!").show();
       }

--- a/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
+++ b/feature_layers/feature-layer-dictionary-renderer/src/main/java/com/esri/samples/feature_layer_dictionary_renderer/FeatureLayerDictionaryRendererSample.java
@@ -61,7 +61,7 @@ public class FeatureLayerDictionaryRendererSample extends Application {
     ArcGISMap map = new ArcGISMap(BasemapStyle.ARCGIS_TOPOGRAPHIC);
     mapView.setMap(map);
 
-    // render tells layer what symbols to apply to what features
+    // define and load a dictionary symbol style from a local style file
     File stylxFile = new File(System.getProperty("data.dir"), "./samples-data/stylx/mil2525d.stylx");
     var dictionarySymbolStyle = DictionarySymbolStyle.createFromFile(stylxFile.getAbsolutePath());
     dictionarySymbolStyle.loadAsync();


### PR DESCRIPTION
This PR updates the Feature Layer Dictionary Renderer sample to address a bug where the user would get a dialog warning them that the feature layer hadn't loaded correctly despite the feature layers displaying ok on the map. 

This was due to a race condition caused by the re-use of the `FeatureLayer` variable within the for loop. I've separated out the workflow here in to two for loops for readability, one for getting the geodatabase feature tables, and the other for getting the layers from the map's list of operational layers. 

I've also added some vars in for a more modern look!

@jenmerritt could you have a look please? thanks! 