### PR TITLE
Add error handling to List Transformations

### DIFF
--- a/geometry/list-transformations-by-suitability/build.gradle
+++ b/geometry/list-transformations-by-suitability/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.esri.samples'
 
 ext {
-    arcgisVersion = '100.15.0'
+    arcgisVersion = '200.0.0-3714'
 }
 
 javafx {

--- a/geometry/list-transformations-by-suitability/src/main/java/com/esri/samples/list_transformations_by_suitability/ListTransformationsBySuitabilitySample.java
+++ b/geometry/list-transformations-by-suitability/src/main/java/com/esri/samples/list_transformations_by_suitability/ListTransformationsBySuitabilitySample.java
@@ -23,6 +23,7 @@ import javafx.event.ActionEvent;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ListCell;
@@ -144,10 +145,14 @@ public class ListTransformationsBySuitabilitySample extends Application {
       transformButton.setOnAction(e -> {
         DatumTransformation transformation = transformationsListView.getSelectionModel().getSelectedItem();
         if (transformation != null) {
-          Point projectedPoint = (Point) GeometryEngine.project(originalGraphic.getGeometry(), mapView.getSpatialReference(),
-            transformation);
-          transformedGraphic.setVisible(true);
-          transformedGraphic.setGeometry(projectedPoint);
+          try {
+            Point projectedPoint = (Point) GeometryEngine.project(originalGraphic.getGeometry(), mapView.getSpatialReference(),
+              transformation);
+            transformedGraphic.setVisible(true);
+            transformedGraphic.setGeometry(projectedPoint);
+          } catch (Exception ex) {
+            new Alert(Alert.AlertType.ERROR, ex.getMessage()).show();
+          }
         }
       });
 


### PR DESCRIPTION
<!-- Give the PR a meaningful title that makes for a concise description of the content within the PR. For example, the title of a PR for a new sample should be "New sample: xxx" or for a bug fix, "Patch: fix (description of bug) in sample x". -->

<!-- If you are merging a sample for the current release, ensure the target branch is `main`. If merging a sample for the next release, ensure the target branch is `v.next`. -->

### Description

Refer to issue 7532

This sample has geometry transformations where there are sometimes deliberately Missing grid files, readme states: `If the selected transformation is not usable (has missing grid files) then an error is displayed.`
However an error isn't being displayed to the user, so it appears to just fail, though there is a stacktrace when run via the IDE. This PR adds an alert for the user, stating the information about the missing grid file. The dialog content is consistent with messages other platforms are displaying to users in this sample.

<!-- Give a brief summary description (one or two sentences) of the work done within the PR, and also write any particular points on which you'd like specific feedback/advice on. Ensure to both request a review and also assign that reviewer, as well as tag them in this PR description. -->

Checklist:
- [ ] Set target branch to main (current release) or v.next (next release)
- [ ] Request a reviewer
- [ ] Assign a reviewer
- [ ] Tag reviewer in comment
