### PR TITLE
Fix broken v100 links

### DIFF
--- a/ogc/wms-layer-url/README.md
+++ b/ogc/wms-layer-url/README.md
@@ -20,7 +20,7 @@ The map will load automatically when the sample starts.
 
 ## About the data
 
-This sample uses a [U.S. National Weather Service radar map](https://nowcoast.noaa.gov/geoserver/observations/weather_radar/wms). Because WMS services generate map images on-the-fly, this layer is always up-to-date with the latest [NOAA NEXRAD radar](https://www.ncdc.noaa.gov/data-access/radar-data/nexrad) observations.
+This sample uses the WMS service behind the [U.S. National Weather Service radar map](https://nowcoast.noaa.gov/geoserver/observations/weather_radar/wms?SERVICE=WMS&REQUEST=GetCapabilities). Because WMS services generate map images on-the-fly, this layer is always up-to-date with the latest NOAA nowCOAST real-time coastal observations, forecasts, and warnings.
 
 ## Relevant API
 

--- a/search/find-address/README.md
+++ b/search/find-address/README.md
@@ -28,7 +28,7 @@ Select an entry from the drop-down menu at the top left of the screen to zoom to
 
 ## Additional information
 
-This sample uses the World Geocoding Service. For more information, see the [Geocoding service](https://developers.arcgis.com/documentation/mapping-apis-and-services/search/services/geocoding-service/) help topic on the ArcGIS Developer website.
+This sample uses the World Geocoding Service. For more information, see the [Geocoding service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm) help topic on the ArcGIS REST APIs website.
 
 ## Tags
 

--- a/search/find-place/README.md
+++ b/search/find-place/README.md
@@ -41,7 +41,7 @@ Choose a type of place in the first field and an area to search within in the se
 
 ## Additional information
 
-This sample uses the World Geocoding Service. For more information, see the [Geocoding service](https://developers.arcgis.com/documentation/mapping-apis-and-services/search/services/geocoding-service/) help topic on the ArcGIS Developer website.
+This sample uses the World Geocoding Service. For more information, see the [Geocoding service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm) help topic on the ArcGIS REST APIs website.
 
 ## Tags
 

--- a/search/reverse-geocode-online/README.md
+++ b/search/reverse-geocode-online/README.md
@@ -27,7 +27,7 @@ Click on the map to see the nearest address displayed in a callout.
 
 ## Additional information
 
-This sample uses the World Geocoding Service. For more information, see the [Geocoding service](https://developers.arcgis.com/documentation/mapping-apis-and-services/search/services/geocoding-service/) help topic on the ArcGIS Developer website.
+This sample uses the World Geocoding Service. For more information, see the [Geocoding service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm) help topic on the ArcGIS REST APIs website.
 
 ## Tags
 


### PR DESCRIPTION
Bug fix: Fix broken URLs being reported by [DevEx Dashboard](https://dashboard.afd.geocloud.com/link-checker/next).  These fixes target 100.15.0 and target that branch.

### Description
Search:
- find-address
- find-place
- reverse-geocode-online
Fixed broken Geocoding Service link (DevEx removed as part of citra v2 work). I now redirect to ArcGIS REST APIs documentation instead.

OGC:
- wms-layer-url
Replaced `About the data` text to match .NET equivalent sample which fixes a broken link to NOAA NEXRAD radar.

Checklist:
- [x] Set target branch to main (current release) or v.next (next release)
- [x] Request a reviewer
- [ ] Assign a reviewer
- [ ] Tag reviewer in comment
