### PR TITLE
Testing drawStatus property 1

### DIFF
--- a/feature_layers/toggle-between-feature-request-modes/src/main/java/com/esri/samples/toggle_between_feature_request_modes/ToggleBetweenFeatureRequestModesSample.java
+++ b/feature_layers/toggle-between-feature-request-modes/src/main/java/com/esri/samples/toggle_between_feature_request_modes/ToggleBetweenFeatureRequestModesSample.java
@@ -132,11 +132,8 @@ public class ToggleBetweenFeatureRequestModesSample extends Application {
       // set the starting viewpoint for the map view
       mapView.setViewpoint(new Viewpoint(45.5266, -122.6219, 6000));
       // disable the vbox and show a progress indicator when the map view is drawing (e.g. when fetching caches)
-      mapView.addDrawStatusChangedListener(e -> {
-        boolean drawStatusInProgress = e.getDrawStatus() == DrawStatus.IN_PROGRESS;
-        progressIndicator.setVisible(drawStatusInProgress);
-        controlsVBox.setDisable(drawStatusInProgress);
-      });
+      controlsVBox.disableProperty().bind(mapView.drawStatusProperty().isEqualTo(DrawStatus.IN_PROGRESS));
+      progressIndicator.visibleProperty().bind(mapView.drawStatusProperty().isEqualTo(DrawStatus.IN_PROGRESS));
 
       // add label and button to the control panel
       controlsVBox.getChildren().addAll(cacheButton, noCacheButton, manualCacheButton, label, populateButton);

--- a/network_analysis/find-service-areas-for-multiple-facilities/src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java
+++ b/network_analysis/find-service-areas-for-multiple-facilities/src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java
@@ -126,7 +126,7 @@ public class FindServiceAreasForMultipleFacilitiesSample extends Application {
         // zoom to the extent of the feature layer
         mapView.setViewpointGeometryAsync(facilitiesFeatureLayer.getFullExtent(), 130);
 
-        // enable the find service areas button when the feature layer has not loaded
+        // enable the find service areas button when the feature layer has loaded
         findServiceAreasButton.disableProperty().bind(Bindings.createBooleanBinding(()->
           facilitiesFeatureLayer.getLoadStatus() != LoadStatus.LOADED));
 

--- a/network_analysis/find-service-areas-for-multiple-facilities/src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java
+++ b/network_analysis/find-service-areas-for-multiple-facilities/src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java
@@ -22,8 +22,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import javafx.application.Application;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
+import javafx.beans.binding.Bindings;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
@@ -43,7 +42,6 @@ import com.esri.arcgisruntime.layers.FeatureLayer;
 import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.BasemapStyle;
-import com.esri.arcgisruntime.mapping.view.DrawStatus;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -128,24 +126,12 @@ public class FindServiceAreasForMultipleFacilitiesSample extends Application {
         // zoom to the extent of the feature layer
         mapView.setViewpointGeometryAsync(facilitiesFeatureLayer.getFullExtent(), 130);
 
-        // enable the find service areas button when the draw status is completed for the first time
-        ChangeListener<DrawStatus> drawStatusChangeListener = new ChangeListener<>() {
-          @Override
-          public void changed(ObservableValue<? extends DrawStatus> observable, DrawStatus oldValue, DrawStatus newValue) {
-            if (newValue == DrawStatus.COMPLETED) {
-              // enable the 'find service areas' button
-              findServiceAreasButton.setDisable(false);
-              mapView.drawStatusProperty().removeListener(this);
-            }
-          }
-        };
-        mapView.drawStatusProperty().addListener(drawStatusChangeListener);
+        // disable the find service areas button when the feature layer has not loaded
+        findServiceAreasButton.disableProperty().bind(Bindings.createBooleanBinding(()->
+          facilitiesFeatureLayer.getLoadStatus().equals(LoadStatus.NOT_LOADED)));
 
         // determine the service areas and display them when the button is clicked
         findServiceAreasButton.setOnAction(event -> {
-
-          // disable the button
-          findServiceAreasButton.setDisable(true);
 
           // show the progress indicator
           progressIndicator.setVisible(true);

--- a/network_analysis/find-service-areas-for-multiple-facilities/src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java
+++ b/network_analysis/find-service-areas-for-multiple-facilities/src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java
@@ -126,9 +126,9 @@ public class FindServiceAreasForMultipleFacilitiesSample extends Application {
         // zoom to the extent of the feature layer
         mapView.setViewpointGeometryAsync(facilitiesFeatureLayer.getFullExtent(), 130);
 
-        // disable the find service areas button when the feature layer has not loaded
+        // enable the find service areas button when the feature layer has not loaded
         findServiceAreasButton.disableProperty().bind(Bindings.createBooleanBinding(()->
-          facilitiesFeatureLayer.getLoadStatus().equals(LoadStatus.NOT_LOADED)));
+          facilitiesFeatureLayer.getLoadStatus() != LoadStatus.LOADED));
 
         // determine the service areas and display them when the button is clicked
         findServiceAreasButton.setOnAction(event -> {

--- a/network_analysis/find-service-areas-for-multiple-facilities/src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java
+++ b/network_analysis/find-service-areas-for-multiple-facilities/src/main/java/com/esri/samples/find_service_areas_for_multiple_facilities/FindServiceAreasForMultipleFacilitiesSample.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import javafx.application.Application;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
@@ -29,6 +31,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
@@ -41,8 +44,6 @@ import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.DrawStatus;
-import com.esri.arcgisruntime.mapping.view.DrawStatusChangedEvent;
-import com.esri.arcgisruntime.mapping.view.DrawStatusChangedListener;
 import com.esri.arcgisruntime.mapping.view.Graphic;
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
 import com.esri.arcgisruntime.mapping.view.MapView;
@@ -102,8 +103,8 @@ public class FindServiceAreasForMultipleFacilitiesSample extends Application {
 
     // create fill symbols for rendering the result
     ArrayList<SimpleFillSymbol> fillSymbols = new ArrayList<>();
-    fillSymbols.add(new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, 0x66FFA500, null));
-    fillSymbols.add(new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, 0x66FF0000, null));
+    fillSymbols.add(new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, Color.web("FFA500", 0.7), null));
+    fillSymbols.add(new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, Color.web("FF0000", 0.7), null));
 
     // create a feature table of facilities using a FeatureServer
     ArcGISFeatureTable facilitiesTable = new ServiceFeatureTable("https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/ArcGIS/rest/services/San_Diego_Facilities/FeatureServer/0");
@@ -128,16 +129,17 @@ public class FindServiceAreasForMultipleFacilitiesSample extends Application {
         mapView.setViewpointGeometryAsync(facilitiesFeatureLayer.getFullExtent(), 130);
 
         // enable the find service areas button when the draw status is completed for the first time
-        mapView.addDrawStatusChangedListener(new DrawStatusChangedListener() {
+        ChangeListener<DrawStatus> drawStatusChangeListener = new ChangeListener<>() {
           @Override
-          public void drawStatusChanged(DrawStatusChangedEvent drawStatusChangedEvent) {
-            if (drawStatusChangedEvent.getDrawStatus() == DrawStatus.COMPLETED) {
+          public void changed(ObservableValue<? extends DrawStatus> observable, DrawStatus oldValue, DrawStatus newValue) {
+            if (newValue == DrawStatus.COMPLETED) {
               // enable the 'find service areas' button
               findServiceAreasButton.setDisable(false);
-              mapView.removeDrawStatusChangedListener(this);
+              mapView.drawStatusProperty().removeListener(this);
             }
           }
-        });
+        };
+        mapView.drawStatusProperty().addListener(drawStatusChangeListener);
 
         // determine the service areas and display them when the button is clicked
         findServiceAreasButton.setOnAction(event -> {


### PR DESCRIPTION
### Description

Test `drawStatus` property binding and listener in the following samples:

- `edit-and-sync-features`
- `generate-offline-map-with-local-basemap`
- `find-service-areas-for-multiple-facilities`: Not binding progress indicator as it's used for a service task. 
- `toogle-between-feature-request-modes`: Binding `vBox` or using listener linked to [#7280](https://devtopia.esri.com/runtime/java/issues/7280)

Checklist:
- [ ] Set target branch to main (current release) or v.next (next release)
- [ ] Request a reviewer
- [ ] Assign a reviewer
- [ ] Tag reviewer in comment
