### PR TITLE
Testing loadStatus property 2

### DIFF
--- a/map/access-load-status/src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java
+++ b/map/access-load-status/src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java
@@ -63,7 +63,7 @@ public class AccessLoadStatusSample extends Application {
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
       // create a control panel
-      VBox controlsVBox = new VBox(6);
+      var controlsVBox = new VBox(6);
       controlsVBox.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(0,0,0,0.3)"), CornerRadii.EMPTY,
           Insets.EMPTY)));
       controlsVBox.setPadding(new Insets(10.0));
@@ -71,12 +71,12 @@ public class AccessLoadStatusSample extends Application {
       controlsVBox.getStyleClass().add("panel-region");
 
       // create area to display load status text
-      Label loadStatusLabel = new Label("Load Status");
+      var loadStatusLabel = new Label("Load Status");
       loadStatusLabel.getStyleClass().add("panel-label");
       TextArea loadStatusText = new TextArea();
       loadStatusText.setMaxHeight(200);
 
-      Button reloadMapButton = new Button("Reload ArcGISMap");
+      var reloadMapButton = new Button("Reload ArcGISMap");
       reloadMapButton.setMaxWidth(Double.MAX_VALUE);
 
       // reload the map when the button is clicked
@@ -86,26 +86,14 @@ public class AccessLoadStatusSample extends Application {
         // reload the map
         map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
-        map.addLoadStatusChangedListener(e -> {
-          String loadingStatus;
-
+        map.loadStatusProperty().addListener((observable, oldValue, newValue) -> {
           // check the loading status
-          switch (e.getNewLoadStatus()) {
-            case LOADING:
-              loadingStatus = "Load Status: LOADING!";
-              break;
-            case FAILED_TO_LOAD:
-              loadingStatus = "Load Status: FAILED TO LOAD!";
-              break;
-            case NOT_LOADED:
-              loadingStatus = "Load Status: NOT LOADED!";
-              break;
-            case LOADED:
-              loadingStatus = "Load Status: LOADED!";
-              break;
-            default:
-              loadingStatus = "Load Status: ERROR!";
-          }
+          String loadingStatus = switch (newValue) {
+            case LOADING -> "Load Status: LOADING!";
+            case FAILED_TO_LOAD -> "Load Status: FAILED TO LOAD!";
+            case NOT_LOADED -> "Load Status: NOT LOADED!";
+            case LOADED -> "Load Status: LOADED!";
+          };
 
           // update the load status text to the loading status that was fired
           Platform.runLater(() -> loadStatusText.appendText(loadingStatus + "\n"));

--- a/map/access-load-status/src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java
+++ b/map/access-load-status/src/main/java/com/esri/samples/access_load_status/AccessLoadStatusSample.java
@@ -87,13 +87,24 @@ public class AccessLoadStatusSample extends Application {
         map = new ArcGISMap(BasemapStyle.ARCGIS_IMAGERY_STANDARD);
 
         map.loadStatusProperty().addListener((observable, oldValue, newValue) -> {
-          // check the loading status
-          String loadingStatus = switch (newValue) {
-            case LOADING -> "Load Status: LOADING!";
-            case FAILED_TO_LOAD -> "Load Status: FAILED TO LOAD!";
-            case NOT_LOADED -> "Load Status: NOT LOADED!";
-            case LOADED -> "Load Status: LOADED!";
-          };
+          // create and update a string variable depending on the load status
+          String loadingStatus;
+          switch (newValue) {
+            case LOADING:
+              loadingStatus = "Load Status: LOADING!";
+              break;
+            case FAILED_TO_LOAD:
+              loadingStatus = "Load Status: FAILED TO LOAD!";
+              break;
+            case NOT_LOADED:
+              loadingStatus = "Load Status: NOT LOADED!";
+              break;
+            case LOADED:
+              loadingStatus = "Load Status: LOADED!";
+              break;
+            default:
+              loadingStatus = "Load Status: ERROR!";
+          }
 
           // update the load status text to the loading status that was fired
           Platform.runLater(() -> loadStatusText.appendText(loadingStatus + "\n"));

--- a/raster/raster-rendering-rule/src/main/java/com/esri/samples/raster_rendering_rule/RasterRenderingRuleSample.java
+++ b/raster/raster-rendering-rule/src/main/java/com/esri/samples/raster_rendering_rule/RasterRenderingRuleSample.java
@@ -70,14 +70,14 @@ public class RasterRenderingRuleSample extends Application {
       ArcGISRuntimeEnvironment.setApiKey(yourAPIKey);
 
       // create a control panel
-      VBox controlsVBox = new VBox(8);
+      var controlsVBox = new VBox(8);
       controlsVBox.setBackground(new Background(new BackgroundFill(Paint.valueOf("rgba(0,0,0,0.6)"), CornerRadii.EMPTY, Insets.EMPTY)));
       controlsVBox.setPadding(new Insets(10.0));
       controlsVBox.setMaxSize(260, 160);
       controlsVBox.getStyleClass().add("panel-region");
 
       // create progress indicator
-      ProgressIndicator progressIndicator = new ProgressIndicator();
+      var progressIndicator = new ProgressIndicator();
       progressIndicator.setVisible(false);
 
       // create drop down menu of Rendering Rules
@@ -148,13 +148,7 @@ public class RasterRenderingRuleSample extends Application {
             ImageServiceRaster appliedImageServiceRaster = new ImageServiceRaster(ImageServiceRasterUri);
 
             // show progress indicator while rule is loading
-            appliedImageServiceRaster.addLoadStatusChangedListener((e) -> {
-              if (e.getNewLoadStatus() == LoadStatus.LOADING) {
-                progressIndicator.setVisible(true);
-              } else {
-                progressIndicator.setVisible(false);
-              }
-            });
+            progressIndicator.visibleProperty().bind(appliedImageServiceRaster.loadStatusProperty().isEqualTo(LoadStatus.LOADING));
 
             // apply the rendering rule
             appliedImageServiceRaster.setRenderingRule(renderingRule);


### PR DESCRIPTION
### Description

- Remove deprecated code related to `getNewLoadStatus()`.
- A second progress indicator was added to the `browse-wfs-layers` sample that uses the `setVisible` method when the wfsFeatureTable is being populated. 

Checklist:
- [ ] Set target branch to main (current release) or v.next (next release)
- [ ] Request a reviewer
- [ ] Assign a reviewer
- [ ] Tag reviewer in comment
