### PR TITLE
Update metadata style check scripts

### DIFF
--- a/.github/scripts/ci/readme_metadata_style_check/README_style_checker.py
+++ b/.github/scripts/ci/readme_metadata_style_check/README_style_checker.py
@@ -51,6 +51,7 @@ categories = {
     'ogc',
     'portal',
     'raster',
+    'real_time'
     'scene',
     'search',
     'symbology',

--- a/.github/scripts/ci/readme_metadata_style_check/entry.py
+++ b/.github/scripts/ci/readme_metadata_style_check/entry.py
@@ -24,6 +24,7 @@ categories = {
     'ogc',
     'portal',
     'raster',
+    'real_time'
     'scene',
     'search',
     'symbology',

--- a/.github/scripts/ci/readme_metadata_style_check/metadata_style_checker.py
+++ b/.github/scripts/ci/readme_metadata_style_check/metadata_style_checker.py
@@ -153,6 +153,7 @@ class MetadataCreator:
         results = list(filter(lambda x: 'build/' not in x, results)) # exclude \build folder
         results = list(filter(lambda x: 'out/' not in x, results)) # exclude \out folder
         results = list(filter(lambda x: 'Launcher' not in x, results)) # exclude *Launcher.java
+        results = list(filter(lambda x: 'module-info' not in x, results)) # exclude module-info.java
         results = list(map(lambda x: x.replace(os.sep, '/'), results)) # eliminate double backslashes in the paths
 
         return sorted(results)

--- a/.github/scripts/ci/readme_metadata_style_check/metadata_style_checker.py
+++ b/.github/scripts/ci/readme_metadata_style_check/metadata_style_checker.py
@@ -25,6 +25,7 @@ categories = {
     'ogc',
     'portal',
     'raster',
+    'real_time'
     'scene',
     'search',
     'symbology',


### PR DESCRIPTION
### Description

- Update the scripts to include the new `real_time` category for metadata style checks
- Update the `metadata_style_checker` script to exclude the `module-info.java` file for checks
- Tested running the [metadata_style_checker](https://devtopia.esri.com/runtime/common-samples/wiki/Java-Samples-Repo%3A-A-Contribution-Guide#running-locally) locally

Checklist:
- [ ] Set target branch to main (current release) or v.next (next release)
- [ ] Request a reviewer
- [ ] Assign a reviewer
- [ ] Tag reviewer in comment
